### PR TITLE
Bugfix Image Not Found But Error null

### DIFF
--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -151,6 +151,23 @@
     XCTAssert(outAnimatedImage == nil, @"Animated image is not nil.");
 }
 
+- (void)testErrorOnNilURLDownload
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    __block NSError *outError = nil;
+    [self.imageManager downloadImageWithURL:nil
+                                    options:PINRemoteImageManagerDownloadOptionsNone
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         outError = result.error;
+         dispatch_semaphore_signal(semaphore);
+     }];
+    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
+    XCTAssert(outError.code == NSURLErrorUnsupportedURL);
+    XCTAssert([outError.userInfo[NSLocalizedDescriptionKey] isEqualToString:@"unsupported URL"]);
+}
+
 - (void)testDecoding
 {
     dispatch_group_t group = dispatch_group_create();

--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -50,6 +50,16 @@
     return [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/originals/90/f5/77/90f577fc6abcd24f9a5f9f55b2d7482b.jpg"];
 }
 
+- (NSURL *)emptyURL
+{
+    return [NSURL URLWithString:@""];
+}
+
+- (NSURL *)fourZeroFourURL
+{
+    return [NSURL URLWithString:@"https://www.pinterest.com/404/"];
+}
+
 - (NSURL *)JPEGURL_Small
 {
     return [NSURL URLWithString:@"http://media-cache-ec0.pinimg.com/345x/1b/bc/c2/1bbcc264683171eb3815292d2f546e92.jpg"];
@@ -165,7 +175,43 @@
     dispatch_semaphore_wait(semaphore, [self timeout]);
     XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
     XCTAssert(outError.code == NSURLErrorUnsupportedURL);
-    XCTAssert([outError.userInfo[NSLocalizedDescriptionKey] isEqualToString:@"unsupported URL"]);
+    XCTAssert([outError.localizedDescription isEqualToString:@"unsupported URL"]);
+}
+
+- (void)testErrorOnEmptyURLDownload
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    __block NSError *outError = nil;
+    [self.imageManager downloadImageWithURL:[self emptyURL]
+                                    options:PINRemoteImageManagerDownloadOptionsNone
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         outError = result.error;
+         dispatch_semaphore_signal(semaphore);
+     }];
+    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
+    XCTAssert(outError.code == NSURLErrorUnsupportedURL);
+    // iOS8 (and presumably 10.10) returns NSURLErrorUnsupportedURL which means the HTTP NSURLProtocol does not accept it
+    NSArray *validErrorMessages = @[ @"unsupported URL", @"The operation couldn’t be completed. (NSURLErrorDomain error -1002.)"];
+    XCTAssert([validErrorMessages containsObject:outError.localizedDescription], @"%@", outError.localizedDescription);
+}
+
+- (void)testErrorOn404Response
+{
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    __block NSError *outError = nil;
+    [self.imageManager downloadImageWithURL:[self fourZeroFourURL]
+                                    options:PINRemoteImageManagerDownloadOptionsNone
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         outError = result.error;
+         dispatch_semaphore_signal(semaphore);
+     }];
+    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
+    XCTAssert(outError.code == NSURLErrorRedirectToNonExistentLocation);
+    XCTAssert([outError.localizedDescription isEqualToString:@"The requested URL was not found on this server."]);
 }
 
 - (void)testDecoding

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -627,7 +627,7 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
     
     if (completion && ((image || animatedImage) || (url == nil))) {
         //If we're on the main thread, special case to call completion immediately
-        NSError *error;
+        NSError *error = nil;
         if (!url) {
             error = [NSError errorWithDomain:NSURLErrorDomain
                                         code:NSURLErrorUnsupportedURL

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -627,11 +627,17 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
     
     if (completion && ((image || animatedImage) || (url == nil))) {
         //If we're on the main thread, special case to call completion immediately
+        NSError *error;
+        if (!url) {
+            error = [NSError errorWithDomain:NSURLErrorDomain
+                                        code:NSURLErrorUnsupportedURL
+                                    userInfo:@{ NSLocalizedDescriptionKey : @"unsupported URL" }];
+        }
         if (allowEarlyReturn && [NSThread isMainThread]) {
             completion([PINRemoteImageManagerResult imageResultWithImage:image
                                                           animatedImage:animatedImage
                                                           requestLength:0
-                                                                  error:nil
+                                                                  error:error
                                                              resultType:resultType
                                                                    UUID:nil]);
         } else {
@@ -639,7 +645,7 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
                 completion([PINRemoteImageManagerResult imageResultWithImage:image
                                                               animatedImage:animatedImage
                                                               requestLength:0
-                                                                      error:nil
+                                                                      error:error
                                                                  resultType:resultType
                                                                        UUID:nil]);
             });

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -84,7 +84,11 @@
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
-    
+    if ([(NSHTTPURLResponse *)task.response statusCode] == 404 && !error) {
+        error = [NSError errorWithDomain:NSURLErrorDomain
+                                    code:NSURLErrorRedirectToNonExistentLocation
+                                userInfo:@{NSLocalizedDescriptionKey : @"The requested URL was not found on this server."}];
+    }
     __weak typeof(self) weakSelf = self;
     dispatch_async(delegateQueue, ^{
         typeof(self) strongSelf = weakSelf;


### PR DESCRIPTION
This pull request resolves https://github.com/pinterest/PINRemoteImage/issues/23. 

- The reason why a `nil` url did not return an error was because it is handled through an early return method, therefore it does got go through the URL loading system and does not populate the `NSError`.

- The reason why a 404 response does not return in error, is because the [documentation](https://developer.apple.com/library/ios/documentation/Foundation/Reference/NSURLSessionTaskDelegate_protocol/#//apple_ref/occ/intfm/NSURLSessionTaskDelegate/URLSession:task:didCompleteWithError:) states: 

`Server errors are not reported through the error parameter. The only errors your delegate receives through the error parameter are client-side errors, such as being unable to resolve the hostname or connect to the host.`

Which is confusing because if you create a `NSURLSessionTask`, the completion handler of a request which has a `404` response does have the error correctly populated. 

- Empty URLs were handled correctly prior to this pull request, which I determined after it satisfied the tests that I wrote. 

Note: To generate the errors, I just logged what the `NSError` is if you create an analogous `NSURLSessionTask` with a request with the corresponding url, and had the new errors match that. 