### PR TITLE
added support for custom http request headers

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -116,7 +116,7 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask *ta
 @property (nonatomic, readonly) PINCache *cache;
 
 /**
- Creates and returns a PINRemoteImageManager created with the specified configuration. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. You specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc.
+ Create and return a PINRemoteImageManager created with the specified configuration. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. You specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc.
  @param configuration The configuration used to create the PINRemoteImageManager.
  @return A PINRemoteImageManager with the specified configuration.
  */

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -116,6 +116,13 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask *ta
 @property (nonatomic, readonly) PINCache *cache;
 
 /**
+ Creates and returns a PINRemoteImageManager created with the specified configuration. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. You specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc.
+ @param configuration The configuration used to create the PINRemoteImageManager.
+ @return A PINRemoteImageManager with the specified configuration.
+ */
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration;
+
+/**
  Get the shared instance of PINRemoteImageManager
  
  @return Shared instance of PINRemoteImageManager

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -138,10 +138,16 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
 
 - (instancetype)init
 {
+    return [self initWithSessionConfiguration:nil];
+}
+
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration
+{
     if (self = [super init]) {
         self.cache = [self defaultImageCache];
-        NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-        
+        if (!configuration) {
+            configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+        }
         _callbackQueue = dispatch_queue_create("PINRemoteImageManagerCallbackQueue", DISPATCH_QUEUE_CONCURRENT);
         _lock = [[NSLock alloc] init];
         _lock.name = @"PINRemoteImageManager";


### PR DESCRIPTION
This resolves https://github.com/pinterest/PINRemoteImage/issues/43. 

I think this approach made the most sense to me, which is allowing a single instance to have a custom configuration, but leaving the `sharedImageManager` unchanged. Let me know your thoughts. 