### PR TITLE
Fix race conditions in progress generation

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -831,10 +831,7 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
                 NSData *data = task.progressImage.data;
             [strongSelf unlock];
             
-            //if task has been removed, no point in calling completion
-            if (task) {
-                completion(data, error);
-            }
+            completion(data, error);
         }
     }];
     
@@ -1014,23 +1011,20 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
     
     [progressiveImage updateProgressiveImageWithData:data expectedNumberOfBytes:[dataTask countOfBytesExpectedToReceive]];
 
-    __weak typeof(self) weakSelf = self;
-    [_concurrentOperationQueue pin_addOperationWithQueuePriority:PINRemoteImageManagerPriorityLow block:^{
-        typeof(self) strongSelf = weakSelf;
-        [strongSelf lock];
-            PINRemoteImageDownloadTask *task = [strongSelf.tasks objectForKey:[strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil]];
-        [strongSelf unlock];
-        
-        if (hasProgressBlocks && [[strongSelf class] isiOS8OrGreater]) {
+    if (hasProgressBlocks && [[self class] isiOS8OrGreater]) {
+        __weak typeof(self) weakSelf = self;
+        [_concurrentOperationQueue pin_addOperationWithQueuePriority:PINRemoteImageManagerPriorityLow block:^{
+            typeof(self) strongSelf = weakSelf;
             UIImage *progressImage = [progressiveImage currentImage];
             if (progressImage) {
                 [strongSelf lock];
+                    PINRemoteImageDownloadTask *task = [strongSelf.tasks objectForKey:[strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil]];
                     task = [strongSelf.tasks objectForKey:[strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil]];
                     [task callProgressWithQueue:_callbackQueue withImage:progressImage];
                 [strongSelf unlock];
             }
-        }
-    }];
+        }];
+    }
 }
 
 - (void)didCompleteTask:(NSURLSessionTask *)task withError:(NSError *)error

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1019,8 +1019,7 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
             if (progressImage) {
                 [strongSelf lock];
                     PINRemoteImageDownloadTask *task = [strongSelf.tasks objectForKey:[strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil]];
-                    task = [strongSelf.tasks objectForKey:[strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil]];
-                    [task callProgressWithQueue:_callbackQueue withImage:progressImage];
+                    [task callProgressWithQueue:strongSelf.callbackQueue withImage:progressImage];
                 [strongSelf unlock];
             }
         }];

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1015,7 +1015,8 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
             UIImage *progressImage = [progressiveImage currentImage];
             if (progressImage) {
                 [strongSelf lock];
-                    PINRemoteImageDownloadTask *task = [strongSelf.tasks objectForKey:[strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil]];
+                    NSString *cacheKey = [strongSelf cacheKeyForURL:[[dataTask originalRequest] URL] processorKey:nil];
+                    PINRemoteImageDownloadTask *task = strongSelf.tasks[cacheKey];
                     [task callProgressWithQueue:strongSelf.callbackQueue withImage:progressImage];
                 [strongSelf unlock];
             }

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -93,7 +93,6 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
 
 @interface PINRemoteImageManager () <PINURLSessionManagerDelegate>
 {
-    dispatch_queue_t _concurrentQueue;
     dispatch_queue_t _callbackQueue;
     NSLock *_lock;
     NSOperationQueue *_concurrentOperationQueue;
@@ -142,7 +141,6 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
         self.cache = [self defaultImageCache];
         NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         
-        _concurrentQueue = dispatch_queue_create("PINRemoteImageManagerConcurrentQueue", DISPATCH_QUEUE_CONCURRENT);
         _callbackQueue = dispatch_queue_create("PINRemoteImageManagerCallbackQueue", DISPATCH_QUEUE_CONCURRENT);
         _lock = [[NSLock alloc] init];
         _lock.name = @"PINRemoteImageManager";
@@ -157,7 +155,6 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
         _urlSessionTaskQueue.maxConcurrentOperationCount = 10;
         
         self.sessionManager = [[PINURLSessionManager alloc] initWithSessionConfiguration:configuration];
-        self.sessionManager.completionQueue = _concurrentQueue;
         self.sessionManager.delegate = self;
         
         self.estimatedRemainingTimeThreshold = 0.0;

--- a/Pod/Classes/PINURLSessionManager.h
+++ b/Pod/Classes/PINURLSessionManager.h
@@ -24,7 +24,6 @@
 
 - (void)invalidateSessionAndCancelTasks;
 
-@property (atomic, strong) dispatch_queue_t completionQueue;
 @property (atomic, weak) id <PINURLSessionManagerDelegate> delegate;
 
 @end

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -48,7 +48,8 @@
         if (completionHandler) {
             [self.completions setObject:completionHandler forKey:@(dataTask.taskIdentifier)];
         }
-        [self.delegateQueues setObject:dispatch_queue_create([[NSString stringWithFormat:@"PINURLSessionManager delegate queue - %ld", (unsigned long)dataTask.taskIdentifier] UTF8String], DISPATCH_QUEUE_SERIAL) forKey:@(dataTask.taskIdentifier)];
+        dispatch_queue_t delegateQueue = dispatch_queue_create([[NSString stringWithFormat:@"PINURLSessionManager delegate queue - %ld", (unsigned long)dataTask.taskIdentifier] UTF8String], DISPATCH_QUEUE_SERIAL);
+        [self.delegateQueues setObject:delegateQueue forKey:@(dataTask.taskIdentifier)];
     [self unlock];
     return dataTask;
 }

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -37,7 +37,7 @@
 - (void)invalidateSessionAndCancelTasks
 {
     [self lock];
-    [self.session invalidateAndCancel];
+        [self.session invalidateAndCancel];
     [self unlock];
 }
 
@@ -48,7 +48,8 @@
         if (completionHandler) {
             [self.completions setObject:completionHandler forKey:@(dataTask.taskIdentifier)];
         }
-        dispatch_queue_t delegateQueue = dispatch_queue_create([[NSString stringWithFormat:@"PINURLSessionManager delegate queue - %ld", (unsigned long)dataTask.taskIdentifier] UTF8String], DISPATCH_QUEUE_SERIAL);
+        NSString *queueName = [NSString stringWithFormat:@"PINURLSessionManager delegate queue - %ld", (unsigned long)dataTask.taskIdentifier];
+        dispatch_queue_t delegateQueue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_SERIAL);
         [self.delegateQueues setObject:delegateQueue forKey:@(dataTask.taskIdentifier)];
     [self unlock];
     return dataTask;
@@ -69,7 +70,7 @@
 - (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
 {
     [self lock];
-    dispatch_queue_t delegateQueue = self.delegateQueues[@(dataTask.taskIdentifier)];
+        dispatch_queue_t delegateQueue = self.delegateQueues[@(dataTask.taskIdentifier)];
     [self unlock];
     
     __weak typeof(self) weakSelf = self;
@@ -81,7 +82,7 @@
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
     [self lock];
-    dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
+        dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
     
     __weak typeof(self) weakSelf = self;


### PR DESCRIPTION
There was a race condition which existed in which completion would be called before progress was completed. This sets up a serial queue for every download task so progress and completion happen in the correct ordering.