### PR TITLE
Set QOS / Thread priority

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1244,9 +1244,8 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
 {
     NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:block];
     operation.queuePriority = operationPriorityWithImageManagerPriority(priority);
-    operation.qualityOfService = NSOperationQualityOfServiceBackground;
 #if defined(__IPHONE_8_0)
-    operation.qualityOfService = NSQualityOfServiceBackground;
+    operation.qualityOfService = NSOperationQualityOfServiceBackground;
 #else
     operation.threadPriority = 0.2;
 #endif

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -149,6 +149,9 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
         _concurrentOperationQueue = [[NSOperationQueue alloc] init];
         _concurrentOperationQueue.name = @"PINRemoteImageManager Concurrent Operation Queue";
         _concurrentOperationQueue.maxConcurrentOperationCount = NSOperationQueueDefaultMaxConcurrentOperationCount;
+#if defined(__IPHONE_8_0)
+        _concurrentOperationQueue.qualityOfService = NSQualityOfServiceBackground;
+#endif
         _urlSessionTaskQueue = [[NSOperationQueue alloc] init];
         _urlSessionTaskQueue.name = @"PINRemoteImageManager Concurrent URL Session Task Queue";
         _urlSessionTaskQueue.maxConcurrentOperationCount = 10;
@@ -1241,6 +1244,12 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
 {
     NSBlockOperation *operation = [NSBlockOperation blockOperationWithBlock:block];
     operation.queuePriority = operationPriorityWithImageManagerPriority(priority);
+    operation.qualityOfService = NSOperationQualityOfServiceBackground;
+#if defined(__IPHONE_8_0)
+    operation.qualityOfService = NSQualityOfServiceBackground;
+#else
+    operation.threadPriority = 0.2;
+#endif
     [self addOperation:operation];
 }
 


### PR DESCRIPTION
Surprisingly, it seems that leaving the qos priority to default does not actually lead to a qos of background like the documentation states. I've found that the QOS gets upgraded to user interactive in some cases. This explicitly sets the QOS on all operations to background so we don't affect scroll performance.