### PR TITLE
Release our lock when we encounter a canceled task

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -390,6 +390,7 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
          [strongSelf lock];
              //check canceled tasks first
              if ([strongSelf.canceledTasks containsObject:UUID]) {
+                 [strongSelf unlock];
                  return;
              }
              [strongSelf.canceledTasks removeAllObjects];


### PR DESCRIPTION
This early-out condition would exit while still holding our lock, resulting in
Very Bad Things (tm) down the line.