### PR TITLE
Fixes podspec syntax for git tag.

### DIFF
--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/pinterest/PINRemoteImage"
   s.license          = 'Apache 2.0'
   s.author           = { "Garrett Moon" => "garrett@pinterest.com" }
-  s.source           = { :git => "https://github.com/pinterest/PINRemoteImage.git", :tag => 1.1.1 }
+  s.source           = { :git => "https://github.com/pinterest/PINRemoteImage.git", :tag => "1.1.1" }
   s.social_media_url = 'https://twitter.com/garrettmoon'
 
   s.platform     = :ios, '6.0'


### PR DESCRIPTION
The podspec contains a syntax error for the git tag value, which prevents Cocoapods from installing versions greater than `1.0.0`.

You can run `pod spec lint` in the project directory to validate the podspec.