### PR TITLE
made changes so FLAnimatedImage is optional / updated PINCache / fix issue with tag not updated

### DIFF
--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -11,7 +11,9 @@
 #import <PINRemoteImage/PINRemoteImage.h>
 #import <PINRemoteImage/PINURLSessionManager.h>
 #import <PINRemoteImage/UIImageView+PINRemoteImage.h>
+#if USE_FLANIMATED_IMAGE
 #import <FLAnimatedImage/FLAnimatedImage.h>
+#endif
 #import <PINCache/PINCache.h>
 
 #if DEBUG
@@ -136,6 +138,7 @@
     [super tearDown];
 }
 
+#if USE_FLANIMATED_IMAGE
 - (void)testGIFDownload
 {
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
@@ -153,6 +156,7 @@
     XCTAssert(outAnimatedImage && [outAnimatedImage isKindOfClass:[FLAnimatedImage class]], @"Failed downloading animatedImage or animatedImage is not an FLAnimatedImage.");
     XCTAssert(outImage == nil, @"Image is not nil.");
 }
+#endif
 
 - (void)testInitWithNilConfiguration
 {
@@ -427,6 +431,7 @@
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:NULL];
 }
 
+#if USE_FLANIMATED_IMAGE
 - (void)testFLAnimatedImageView
 {
     XCTestExpectation *imageSetExpectation = [self expectationWithDescription:@"animatedImageView did not have animated image set"];
@@ -441,6 +446,7 @@
 
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:NULL];
 }
+#endif
 
 - (void)testEarlyReturn {
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
@@ -460,6 +466,7 @@
     XCTAssert(image != nil, @"image callback did not occur synchronously.");
 }
 
+#if USE_FLANIMATED_IMAGE
 - (void)testload
 {
     srand([[NSDate date] timeIntervalSince1970]);
@@ -492,6 +499,7 @@
     }
     dispatch_group_wait(group, [self timeoutWithInterval:100]);
 }
+#endif
 
 - (void)testInvalidObject
 {

--- a/Example/PINRemoteImage/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/PINRemoteImage/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -7,8 +7,18 @@
     },
     {
       "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "40x40",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
     },
     {
       "idiom" : "iphone",

--- a/Example/PINRemoteImage/PINViewController.m
+++ b/Example/PINRemoteImage/PINViewController.m
@@ -8,9 +8,12 @@
 
 #import "PINViewController.h"
 
+#import <PINRemoteImage/PINRemoteImage.h>
 #import <PINRemoteImage/UIImageView+PINRemoteImage.h>
 #import <PINCache/PINCache.h>
+#if USE_FLANIMATED_IMAGE
 #import <FLAnimatedImage/FLAnimatedImageView.h>
+#endif
 
 @interface PINViewController () <UICollectionViewDataSource, UICollectionViewDelegate>
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -24,10 +24,14 @@ PODS:
   - libwebp/utils (0.4.3):
     - libwebp/core
   - libwebp/webp (0.4.3)
-  - PINCache (2.0)
-  - PINRemoteImage (1.0):
+  - PINCache (2.1)
+  - PINRemoteImage (1.2):
+    - PINRemoteImage/FLAnimatedImage (= 1.2)
+  - PINRemoteImage/Core (1.2):
+    - PINCache (>= 2.1)
+  - PINRemoteImage/FLAnimatedImage (1.2):
     - FLAnimatedImage (>= 1.0)
-    - PINCache (>= 2.0)
+    - PINRemoteImage/Core
 
 DEPENDENCIES:
   - libwebp
@@ -41,7 +45,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FLAnimatedImage: f9422f796135aff80d8c00b2afc48015bb746e24
   libwebp: 360ed8bc4ec8da413f07f84071e7f5a5c67a285d
-  PINCache: ca953ba93ce1edde056fdd99121ee65b295a08c9
-  PINRemoteImage: 549bfaee9043ea79fed7a2eb5b620d41557159df
+  PINCache: 0581b0a7578fc0bbc6c7a8b70b0615388bea064c
+  PINRemoteImage: 7505a2b822982cd37665c410373a3cf8fb5db8a6
 
 COCOAPODS: 0.37.2

--- a/Example/Pods/Local Podspecs/PINRemoteImage.podspec.json
+++ b/Example/Pods/Local Podspecs/PINRemoteImage.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "PINRemoteImage",
-  "version": "1.0",
+  "version": "1.2",
   "summary": "A thread safe, performant, feature rich image fetcher",
   "homepage": "https://github.com/pinterest/PINRemoteImage",
   "license": "Apache 2.0",
@@ -9,26 +9,48 @@
   },
   "source": {
     "git": "https://github.com/pinterest/PINRemoteImage.git",
-    "tag": 1.0
+    "tag": "1.2"
   },
   "social_media_url": "https://twitter.com/garrettmoon",
   "platforms": {
     "ios": "6.0"
   },
   "requires_arc": true,
-  "source_files": "Pod/Classes/**/*.{h,m}",
-  "public_header_files": "Pod/Classes/**/*.h",
-  "frameworks": [
-    "UIKit",
-    "ImageIO",
-    "CoreImage"
-  ],
-  "dependencies": {
-    "FLAnimatedImage": [
-      ">= 1.0"
-    ],
-    "PINCache": [
-      ">=2.0"
-    ]
-  }
+  "default_subspecs": "FLAnimatedImage",
+  "subspecs": [
+    {
+      "name": "Core",
+      "source_files": "Pod/Classes/**/*.{h,m}",
+      "exclude_files": [
+        "Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
+        "Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
+      ],
+      "public_header_files": "Pod/Classes/**/*.h",
+      "frameworks": [
+        "UIKit",
+        "ImageIO",
+        "CoreImage"
+      ],
+      "dependencies": {
+        "PINCache": [
+          ">=2.1"
+        ]
+      }
+    },
+    {
+      "name": "FLAnimatedImage",
+      "dependencies": {
+        "PINRemoteImage/Core": [
+
+        ],
+        "FLAnimatedImage": [
+          ">= 1.0"
+        ]
+      },
+      "source_files": [
+        "Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h",
+        "Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m"
+      ]
+    }
+  ]
 }

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -24,10 +24,14 @@ PODS:
   - libwebp/utils (0.4.3):
     - libwebp/core
   - libwebp/webp (0.4.3)
-  - PINCache (2.0)
-  - PINRemoteImage (1.0):
+  - PINCache (2.1)
+  - PINRemoteImage (1.2):
+    - PINRemoteImage/FLAnimatedImage (= 1.2)
+  - PINRemoteImage/Core (1.2):
+    - PINCache (>= 2.1)
+  - PINRemoteImage/FLAnimatedImage (1.2):
     - FLAnimatedImage (>= 1.0)
-    - PINCache (>= 2.0)
+    - PINRemoteImage/Core
 
 DEPENDENCIES:
   - libwebp
@@ -41,7 +45,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   FLAnimatedImage: f9422f796135aff80d8c00b2afc48015bb746e24
   libwebp: 360ed8bc4ec8da413f07f84071e7f5a5c67a285d
-  PINCache: ca953ba93ce1edde056fdd99121ee65b295a08c9
-  PINRemoteImage: 549bfaee9043ea79fed7a2eb5b620d41557159df
+  PINCache: 0581b0a7578fc0bbc6c7a8b70b0615388bea064c
+  PINRemoteImage: 7505a2b822982cd37665c410373a3cf8fb5db8a6
 
 COCOAPODS: 0.37.2

--- a/Example/Pods/PINCache/PINCache/PINCache.h
+++ b/Example/Pods/PINCache/PINCache/PINCache.h
@@ -80,6 +80,8 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  */
 + (instancetype)sharedCache;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  Multiple instances with the same name are allowed and can safely access
  the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
@@ -160,7 +162,7 @@ typedef void (^PINCacheObjectBlock)(PINCache *cache, NSString *key, id __nullabl
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (id)objectForKey:(NSString *)key;
+- (__nullable id)objectForKey:(NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object has been set.

--- a/Example/Pods/PINCache/PINCache/PINCache.m
+++ b/Example/Pods/PINCache/PINCache/PINCache.m
@@ -27,6 +27,12 @@ NSString * const PINCacheSharedName = @"PINCacheShared";
 }
 #endif
 
+- (instancetype)init
+{
+    @throw [NSException exceptionWithName:@"Must initialize with a name" reason:@"PINCache must be initialized with a name. Call initWithName: instead." userInfo:nil];
+    return [self initWithName:@""];
+}
+
 - (instancetype)initWithName:(NSString *)name
 {
     return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) firstObject]];
@@ -293,7 +299,7 @@ NSString * const PINCacheSharedName = @"PINCacheShared";
     return byteCount;
 }
 
-- (id)objectForKey:(NSString *)key
+- (__nullable id)objectForKey:(NSString *)key
 {
     if (!key)
         return nil;

--- a/Example/Pods/PINCache/PINCache/PINDiskCache.h
+++ b/Example/Pods/PINCache/PINCache/PINDiskCache.h
@@ -19,7 +19,7 @@ typedef void (^PINDiskCacheBlock)(PINDiskCache *cache);
  A callback block which provides the cache, key and object as arguments
  */
 
-typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object, NSURL *fileURL);
+typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <NSCoding>  __nullable object, NSURL * __nullable fileURL);
 
 /**
  `PINDiskCache` is a thread safe key/value store backed by the file system. It accepts any object conforming
@@ -147,6 +147,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  */
 + (void)emptyTrash;
 
+- (instancetype)init NS_UNAVAILABLE;
 
 /**
  Multiple instances with the same name are allowed and can safely access
@@ -289,7 +290,7 @@ typedef void (^PINDiskCacheObjectBlock)(PINDiskCache *cache, NSString *key, id <
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (id <NSCoding>)objectForKey:(NSString *)key;
+- (__nullable id <NSCoding>)objectForKey:(NSString *)key;
 
 /**
  Retrieves the file URL for the specified key. This method blocks the calling thread until the

--- a/Example/Pods/PINCache/PINCache/PINMemoryCache.h
+++ b/Example/Pods/PINCache/PINCache/PINMemoryCache.h
@@ -246,7 +246,7 @@ typedef void (^PINMemoryCacheObjectBlock)(PINMemoryCache *cache, NSString *key, 
  @param key The key associated with the object.
  @result The object for the specified key.
  */
-- (id)objectForKey:(nullable NSString *)key;
+- (__nullable id)objectForKey:(nullable NSString *)key;
 
 /**
  Stores an object in the cache for the specified key. This method blocks the calling thread until the object

--- a/Example/Pods/PINCache/PINCache/PINMemoryCache.m
+++ b/Example/Pods/PINCache/PINCache/PINMemoryCache.m
@@ -381,7 +381,7 @@ NSString * const PINMemoryCachePrefix = @"com.pinterest.PINMemoryCache";
 
 #pragma mark - Public Synchronous Methods -
 
-- (id)objectForKey:(NSString *)key
+- (__nullable id)objectForKey:(NSString *)key
 {
     NSDate *now = [[NSDate alloc] init];
     

--- a/Example/Pods/PINCache/README.md
+++ b/Example/Pods/PINCache/README.md
@@ -1,5 +1,8 @@
 # PINCache
 
+[![CocoaPods](https://img.shields.io/cocoapods/v/PINCache.svg)](http://cocoadocs.org/docsets/PINCache/)
+[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+
 ## Fast, non-deadlocking parallel object cache for iOS and OS X.
 
 [PINCache](PINCache/PINCache.h) is a fork of [TMCache](https://github.com/tumblr/TMCache) re-architected to fix issues with deadlocking caused by heavy use. It is a key/value store designed for persisting temporary objects that are expensive to reproduce, such as downloaded data or the results of slow processing. It is comprised of two self-similar stores, one in memory ([PINMemoryCache](PINCache/PINMemoryCache.h)) and one on disk ([PINDiskCache](PINCache/PINDiskCache.h)), all backed by GCD and safe to access from multiple threads simultaneously. On iOS, `PINMemoryCache` will clear itself when the app receives a memory warning or goes into the background. Objects stored in `PINDiskCache` remain until you trim the cache yourself, either manually or by setting a byte or age limit.
@@ -47,6 +50,12 @@ Install the docs by double clicking the `.docset` file under `docs/`, or view th
 ### CocoaPods
 
 Add [PINCache](http://cocoapods.org/?q=name%3APINCache) to your `Podfile` and run `pod install`.
+
+### Carthage
+
+Add the following line to your `Cartfile` and run `carthage update --platform ios`. Then follow [this instruction of Carthage](https://github.com/carthage/carthage#adding-frameworks-to-unit-tests-or-a-framework) to embed the framework.
+
+```github "pinterest/PINCache"```
 
 ## Requirements
 

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,1320 +7,1254 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0054C6CE337A84AD0E622BB9 /* PINDataTaskOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = E8165FCF32E8CF65F30108C5 /* PINDataTaskOperation.m */; };
-		0178EC08ADD2B294DFC39917 /* PINRemoteImageDownloadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A07BC1E88ECB3A7A9754AD8 /* PINRemoteImageDownloadTask.m */; };
-		0197CBC730CF67F7323448F1 /* UIButton+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 2503E7DC56549A7F5FCB3801 /* UIButton+PINRemoteImage.h */; };
-		01DEB31C00F5F2188B1AD53F /* analysis.c in Sources */ = {isa = PBXBuildFile; fileRef = 018FA8B5BC6377615A5FD0BC /* analysis.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		0266B36A5E3F5E755360D8EC /* PINRemoteImageManagerResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DA5BF7E6A2F099A7394B5B83 /* PINRemoteImageManagerResult.m */; };
-		046F102F36A3D152D5AC1971 /* Pods-PINRemoteImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = EB7639592B4A22DFD17D33BA /* Pods-PINRemoteImage-dummy.m */; };
-		05A44ACCF1D4B12E5D08BB82 /* PINDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F8222347FFCA6E4E0086D3E7 /* PINDiskCache.h */; };
-		061A9040BEBAC4289EC7067F /* PINRemoteImageCategoryManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A92D9362BBE2CC7A086BC6E9 /* PINRemoteImageCategoryManager.h */; };
-		071394E9A2D7E90AB453B61F /* vp8enci.h in Headers */ = {isa = PBXBuildFile; fileRef = 020E9CCFD42B5BE529C5AB36 /* vp8enci.h */; };
-		0AB25D28BE14AC5837C5C78C /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = 291680B33C1A5ACB978C3084 /* tree.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		0AEFC96CA9A31A0CB782452F /* PINRemoteImageTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 58CDA5997CD4B853F48AAC21 /* PINRemoteImageTask.m */; };
-		0B27C597C4A275EFBBE95A6C /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = 69C2E5F2777D66B8795CC895 /* upsampling.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		0B800FFA419BE7E44FDF7C44 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = BA20EC564FE2895DBFBC18CC /* demux.h */; };
-		0D23241A86754CD27900C39F /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C002129DC8236BA0B2372424 /* PINMemoryCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		0DC2B39F813E84F3D544673D /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C918AA802ABFAC8226860B6 /* MobileCoreServices.framework */; };
-		0EAC1A52B33B6BA85FF07B61 /* PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 18F4BA910200CFFFE21F8243 /* PINRemoteImage.h */; };
-		0EED3E2F2DA00E9B83E4D6F1 /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C924F20DEF8A1EC8D661176 /* bit_reader.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		11E1A01C2DE010ED64CB47F7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		120DCB47A34E36B1C0E7F6E2 /* muxread.c in Sources */ = {isa = PBXBuildFile; fileRef = E902F4F9D0DB309C93FA57B4 /* muxread.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		13CF04FD47AF50334A7A56E0 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = FDC25C6EEC0F714AB6FF163F /* alpha.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		150A2F31FA767EC5CB8A40DA /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = 877050E43BA77C4B9CF4D73F /* cpu.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		15F7DC5B1E9649C8E18604BC /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		169711B2CF880C8C12B9D0ED /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = 668813EB85E7836278E80DA0 /* thread.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		184C89F41A98C9A714E30789 /* UIButton+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2106867C7D4FC0B39EB23833 /* UIButton+PINRemoteImage.m */; };
-		19A0A48CCEAF093F2647F5F4 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = 04AE64E18B08566BA7299D6C /* alpha.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		19AB195DCDE1CB2027D0AC27 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = 731F9F85DFDF7A4FF72C64FE /* huffman_encode.h */; };
-		19F66D39D047D85B62CF20A3 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = F274C0F4ECBAA2C7F6999BAB /* frame.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		1B73DDCEAB20A277E973A274 /* FLAnimatedImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 750F9D26ECC12BD617C0C1BC /* FLAnimatedImageView+PINRemoteImage.m */; };
-		1B7B000CC72C8985C38AD02D /* filter.c in Sources */ = {isa = PBXBuildFile; fileRef = DE9188458BBD5EDBE7116F1A /* filter.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		1C82ACAF8DAAB30087625BD9 /* picture_csp.c in Sources */ = {isa = PBXBuildFile; fileRef = 607B72386DFA740FF29A3D0E /* picture_csp.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		1D5FBEDA3E96670F25C103BE /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 4154A2D9D14B75CC098E5348 /* dsp.h */; };
-		1E9539593D4AC73E3F82BD3B /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = C4485503ABDD09722DF3F543 /* quant_levels.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		1F21EF06F42D05B5AF8008AD /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = D93FCE87CE01F32875005BEC /* thread.h */; };
-		1FF0E8127312AF51FD631F4A /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4421D7C6260A68BAA7A591AD /* PINCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		21496AE6AB151B4DB7EF0B83 /* PINRemoteImageDownloadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 15CA334D42BBF9C400E5060F /* PINRemoteImageDownloadTask.h */; };
-		24CBC6A66DBBBEA6521169CB /* PINDataTaskOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BF3B35E85B47A9786C12825 /* PINDataTaskOperation.h */; };
-		29FC2389E4DE15D2F14CD4E4 /* PINRemoteImageManagerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5DAF75968DABCF7713A109 /* PINRemoteImageManagerResult.h */; };
-		2D9614617591E28BAF49AFBB /* PINRemoteImageDownloadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 15CA334D42BBF9C400E5060F /* PINRemoteImageDownloadTask.h */; };
-		2DCA557DAB88A1B7B682894E /* Pods-PINRemoteImage Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 9EC6EB5D912F8635EE261A96 /* Pods-PINRemoteImage Tests-dummy.m */; };
-		30F0C2A194B72D5585C0CD80 /* PINURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 33C8C9F82FFF8FFE3893195F /* PINURLSessionManager.m */; };
-		338BBEC9C9DE309682D8B684 /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 34FB4D5F529754FE0EED4259 /* UIImage+WebP.h */; };
-		340B3059EF0755A4E8825E40 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = 475D1E03B71A8A388B890757 /* bit_reader.h */; };
-		36440D4539BBEF9AEC547538 /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = F2A7F6385B5C12F6E745363F /* FLAnimatedImageView.h */; };
-		3834D239A0D8E4B37E9D1320 /* UIImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 70951C2B6487A163A5B0A3B4 /* UIImageView+PINRemoteImage.m */; };
-		3B859B648C0D5320EFCF60A1 /* PINRemoteImageDownloadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A07BC1E88ECB3A7A9754AD8 /* PINRemoteImageDownloadTask.m */; };
-		3D47A9C56E09B2F9FB3D7A6A /* Nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = 30ACEB879D47301F32AF62B7 /* Nullability.h */; };
-		3D4E83E12858B4EDFAAFC04D /* Pods-PINRemoteImage-PINRemoteImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6FAD3D1B72E92CCF17E8FD33 /* Pods-PINRemoteImage-PINRemoteImage-dummy.m */; };
-		3DC2CE1C38110A804983DF30 /* PINRemoteImageCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A09D9946BF95D39936F81A /* PINRemoteImageCallbacks.m */; };
-		3E07C1262EBFE285E986F41E /* Pods-PINRemoteImage-libwebp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 330EA627D53C757F18E55C48 /* Pods-PINRemoteImage-libwebp-dummy.m */; };
-		3E57203A4E0A7A2F61D36886 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = 213BE7CA6607FA9AEE970348 /* cost.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		3E5BE37A2E6CB447344BE483 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = C01D6989F22F7BBB231E55C2 /* format_constants.h */; };
-		3EB55E1FE95A40BCB71E1F3D /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EC5505BE7AEAB2C00193557 /* PINMemoryCache.h */; };
-		43E62E08F8767B8E3B0664FC /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = C342AC4D0FD7748DBBB4EFB9 /* random.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		445A34F5D4879246592CC458 /* Pods-PINRemoteImage Tests-PINCache-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 04F5C5C2992F9E133C44716F /* Pods-PINRemoteImage Tests-PINCache-dummy.m */; };
-		4640BAF00C031BE9BF041C81 /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 4421D7C6260A68BAA7A591AD /* PINCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		474B4E7AD44D9B42470B2034 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 78F1B339E533B9277943516F /* lossless_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		479C19D8971CA2E6224579F0 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A8EBA7E7FBC35B9A8A30394 /* UIKit.framework */; };
-		4AF583F33E18D2FEB45DC6DD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		4B33CB767CBB664BA94349BB /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = 1707FEF548099A39B521E414 /* neon.h */; };
-		4B40953986B40CA0E596A041 /* PINRemoteImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 900BFB3DBA86DD1F71A10A32 /* PINRemoteImageManager.m */; };
-		4C5CE323C43126945C820B36 /* PINRemoteImageCategoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FB080497D6B2101FD22E882 /* PINRemoteImageCategoryManager.m */; };
-		4D0F029BB2138036CD5AB328 /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = BD5D7CB93AA5767183969903 /* UIImage+WebP.m */; };
-		4D6C03C0F7ADA1FB10FDC834 /* config.c in Sources */ = {isa = PBXBuildFile; fileRef = 26C2F935E2AC495D401540C9 /* config.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		4D7783783B01E192F3879400 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 4B1DCA626F9F48C92F3DE418 /* filters.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		4E6B930997A66BA7B1043388 /* NSData+ImageDetectors.m in Sources */ = {isa = PBXBuildFile; fileRef = E614AEE4EAF4BEB91D514A8D /* NSData+ImageDetectors.m */; };
-		4EE91A61A934450B3FDE9123 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C0978BC16828F75398D69C77 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m */; };
-		508E38DFBAEE452DC930DCE7 /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 36D625A1C5722E002DF529B7 /* lossless_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		5180BB722BFD70B2DFD2A246 /* picture_psnr.c in Sources */ = {isa = PBXBuildFile; fileRef = 17F827E32C8D00DCF280EA65 /* picture_psnr.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		51EC3814C66CFBF2DB052389 /* UIImage+DecodedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = F8922D4AD691C9578CAC76AE /* UIImage+DecodedImage.h */; };
-		5428FC7776D9ABAB986C29BC /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = CA56F921D428CB0F8C3CAD59 /* alpha_processing_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		58342E5F6C37034E21B64361 /* UIImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DF089FD37A6C428D2BE6103 /* UIImageView+PINRemoteImage.h */; };
-		58DEBCA6B2459CBB3F7D14D5 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		59CC9A1AD95F1E57F8BFCE68 /* syntax.c in Sources */ = {isa = PBXBuildFile; fileRef = CCBD8A8DA3A62E37ED1EAE61 /* syntax.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		5CE53C9962D4D7C96CA9D76D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		5DEE4E890051384A75C6DE4B /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = D402E4D0C8870B22B4CB4251 /* dec_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		5E071786A135F50D42E3DA5C /* PINRemoteImageProcessorTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 91514A996BB2EB5AD45AB033 /* PINRemoteImageProcessorTask.m */; };
-		5FEBFA9AAF8D6AAB05FEC5EB /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = EAFBBDBB1B69F77478524F03 /* quant_levels_dec.h */; };
-		60BB65D453CAD94357BA0FD2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		624C08EB10CF5F1E9E937ED5 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 0F74BC9058274E76220B55AD /* huffman_encode.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		63E534AA9FE752F1318D01EE /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 34FB4D5F529754FE0EED4259 /* UIImage+WebP.h */; };
-		641331A32A0C70E6C45BD975 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = 76523450AB74E105E5672A90 /* webp.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		65166FF32752CD4EB006A8B0 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = E9F091AD0EF9EC3CCD15CB7F /* rescaler.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		651B38ED00E99D242CB50E33 /* muxi.h in Headers */ = {isa = PBXBuildFile; fileRef = A6CB42687C3924CA507FEB29 /* muxi.h */; };
-		658332F9F0E99B8F629A34BD /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		6A7A59E335E277164ED311AD /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = 9E2E138C150A2E033F7EA7F0 /* io.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		6C9225359621B71E106B3F09 /* FLAnimatedImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EF29D0AA847A39F6EA22781 /* FLAnimatedImageView+PINRemoteImage.h */; };
-		6CDE93264A295F1B1FBD5328 /* iterator.c in Sources */ = {isa = PBXBuildFile; fileRef = 62A29D0D154A41D24E174461 /* iterator.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		6DEB8D6D7721862B77E8A5BD /* backward_references.h in Headers */ = {isa = PBXBuildFile; fileRef = 460EE0E2DB475B09746A6B99 /* backward_references.h */; };
-		6F11D0DCD64802E800D6D3EA /* PINRemoteImageTask.h in Headers */ = {isa = PBXBuildFile; fileRef = CC098641AD165A2604B4C561 /* PINRemoteImageTask.h */; };
-		70F08C4452062BD2F6BD6B31 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = 2DFC6394E19E6ADB6E1B259F /* decode_vp8.h */; };
-		71C6D3D6C19E9D3FE859323F /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A1A79E582688E787DA8E5E8 /* endian_inl.h */; };
-		72AF1E7CF3B95FB29B34057F /* PINRemoteImageCategoryManager.h in Headers */ = {isa = PBXBuildFile; fileRef = A92D9362BBE2CC7A086BC6E9 /* PINRemoteImageCategoryManager.h */; };
-		736F1C1F357DEE6B98B253DA /* PINRemoteImageProcessorTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 1411ED0557A87A5DB30002D6 /* PINRemoteImageProcessorTask.h */; };
-		74294FD7FCE7FD3FE8B4EFF6 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 895614D466331488DAD056BF /* lossless.h */; };
-		75CC8BD0F7142BD54977A577 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = 2D2DA78D9E2F3326F53A1042 /* webpi.h */; };
-		76391DC9C03685DDF2D74EA0 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF597D47CB4B1E04C0C842AE /* CoreImage.framework */; };
-		765B868DE0740CC3F4D4C3FC /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E12298E3A9B94FB34DD582F /* huffman.h */; };
-		7696F83D8A4D087DE545964C /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = BD5D7CB93AA5767183969903 /* UIImage+WebP.m */; };
-		76BCE3E059394D6D1D347307 /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 23F0490B87B4E6252878FBEB /* FLAnimatedImage.m */; };
-		76E261E1AE58EE46272FA54E /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E2501DEA1D5FF4D546641 /* CoreGraphics.framework */; };
-		7749C2E2A627DB14EFD50599 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = 119A4B22020382EBCE5A5360 /* mux.h */; };
-		79DA0463AB996C09E6963D5E /* PINRemoteImageProcessorTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 91514A996BB2EB5AD45AB033 /* PINRemoteImageProcessorTask.m */; };
-		7DF5222B4E63EA97070927DA /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = C4123DE345C3893977C60A91 /* quant_levels_dec.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		7DFE11EBFDD2A6BC380F91B6 /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 38D01CF812A4A0CD416EDE45 /* enc_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		7EEC24F009FF8C7727816E0F /* NSData+ImageDetectors.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAD1717E22854E0A976F7A7 /* NSData+ImageDetectors.h */; };
-		81070459F2657F4CA4D7C764 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3C9D37AAD05886CCB8209DC8 /* utils.h */; };
-		81E788130BC000A57FD4644B /* cost.h in Headers */ = {isa = PBXBuildFile; fileRef = 96F24A2B6A1531C4005FC59E /* cost.h */; };
-		821FC51B6181E762EC52CF73 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 3DC294E892A7361403ED88E0 /* buffer.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		826F4C9511142A66627C3B8F /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = 346173EF458AB3CC7954C971 /* demux.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		827DC066E5639E2361380303 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 715BAE5F642853A4D2DDCB8D /* yuv_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		83CE5381D7DFB92A632AEF96 /* PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 18F4BA910200CFFFE21F8243 /* PINRemoteImage.h */; };
-		84715579BE2DC4A31C994357 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 552E2501DEA1D5FF4D546641 /* CoreGraphics.framework */; };
-		84AE9536EED15E60A415E543 /* PINProgressiveImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 770CCC566BE67C32F422BF3A /* PINProgressiveImage.m */; };
-		86F37BD4DF1F3EFB26130285 /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EEA4C04C3D3B4300C80329B /* FLAnimatedImageView.m */; };
-		887469D6291AE451CA98A703 /* PINURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DE35B24C590D2183E148D03C /* PINURLSessionManager.h */; };
-		8AF4F1BA79A1F01F81AFE2F4 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 783DF441A2A951109941CDE6 /* enc_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		8B0A0F6BB25922488DE0E57E /* muxedit.c in Sources */ = {isa = PBXBuildFile; fileRef = 1AEBCB8495D272312B6F79A2 /* muxedit.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		8BAAA5770646EB41DF287D35 /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 24C6EA16777643D6C626154D /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m */; };
-		8BFAB7AD6811DBCD287F5BC4 /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 227D1B42D0C08BE81AEC079B /* yuv.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		8C8BC77F20886A4C1E0C14E1 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 5375BF29A50FE83DD5D40CB4 /* dec_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		8CCC709D28D8201C416A9F32 /* NSData+ImageDetectors.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DAD1717E22854E0A976F7A7 /* NSData+ImageDetectors.h */; };
-		8CDE0C80D02E992838E48752 /* muxinternal.c in Sources */ = {isa = PBXBuildFile; fileRef = C6A268B8577C379C5B68409A /* muxinternal.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		8FAD6BFD67311A1B64DE9340 /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 23F0490B87B4E6252878FBEB /* FLAnimatedImage.m */; };
-		919D3A9BD8FDE016E4AED5DC /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = 809A42A4B7712F406A37B27F /* idec.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		9432B1A674E47CCE3E8FE788 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = B26FDA93F54C889F5358DC4A /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m */; };
-		947D194A3B367DDBBCE50BF1 /* PINRemoteImageManagerResult.m in Sources */ = {isa = PBXBuildFile; fileRef = DA5BF7E6A2F099A7394B5B83 /* PINRemoteImageManagerResult.m */; };
-		94AAE24E56F0BDA7521CEE43 /* PINRemoteImageCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = F1A09D9946BF95D39936F81A /* PINRemoteImageCallbacks.m */; };
-		95B422FF46603B1348AD71A6 /* backward_references.c in Sources */ = {isa = PBXBuildFile; fileRef = DA92D6C17316B55CF5905942 /* backward_references.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		960C42E79E722B5C103DE7B9 /* NSData+ImageDetectors.m in Sources */ = {isa = PBXBuildFile; fileRef = E614AEE4EAF4BEB91D514A8D /* NSData+ImageDetectors.m */; };
-		97253DF7650256EDB9125FC4 /* PINDataTaskOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 5BF3B35E85B47A9786C12825 /* PINDataTaskOperation.h */; };
-		99A317CA01A2B3998D0BD47E /* picture_tools.c in Sources */ = {isa = PBXBuildFile; fileRef = AECE0F69954120DEF87DEF8F /* picture_tools.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		9AA558573975E619CB64AA2F /* PINURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = DE35B24C590D2183E148D03C /* PINURLSessionManager.h */; };
-		9BC34D26F17D31F9C89C02FC /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = C002129DC8236BA0B2372424 /* PINMemoryCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		9C16E59B13D9D76F15B56FA4 /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 6163A230B1990890702EA953 /* color_cache.h */; };
-		9DF27DD7993B1C1940CE84B5 /* PINRemoteImageTask.h in Headers */ = {isa = PBXBuildFile; fileRef = CC098641AD165A2604B4C561 /* PINRemoteImageTask.h */; };
-		9E6D22EDBA54DC6B2C76F448 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = D5034A475CE1A83DBD5A266D /* FLAnimatedImage.h */; };
-		9F3E1B812C1144840576267D /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = 6316705DB74586A8BFD65542 /* types.h */; };
-		9F77E440DD7BB095548FE87B /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = 5AB7D7B18F8FBFCDB96DEEEE /* alphai.h */; };
-		9FFEEDB7EADA66A7FC83D5F5 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = BA42CB9CB959CA72FE6A64F3 /* filters.h */; };
-		A52A40F0D7CD7EA5D18B7554 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = ED048724AABCA3AE496D39FA /* frame.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		A6CAAE0E1B7EEF5B82BBAC0E /* Pods-PINRemoteImage-PINCache-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3E177572CA15AC09235B9CC3 /* Pods-PINRemoteImage-PINCache-dummy.m */; };
-		A7FE24A045E1BD35208EE004 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 82D0DF8AD08D326734224970 /* PINDiskCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		A9A5E530578D4D45A35D71D7 /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = 98D6448ACE91F603138DCD99 /* vp8i.h */; };
-		AB8BEB9FC6ABF4576BDA2FF5 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFBD9176C89D30344D2B806F /* QuartzCore.framework */; };
-		ABC0E892EF6CC46D1CDFF1A2 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 30F62A9719C9EF432B6E037D /* bit_writer.h */; };
-		ADAD8BB364E7C45007666977 /* webpenc.c in Sources */ = {isa = PBXBuildFile; fileRef = 92D46CA965D94804A6D2CAB4 /* webpenc.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		B0C4E0A149A56AE3A7C327BC /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = 184233F9F26C7BCC6EA083CD /* tree.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		B1B05353AFEDFC6B9CF47338 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = B56023D6F33AB318A2C726DE /* huffman.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		B33FBBD67D54D89DA7CF305A /* PINRemoteImageCallbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = D29950B5A263A0F2A663EC9A /* PINRemoteImageCallbacks.h */; };
-		B3433A17F6AA69B52078F824 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = 793271E516D880963B2C8646 /* vp8l.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		B3F6EF8583AC30B704335F77 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E92039A90C94272C2A02B76 /* ImageIO.framework */; };
-		B45B4F8CB1585F6921184A1F /* PINRemoteImageManagerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = FA5DAF75968DABCF7713A109 /* PINRemoteImageManagerResult.h */; };
-		B4638F1ADF6217E591D734B9 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = D5034A475CE1A83DBD5A266D /* FLAnimatedImage.h */; };
-		B54F57EC41A5E476D363157F /* FLAnimatedImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 750F9D26ECC12BD617C0C1BC /* FLAnimatedImageView+PINRemoteImage.m */; };
-		B550F567643922FC52BDAB1F /* PINRemoteImageCallbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = D29950B5A263A0F2A663EC9A /* PINRemoteImageCallbacks.h */; };
-		B5B956331152ED3C3536E8A5 /* PINRemoteImageProcessorTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 1411ED0557A87A5DB30002D6 /* PINRemoteImageProcessorTask.h */; };
-		B62EC6867B80887DCE72C303 /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = 300B82EB41148F1B20C9882B /* random.h */; };
-		B7244A5E9AA190E7EB7A3792 /* UIButton+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 2106867C7D4FC0B39EB23833 /* UIButton+PINRemoteImage.m */; };
-		B97D3BAE3154F0FD9D503CDB /* UIImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0DF089FD37A6C428D2BE6103 /* UIImageView+PINRemoteImage.h */; };
-		BFD3B06ABF6AA587A0E93444 /* UIImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 70951C2B6487A163A5B0A3B4 /* UIImageView+PINRemoteImage.m */; };
-		C028FEA1867161B489D11F0A /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = AEED084654AADAC9A365195A /* vp8l.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		C0FC4DA26A488F1E5E39E47B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		C1CAEBBD562F75540A0DA82B /* token.c in Sources */ = {isa = PBXBuildFile; fileRef = 19F749861852615E04CD2119 /* token.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		C1FC43AB9056822941E1D4FC /* FLAnimatedImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EF29D0AA847A39F6EA22781 /* FLAnimatedImageView+PINRemoteImage.h */; };
-		C214A62ED8CC8C05AB9E245B /* UIImage+DecodedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6157B1E2C571146A4BEE0AAC /* UIImage+DecodedImage.m */; };
-		C41AD8E758852CB0AF390918 /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 2EC5505BE7AEAB2C00193557 /* PINMemoryCache.h */; };
-		C4877E8D985BC3B401661D01 /* Nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = 30ACEB879D47301F32AF62B7 /* Nullability.h */; };
-		C512506BEC68ED57F34568D3 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 4905DDAE71A14D8336691112 /* lossless.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		C7E6F559B263FB2FCB824DC2 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BFC45008AE493FAE4B094E4 /* rescaler.h */; };
-		C8242C1CB93BCDF55AF0FCB4 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 03DDB62B993FD5786D674298 /* decode.h */; };
-		C847837DCB682806B0B5E1F1 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DFBD9176C89D30344D2B806F /* QuartzCore.framework */; };
-		C8A11CDC61F7A6538D1FF85F /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = 4DF809949EDDEFD1C5DCC4EF /* quant.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		CA8407E30DF275F352A0D37E /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = F937251E72F8D803DF740FD1 /* quant_levels.h */; };
-		CACA9F18D260194BF52A8ED4 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 5EA8E94BD7BAD9DE33E88FA2 /* upsampling_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		CB3FE2781B31BE4381BF0836 /* PINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = BA0C344DEDA0F9DB769B8DC6 /* PINCache.h */; };
-		CBA6BCBA6E28729E5AF0E0AC /* PINRemoteImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = D840FD9797CCDA096D1278AA /* PINRemoteImageManager.h */; };
-		CBC69E75C94F773998E1F3DA /* PINDataTaskOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = E8165FCF32E8CF65F30108C5 /* PINDataTaskOperation.m */; };
-		CCDACA97E4B42AF015F6B610 /* PINRemoteImageTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 58CDA5997CD4B853F48AAC21 /* PINRemoteImageTask.m */; };
-		CE5A37825E2FF07B7347631E /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = 528709200F12486986039B5B /* vp8.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		CE8DC7C818F1EF96F5BF70CF /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = 08824028B560E91F8052A59F /* utils.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		CF4B2B37B54BB80AC7C3308A /* PINRemoteImageCategoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 7FB080497D6B2101FD22E882 /* PINRemoteImageCategoryManager.m */; };
-		CFB65695735CFB8342F9CA01 /* picture.c in Sources */ = {isa = PBXBuildFile; fileRef = 84D3613B0081663D339FEB2B /* picture.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		D1A158A58AFDBB0A530C3C43 /* PINRemoteImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 900BFB3DBA86DD1F71A10A32 /* PINRemoteImageManager.m */; };
-		D39C8A6403AC467B20D41AB2 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = FCB69CB08EB887067B347EED /* vp8li.h */; };
-		D3D60405B1B607C7186C9B76 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A630F2BD1F71D2770EDE64F1 /* Foundation.framework */; };
-		D70CC57C9C8388C257E675F5 /* PINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = BA0C344DEDA0F9DB769B8DC6 /* PINCache.h */; };
-		D99834E4173775B590A5612B /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E92039A90C94272C2A02B76 /* ImageIO.framework */; };
-		D9B132BFBF470111603C7F11 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 9F24BC8343FE6CF0CEB0FB27 /* alpha_processing.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		DA083E9EAFE7D36F9D112CDF /* PINProgressiveImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 28D7D0A5B7D11970BDD94AEF /* PINProgressiveImage.h */; };
-		DA567EF5C549B7A2F6EC9A03 /* UIButton+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 2503E7DC56549A7F5FCB3801 /* UIButton+PINRemoteImage.h */; };
-		DB5A11826E1743091C771612 /* histogram.c in Sources */ = {isa = PBXBuildFile; fileRef = 0E5112E3F64D019481017388 /* histogram.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		DB7A2A7F9B8FBBB663A5B941 /* PINDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F8222347FFCA6E4E0086D3E7 /* PINDiskCache.h */; };
-		DBD7A7FAC4662D051090FE92 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8839C73E910D9D4E92346929 /* bit_reader_inl.h */; };
-		DD1B5E639FA933CF253DD99B /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = 6637574CFFC3A8608AFDC57B /* quant.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		DD2BD3DB123636984125A4B3 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = DFC3CD908E9C2EE4B301B432 /* upsampling_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		DDEA111953BE877A78C9C7D1 /* yuv_tables_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B6A3115CEB5BC85ACABA43 /* yuv_tables_sse2.h */; };
-		E01855C898ACEFF3AF632E0A /* PINRemoteImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = D840FD9797CCDA096D1278AA /* PINRemoteImageManager.h */; };
-		E12118E4BE51B81623038E4F /* PINURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 33C8C9F82FFF8FFE3893195F /* PINURLSessionManager.m */; };
-		E2BD09BC5C2745EE7BDA3AB9 /* PINProgressiveImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 28D7D0A5B7D11970BDD94AEF /* PINProgressiveImage.h */; };
-		E360F7BE022956F35F0B769D /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E92039A90C94272C2A02B76 /* ImageIO.framework */; };
-		E9A17BE3E525BE06F079A433 /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 82D0DF8AD08D326734224970 /* PINDiskCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
-		EAD180400E6D19B2950D3B50 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 7CDACEDED47F9E871576FDD5 /* yuv_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		EC1E5FB40654D64036F81695 /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = FC4FFBA1FEF5D4C4143ACC54 /* mux_types.h */; };
-		ED852B868D28A078173D81CB /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 2EEA4C04C3D3B4300C80329B /* FLAnimatedImageView.m */; };
-		EDCF10ACB44DF709C73B6B04 /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = 0C59AFEDC7708E422C40C308 /* dec_clip_tables.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		EDF6345D40421A1AEF72B73B /* picture_rescale.c in Sources */ = {isa = PBXBuildFile; fileRef = 6CAACF882F1B9A78A6D72DE4 /* picture_rescale.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		EF2F505FB3B719C43E67ED33 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = 6A473B0A3E09DDD102E55D0D /* bit_writer.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		EF79A8255DA7C465777EB2C4 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 79B7B5C3B3E806FF5E198A55 /* enc_avx2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		EF9765DC380EEA12A2A80433 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 46C17FAB98D60BA7B4144046 /* dec_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		EFF6C10276463A52A6716DAE /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = F2A7F6385B5C12F6E745363F /* FLAnimatedImageView.h */; };
-		F2D7FF6F71741A80867D8899 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = 4F5A7A8B06DB59D227A30337 /* dec.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		F3B32880B6C5F4BF91409903 /* UIImage+DecodedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = F8922D4AD691C9578CAC76AE /* UIImage+DecodedImage.h */; };
-		F4906FF2987F2F0C21FC2E33 /* histogram.h in Headers */ = {isa = PBXBuildFile; fileRef = 739A945AD4203B330E3ADC71 /* histogram.h */; };
-		F537DFF88515D90E8327E408 /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = 03E781702445143853DE9F1E /* enc.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		F57AE31AE67F8CC414FA1847 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = CDB47F1E1BEE88EC5F15D7F5 /* enc_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		F5EF8CA94A96F67906961FD2 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = EB058DE67218FE36A48A45E8 /* color_cache.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		F7955440CC4FE43ED916D3A0 /* PINProgressiveImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 770CCC566BE67C32F422BF3A /* PINProgressiveImage.m */; };
-		F7FA1D61E8C733C1320F20C2 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = A8224771F2044567D187303A /* yuv.h */; };
-		F8D7DE2B94BB4E3028700DF7 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A8EBA7E7FBC35B9A8A30394 /* UIKit.framework */; };
-		F93487AE0A0B97F4F9F4982E /* UIImage+DecodedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6157B1E2C571146A4BEE0AAC /* UIImage+DecodedImage.m */; };
-		FA039AFC75E91F3A5347D847 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E92039A90C94272C2A02B76 /* ImageIO.framework */; };
-		FA4D50F968D90739B85224C1 /* lossless_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 8B8507BB0956AC4C0A042052 /* lossless_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
-		FB863628DF97264623E1E2D2 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = 8FECF902E84AC3C2FCF0002D /* vp8li.h */; };
-		FC7A930BB3C048B6E3D2ABDB /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AF597D47CB4B1E04C0C842AE /* CoreImage.framework */; };
-		FD0F5378EA5B299F9F21BE04 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8C918AA802ABFAC8226860B6 /* MobileCoreServices.framework */; };
-		FD6A6971FE246D8429F967EE /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0848E937F532D50A98429553 /* encode.h */; };
+		0094A47556FDC879C6D6356E /* FLAnimatedImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = A1EAC63C315E4C32D45957BF /* FLAnimatedImageView+PINRemoteImage.m */; };
+		02C1EE7FC16C22DA88F43AD4 /* quant_levels.c in Sources */ = {isa = PBXBuildFile; fileRef = 93E33A749AD14EB35FF0FA31 /* quant_levels.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		03EB20EE7E05EC9EF9BB8982 /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CA4E371A1D3FC1E9FCD2C4A /* FLAnimatedImage.m */; };
+		047E46CB60F4788C1A927AE4 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 452ABBFF35FBCE2401926EE0 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m */; };
+		07FB7C0AA5DDF7DDDDB8180C /* NSData+ImageDetectors.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AEF73E9E68A8B37765FFE7 /* NSData+ImageDetectors.m */; };
+		0B079D7B9B1F41E67CECF87B /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D04F2F9D359D731DFD9D5BB /* CoreImage.framework */; };
+		0B51B9CA0CE0CEAA9E44FA0B /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44C213D9012C09902F626D8D /* QuartzCore.framework */; };
+		0C27D04DBE80E4B0A415AF87 /* vp8enci.h in Headers */ = {isa = PBXBuildFile; fileRef = 80D2FDEA75A66CAAF4F92883 /* vp8enci.h */; };
+		0DDB67CBD31E957A1AA82891 /* histogram.c in Sources */ = {isa = PBXBuildFile; fileRef = CD3777DB27D91C006537BFC6 /* histogram.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		0DFB6C60173C5C15AC1D38FA /* bit_reader.c in Sources */ = {isa = PBXBuildFile; fileRef = 3CABF8EC83146EB980B2682C /* bit_reader.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		0EA32304B4F7C1916B519C4C /* UIImage+DecodedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 68F6EA37D82944A4D73413DB /* UIImage+DecodedImage.m */; };
+		0F0776A8ED667DFE43F929AC /* PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5629341AF914E376F66313 /* PINRemoteImage.h */; };
+		1039361A8DC38000BC3F0B54 /* PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9B5629341AF914E376F66313 /* PINRemoteImage.h */; };
+		10EAB51384E3B2D4C9F4BBE9 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 31F01E43660702EA2B7C74BE /* buffer.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		1309A2B6B06085B3B355C0E0 /* cost.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A427A2D8751ABE66D62D763 /* cost.h */; };
+		1348C1D2629B33669915412E /* random.c in Sources */ = {isa = PBXBuildFile; fileRef = E3E3AB245A8B79CE36BEC5FD /* random.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		1405E5094BB9BDD89FA1CF5C /* PINRemoteImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2904117440C98966700B86A8 /* PINRemoteImageManager.m */; };
+		15891EB0433C4442D1B7FA2E /* PINRemoteImageProcessorTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ED575F1C4CD6FCE15444090 /* PINRemoteImageProcessorTask.m */; };
+		1639EB89362F26983A3ADAB1 /* PINRemoteImageProcessorTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D0CCC325790418BBABC259E /* PINRemoteImageProcessorTask.h */; };
+		169164E70734BBCFED790329 /* Pods-PINRemoteImage-PINCache-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C1C4102260B5CB9D40248207 /* Pods-PINRemoteImage-PINCache-dummy.m */; };
+		1784D7E77879218E94E0B882 /* yuv_tables_sse2.h in Headers */ = {isa = PBXBuildFile; fileRef = 144925D10E355A3E8BE1A241 /* yuv_tables_sse2.h */; };
+		17FDB2E0321B5C77B4660C84 /* PINRemoteImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F050B9E2172D157403ECB532 /* PINRemoteImageManager.h */; };
+		18712DEABB45CDF482FA801E /* PINDataTaskOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEA8EBA769657A40B841BFE5 /* PINDataTaskOperation.m */; };
+		18DEFCF80BC5FDAD7911AF18 /* huffman_encode.h in Headers */ = {isa = PBXBuildFile; fileRef = 70EB8DE515C61A5D8FC9E7A7 /* huffman_encode.h */; };
+		19154C8D5371B3FFE771492F /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 002E645F13D022F93A6F4741 /* PINDiskCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		19A4848B0874302A689A112D /* quant_levels_dec.h in Headers */ = {isa = PBXBuildFile; fileRef = 087F18EDDE14738AFA0DDE34 /* quant_levels_dec.h */; };
+		19EF258AF4167780E663707B /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4CBCD20720278A05CA0C78 /* ImageIO.framework */; };
+		1B8C7BAD3FBDDDBD18D0974D /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4CBCD20720278A05CA0C78 /* ImageIO.framework */; };
+		1BA6BD982BEF6F7C3B283233 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E036357C7BE69A4A8411CC8 /* decode.h */; };
+		1CBB8A57DECE7D1B5F13984C /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D616041EDA8195E90AA3B12 /* PINCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		1D4D8D1639B7AB607CA699A1 /* analysis.c in Sources */ = {isa = PBXBuildFile; fileRef = 07C35A427B16AD45795C6335 /* analysis.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		1E3276533A42252EF7D6A489 /* vp8.c in Sources */ = {isa = PBXBuildFile; fileRef = 6B666F75709BC40C9919CE52 /* vp8.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		1E583050473B2D10F6EE2840 /* PINRemoteImageCategoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C06C732A3E3DCFDD478758A4 /* PINRemoteImageCategoryManager.m */; };
+		1EB40AFB1329F397E6EBA9FA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		1ED0BA8F53C46113B4CE8CD0 /* PINRemoteImageDownloadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = A7DBA32B5F1BC2B095B58DE4 /* PINRemoteImageDownloadTask.h */; };
+		1FACE7CE823B276307026136 /* color_cache.c in Sources */ = {isa = PBXBuildFile; fileRef = 9D5283C4C58CEC815EC2756D /* color_cache.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		2052BE9B64CC04F6A135EC2E /* NSData+ImageDetectors.m in Sources */ = {isa = PBXBuildFile; fileRef = 33AEF73E9E68A8B37765FFE7 /* NSData+ImageDetectors.m */; };
+		210784816A2E1EC651E40B62 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		2116CB642B3919F226BCA7E2 /* PINRemoteImageManagerResult.m in Sources */ = {isa = PBXBuildFile; fileRef = D6B3E488C2E32A71EEBCB2AD /* PINRemoteImageManagerResult.m */; };
+		220E2C72171C43F2995C09C4 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = B78C15E8DFA5C1B3EF25452F /* FLAnimatedImage.h */; };
+		245FEDF49A2C07CA2BBAD55E /* enc_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 8A2850CDB3C10F3465131AAA /* enc_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		262D233C01550535D6D1CE4D /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = 689E7A7FD0DBD72E2A442847 /* tree.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		2718C7039BD569D2D72CBE15 /* NSData+ImageDetectors.h in Headers */ = {isa = PBXBuildFile; fileRef = D25E81CB296EC9A0E46E868C /* NSData+ImageDetectors.h */; };
+		2897134AD66AA1968F4E53D9 /* rescaler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8F0B93E9AFF81CBDC1DF67FF /* rescaler.h */; };
+		28A7A89FFF79424001E7B4E8 /* PINProgressiveImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EAD94C9C22F68324F90913C /* PINProgressiveImage.h */; };
+		290BFE8937FB52B0278319EF /* PINRemoteImageCategoryManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B0BF246114FB26A8A30DC0AD /* PINRemoteImageCategoryManager.h */; };
+		29DC979FA0B3C7FA5A05BE4C /* lossless_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 55A7198EEE01380E97EB3B91 /* lossless_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		2A087E8B391B049CA817FCD2 /* cost.c in Sources */ = {isa = PBXBuildFile; fileRef = D51C15928903038BE170073F /* cost.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		2B1BC64717D178330CFC578A /* PINDataTaskOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = BF043BD628437EE79D702598 /* PINDataTaskOperation.h */; };
+		2C7926679D9F093E5B5E7872 /* bit_writer.h in Headers */ = {isa = PBXBuildFile; fileRef = 6C07892512E3B23951EFA616 /* bit_writer.h */; };
+		2D6D90420C4593D3D172F715 /* histogram.h in Headers */ = {isa = PBXBuildFile; fileRef = C5FF526DD09A158931D49CD7 /* histogram.h */; };
+		2E60682CB5A0A21D625A9E8A /* PINRemoteImageManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 2904117440C98966700B86A8 /* PINRemoteImageManager.m */; };
+		2F1E6CC7F0BCE1057F635633 /* filter.c in Sources */ = {isa = PBXBuildFile; fileRef = D349EBBA19654B57707F1E74 /* filter.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		31FE5C2018CF8D763F811E9A /* PINProgressiveImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0EAD94C9C22F68324F90913C /* PINProgressiveImage.h */; };
+		32FC3007865289C23440A2C0 /* thread.c in Sources */ = {isa = PBXBuildFile; fileRef = 1C5E54F58258FC163E9DB58D /* thread.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		36CB2E4C71AEFE7702819E48 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 44C213D9012C09902F626D8D /* QuartzCore.framework */; };
+		37EFF193DB0A6A78E2144770 /* enc_avx2.c in Sources */ = {isa = PBXBuildFile; fileRef = 703C6BD0871A9BF3BC4875B1 /* enc_avx2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		3886C351B66F121EBA77F5A0 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = D1E2D98F066F7A496238AF3D /* frame.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		38CB189C568E2F8F57CC3A0D /* FLAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CA4E371A1D3FC1E9FCD2C4A /* FLAnimatedImage.m */; };
+		39AA8CD157E19842839C7A5A /* UIImage+DecodedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 68F6EA37D82944A4D73413DB /* UIImage+DecodedImage.m */; };
+		39FF73D7A5F174BD76D2EFED /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		3A4B90587C21DC8496CDFD12 /* cpu.c in Sources */ = {isa = PBXBuildFile; fileRef = C0CB102BF6E2999E137D39C9 /* cpu.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		3A667F5DB9EAA37E3E82430D /* UIImage+DecodedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E6C843B0FFCDC59978F0CD /* UIImage+DecodedImage.h */; };
+		3AB9629B85A2E26BCF288437 /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B3B218256231422D79A11C84 /* FLAnimatedImageView.m */; };
+		3CC22E823334E1D3A6CACD18 /* PINRemoteImageManagerResult.m in Sources */ = {isa = PBXBuildFile; fileRef = D6B3E488C2E32A71EEBCB2AD /* PINRemoteImageManagerResult.m */; };
+		3CCC4C341A1A67CF77B4C69E /* PINRemoteImageCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = A2B6E7196058ABCD9E9F93AD /* PINRemoteImageCallbacks.m */; };
+		3D5C2A89984D602525598E79 /* yuv.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A2EC7121145E3C367671823 /* yuv.h */; };
+		3FC1B89BEF4B0BE4FBFA3A4F /* PINURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D4E03FC9CE520645EAC61E08 /* PINURLSessionManager.m */; };
+		402297B807232FAAB993D824 /* PINRemoteImageDownloadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E69527D0E662AAD95A395610 /* PINRemoteImageDownloadTask.m */; };
+		426DB38A5E431594FBA1251F /* vp8i.h in Headers */ = {isa = PBXBuildFile; fileRef = F848FF815F6381B4598A4754 /* vp8i.h */; };
+		429FB969ADDF192DAF1908E6 /* PINRemoteImageDownloadTask.h in Headers */ = {isa = PBXBuildFile; fileRef = A7DBA32B5F1BC2B095B58DE4 /* PINRemoteImageDownloadTask.h */; };
+		4422E64C539E6D071CF7C366 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4CBCD20720278A05CA0C78 /* ImageIO.framework */; };
+		449422162A22BEF80CE6340A /* UIImage+DecodedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = A5E6C843B0FFCDC59978F0CD /* UIImage+DecodedImage.h */; };
+		44FE2AD3DD8D8B2C929AE88F /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F35DA2684502C2DCA27B2622 /* PINMemoryCache.h */; };
+		46CF43588B88C5E9F018B222 /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = CC3C5C952139B91BC45E75CE /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m */; };
+		4A3019984EBBCB734D1851EC /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D91327C87EB06EEFDC048AB /* CoreGraphics.framework */; };
+		4A646D1FCB9EB587E7E6A944 /* huffman.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DDB41864DCBD565EAE3BB86 /* huffman.h */; };
+		4ADD232FBE2F89BC5ADFD682 /* FLAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = B78C15E8DFA5C1B3EF25452F /* FLAnimatedImage.h */; };
+		4BBA352FCE81C71575A35CE0 /* muxinternal.c in Sources */ = {isa = PBXBuildFile; fileRef = 64B1DE7C5BA3B54BDE19602D /* muxinternal.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		4D1B6E32A0C3637DAD34F225 /* picture_csp.c in Sources */ = {isa = PBXBuildFile; fileRef = 622677490FE95BF8855EEA3F /* picture_csp.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		4D46AA2D4BE43932E44F1813 /* PINURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 289B4490633CB580D96ED8FE /* PINURLSessionManager.h */; };
+		4D9F41FAE0E55A61575CB6C0 /* FLAnimatedImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D9EF65B27D6DBFAB1EF44A0 /* FLAnimatedImageView+PINRemoteImage.h */; };
+		4E52E9A0E8A4D891289C3821 /* picture_psnr.c in Sources */ = {isa = PBXBuildFile; fileRef = 517D7FE0A9689D78AB10B680 /* picture_psnr.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		502F76EDFB4C686E216EC1A4 /* backward_references.h in Headers */ = {isa = PBXBuildFile; fileRef = E555643519C3F9702B28F5F5 /* backward_references.h */; };
+		509111ECA6C28ECAF777D66C /* utils.c in Sources */ = {isa = PBXBuildFile; fileRef = B734C7A2E54ADBFA07676BC4 /* utils.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		5117C55A6C9544AB925FCA2A /* FLAnimatedImageView.m in Sources */ = {isa = PBXBuildFile; fileRef = B3B218256231422D79A11C84 /* FLAnimatedImageView.m */; };
+		519711DB6DB7827EE02E50E0 /* PINRemoteImageTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 2322476F62E9FE70B93A7FE4 /* PINRemoteImageTask.m */; };
+		546349EC44AB83AD2DC304B1 /* bit_writer.c in Sources */ = {isa = PBXBuildFile; fileRef = D1F29B2317039A4575417574 /* bit_writer.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		556EDC6EA4BDD83D7AF95F99 /* UIButton+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = AC256EE7D2F70048CF7A868C /* UIButton+PINRemoteImage.m */; };
+		5BC17DB97C1FD22F67B50F34 /* syntax.c in Sources */ = {isa = PBXBuildFile; fileRef = 15E7C95802E6DE69BEE8E5AD /* syntax.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		5C0E9B49BB49AB0AA590F74F /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 6474AA66BB8A5F68F4A1C58C /* PINMemoryCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		5F373ABF4818F0C7504A4511 /* Nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E1203C33444213664EFBBA4A /* Nullability.h */; };
+		5F6A726880585038D28F8F4C /* PINRemoteImageDownloadTask.m in Sources */ = {isa = PBXBuildFile; fileRef = E69527D0E662AAD95A395610 /* PINRemoteImageDownloadTask.m */; };
+		5F80A9CA3FEB4E7A2D9DAB43 /* bit_reader_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 9365CD6EBAC0F4CA89A3DC9E /* bit_reader_inl.h */; };
+		5F834A5AA2C65DE1D99706A5 /* UIButton+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 02331317D3899B0E6DD8320D /* UIButton+PINRemoteImage.h */; };
+		6078E30DC14129FAA0561D79 /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = 5268DA59BDABF99F1AD0944A /* UIImage+WebP.m */; };
+		60A0677FE279166C645FC670 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = D3246710D21CD09EECB84A49 /* vp8l.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		60DCCF537097A8ECF30C9DE1 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = CA17741002D92724228EF02E /* vp8li.h */; };
+		616B2FCF4511787570111153 /* alpha_processing.c in Sources */ = {isa = PBXBuildFile; fileRef = 36D9D70985B2DBDD0E5AE903 /* alpha_processing.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		6561FD67E4707F4742AF9812 /* lossless_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 0D286EEF4E6D07BC5C0E67CE /* lossless_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		67034F7E2233E37A66BE3DDB /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = 4D52F0AA9E1BE0A1A5CD6D20 /* alpha.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		67163DD0260900C31DCE6636 /* Pods-PINRemoteImage Tests-PINCache-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C29AB40A97197DF7640E91FB /* Pods-PINRemoteImage Tests-PINCache-dummy.m */; };
+		67CBBC11C09F58F097DC7CF9 /* lossless.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B1BB990497563B941D74F4B /* lossless.h */; };
+		6847D302FC602C48B3399690 /* muxedit.c in Sources */ = {isa = PBXBuildFile; fileRef = E7948655905AE1A3F8780C97 /* muxedit.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		697E010A1FA49E1BD1A8A9E3 /* upsampling_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 1DA341475E29949E9E1F1FD2 /* upsampling_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		6A74A0FC7FBD2F1E170F0555 /* PINURLSessionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 289B4490633CB580D96ED8FE /* PINURLSessionManager.h */; };
+		6BECB8DAA9022040EF9BD60B /* PINRemoteImageCategoryManager.h in Headers */ = {isa = PBXBuildFile; fileRef = B0BF246114FB26A8A30DC0AD /* PINRemoteImageCategoryManager.h */; };
+		6C073AC6E70647AB6F0B14CB /* endian_inl.h in Headers */ = {isa = PBXBuildFile; fileRef = 9A7645820E7854F8AC76D80B /* endian_inl.h */; };
+		6FDEDCE96DB77348636C7DE8 /* picture.c in Sources */ = {isa = PBXBuildFile; fileRef = 4583E5264A6F29FD1B54BF58 /* picture.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		71CE3F7BC83FB693C9949743 /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 62AD0673C84961F5598B388F /* FLAnimatedImageView.h */; };
+		734D71CA72D6C3256C05B1B5 /* PINMemoryCache.h in Headers */ = {isa = PBXBuildFile; fileRef = F35DA2684502C2DCA27B2622 /* PINMemoryCache.h */; };
+		73C566B103CEEB928E544F6F /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = E5E1351EB7476614C4336ED0 /* quant.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		768951F25AACC4C5700F1063 /* NSData+ImageDetectors.h in Headers */ = {isa = PBXBuildFile; fileRef = D25E81CB296EC9A0E46E868C /* NSData+ImageDetectors.h */; };
+		776A69B0D76AB664F7F8C2C5 /* bit_reader.h in Headers */ = {isa = PBXBuildFile; fileRef = C079A820E26E81694890DFB6 /* bit_reader.h */; };
+		776B979D8F64366767EBEC77 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		7B3984A5D367736F91291CDA /* lossless_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = AA888CEC0DC517F377C4F2FB /* lossless_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		7D607B4AE983AB06DF907CD9 /* quant_levels.h in Headers */ = {isa = PBXBuildFile; fileRef = 82A985679CA3614B0380C3FE /* quant_levels.h */; };
+		7EA616756699A10416E952B1 /* filters.c in Sources */ = {isa = PBXBuildFile; fileRef = 7DFFAA3048BA40173308AD34 /* filters.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		7FEB47D533CA4FA748FB1264 /* yuv_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 76A92B34446E65667CFB54E7 /* yuv_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		8020BBCD52795F3276BDAEE5 /* upsampling.c in Sources */ = {isa = PBXBuildFile; fileRef = D9547159833CBC732CCB3812 /* upsampling.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		80FA61337C72D7F2F6918CBE /* yuv.c in Sources */ = {isa = PBXBuildFile; fileRef = 1F99244BFB5A12D8FC97DD05 /* yuv.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		81A1CD9E587FBC1C6CF60B9B /* dec_clip_tables.c in Sources */ = {isa = PBXBuildFile; fileRef = B08D8CE04C3AFA9CF050F9BF /* dec_clip_tables.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		82D38B2A74C164F43EA2BCAB /* idec.c in Sources */ = {isa = PBXBuildFile; fileRef = 51167217F5890A290529558F /* idec.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		834DE17ACBF8F7DF47502529 /* PINRemoteImageCallbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB0A5712FDDBFC13AF90EAE /* PINRemoteImageCallbacks.h */; };
+		8699DE23E681DA098677B62C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		88407AE3419406A8E423CC94 /* muxi.h in Headers */ = {isa = PBXBuildFile; fileRef = 0BFA2A814C50BED72995DFC5 /* muxi.h */; };
+		8A8BC971BC87A639003EEE25 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1632451F317F81C5837DCBA3 /* MobileCoreServices.framework */; };
+		8C0006D0E8AD20967D4F2F73 /* huffman.c in Sources */ = {isa = PBXBuildFile; fileRef = 7A8F88E15EC0E4363C413E89 /* huffman.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		8E0014B2901205894F74A111 /* FLAnimatedImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = A1EAC63C315E4C32D45957BF /* FLAnimatedImageView+PINRemoteImage.m */; };
+		8FE78EF57EA97BA8DD25F70B /* PINRemoteImageManager.h in Headers */ = {isa = PBXBuildFile; fileRef = F050B9E2172D157403ECB532 /* PINRemoteImageManager.h */; };
+		9341A3EE4770A2021A623010 /* dec.c in Sources */ = {isa = PBXBuildFile; fileRef = D9E72BE5473A801CF9ACAFFB /* dec.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		95402FF7528436D42D69E38B /* PINProgressiveImage.m in Sources */ = {isa = PBXBuildFile; fileRef = BDFF42ED8EBE906CEE3C19D5 /* PINProgressiveImage.m */; };
+		975BD3E7D212A71A7B8D530C /* Nullability.h in Headers */ = {isa = PBXBuildFile; fileRef = E1203C33444213664EFBBA4A /* Nullability.h */; };
+		9A1177D25D105D82B7A2610D /* quant_levels_dec.c in Sources */ = {isa = PBXBuildFile; fileRef = E9306DBC766A410DEB9FE244 /* quant_levels_dec.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		9B5A7F03545E3300D5F34D21 /* mux.h in Headers */ = {isa = PBXBuildFile; fileRef = 5E7BB51F9DACED26FD180CC8 /* mux.h */; };
+		9C022A01F08119B8F21D1CDD /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2EC6F4FC8AFC72A09A33FD9 /* UIKit.framework */; };
+		9CBA24A5AD4D7E979FED7351 /* PINRemoteImageCallbacks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CB0A5712FDDBFC13AF90EAE /* PINRemoteImageCallbacks.h */; };
+		9CC58478CEB46E74482FB72E /* PINDataTaskOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = BF043BD628437EE79D702598 /* PINDataTaskOperation.h */; };
+		9D0BC4366F4100E4AC85E6C2 /* io.c in Sources */ = {isa = PBXBuildFile; fileRef = 51A93AF501FD138663F4431F /* io.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		9F5B7696626644B235148F67 /* neon.h in Headers */ = {isa = PBXBuildFile; fileRef = D43D339120D8E934C652C8E6 /* neon.h */; };
+		A34BA2AA2669AA6867E3B7FD /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C5102A86DCDF791157E6EFF /* demux.h */; };
+		A3ACFF80485590ABBAEA7043 /* iterator.c in Sources */ = {isa = PBXBuildFile; fileRef = 0D45CF433191B090268D502A /* iterator.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		A3E1DBF32A0F147009038347 /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = A6140A8032385E6E49B60591 /* types.h */; };
+		A52D4E44A79B321DEBE77B67 /* FLAnimatedImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D9EF65B27D6DBFAB1EF44A0 /* FLAnimatedImageView+PINRemoteImage.h */; };
+		A748CD750333F452F76DCBCD /* PINCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 0D616041EDA8195E90AA3B12 /* PINCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		A7D06AA24B82C419510E8C95 /* PINRemoteImageManagerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 850102C71DEEB6F3A7FC2952 /* PINRemoteImageManagerResult.h */; };
+		A7DB4C297733CD1DDE35951D /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D04F2F9D359D731DFD9D5BB /* CoreImage.framework */; };
+		A90F00E37A5EB92C7E5829F7 /* UIButton+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = AC256EE7D2F70048CF7A868C /* UIButton+PINRemoteImage.m */; };
+		AAF9FA05021E7AB39F6A5874 /* encode.h in Headers */ = {isa = PBXBuildFile; fileRef = F4C27D5F2DA9483AA8197661 /* encode.h */; };
+		ABC8D6E481B0526AB6E698EA /* color_cache.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F80CA4B5153F6B519765BB2 /* color_cache.h */; };
+		AC9A2BC35B1AE01CF9A13688 /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 128080C5B8DAE97C307F48AA /* UIImage+WebP.h */; };
+		AE3652CD1F191E9C0FFFC663 /* PINRemoteImageTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E460DEF575B8F9BFC53BF9B8 /* PINRemoteImageTask.h */; };
+		AF1D1309009C5DE1E51386E1 /* upsampling_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = FF1697F345EAFE9BAB87FA57 /* upsampling_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		B047434439BD4FF516543A66 /* enc_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = 7F747586855B2B08D80E8C65 /* enc_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		B1D51A993DB2AF1352E7FE85 /* FLAnimatedImageView.h in Headers */ = {isa = PBXBuildFile; fileRef = 62AD0673C84961F5598B388F /* FLAnimatedImageView.h */; };
+		B1FAAA2CBFFC1D0C3CF91F06 /* alpha.c in Sources */ = {isa = PBXBuildFile; fileRef = 16BFCE71127012C5092825D3 /* alpha.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		B26C0C30161901317C2180D0 /* UIImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = FB881F69DBA9F64C9FD4F986 /* UIImageView+PINRemoteImage.h */; };
+		B2CB50EAD4222C724FCC01A7 /* enc_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = B96957A211BE67A256453E66 /* enc_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		B3881C4B6507049757C03E7B /* UIButton+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 02331317D3899B0E6DD8320D /* UIButton+PINRemoteImage.h */; };
+		B3B407A31B47C66B7317E5AB /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4D91327C87EB06EEFDC048AB /* CoreGraphics.framework */; };
+		B4732C21CF338F14B670C8B5 /* PINDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A29F94C3D7EC574411A698 /* PINDiskCache.h */; };
+		B4ACAA9F1007749F9806E015 /* PINRemoteImageCallbacks.m in Sources */ = {isa = PBXBuildFile; fileRef = A2B6E7196058ABCD9E9F93AD /* PINRemoteImageCallbacks.m */; };
+		B55C9CD7F56C8FED4EB7D2DA /* config.c in Sources */ = {isa = PBXBuildFile; fileRef = 2D7F5B80A8DCACEAAF77F899 /* config.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		B64099DA25B3745FA3C16D30 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		B7E111BBD287134CEE234D0D /* random.h in Headers */ = {isa = PBXBuildFile; fileRef = 6D216038D4F2854B984836EC /* random.h */; };
+		B8E04E8257B101C8A6FA8DD3 /* dsp.h in Headers */ = {isa = PBXBuildFile; fileRef = 6CD425DF49D7A58E10942A2C /* dsp.h */; };
+		B99582F0E55F42083AD849BA /* alphai.h in Headers */ = {isa = PBXBuildFile; fileRef = 214C502BB1A4BC420B333D5C /* alphai.h */; };
+		BB3110561B651EF130E658EE /* PINMemoryCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 6474AA66BB8A5F68F4A1C58C /* PINMemoryCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		BF8F9334AEDC834BE8A7485B /* alpha_processing_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 9B029AC1FDB4099426F5535A /* alpha_processing_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		C1DBB812E7CA2BB22FF11E72 /* webp.c in Sources */ = {isa = PBXBuildFile; fileRef = ADEAE7778146D46205A810E9 /* webp.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		C2B7CA39236DF09D4A5CA89C /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2EC6F4FC8AFC72A09A33FD9 /* UIKit.framework */; };
+		C344DDFD6F51C162504063B9 /* huffman_encode.c in Sources */ = {isa = PBXBuildFile; fileRef = 938490304538811C80D06E0C /* huffman_encode.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		C48E04228AE5C0764981017F /* PINDiskCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 002E645F13D022F93A6F4741 /* PINDiskCache.m */; settings = {COMPILER_FLAGS = "-DOS_OBJECT_USE_OBJC=0"; }; };
+		C4CCABFB7C66748AA8395BFB /* dec_neon.c in Sources */ = {isa = PBXBuildFile; fileRef = DAD14ABBC1257F8801CCED50 /* dec_neon.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		C5DDC4B7EC3D4BC785475E68 /* filters.h in Headers */ = {isa = PBXBuildFile; fileRef = F22C803B44692927AA234CAB /* filters.h */; };
+		C6CC8E22A26ED28CF6924883 /* webpi.h in Headers */ = {isa = PBXBuildFile; fileRef = B6753CEF9354FFBF78BD5589 /* webpi.h */; };
+		C9DA08DBB631C364EBBEEA3B /* muxread.c in Sources */ = {isa = PBXBuildFile; fileRef = 3BF09DF1C61D0B047C34C79B /* muxread.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		CA4B0E08B2FF8828E16F1570 /* dec_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = 987701B44446E0D53697C62F /* dec_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		CADC210C9D101453ED12AE22 /* PINRemoteImageCategoryManager.m in Sources */ = {isa = PBXBuildFile; fileRef = C06C732A3E3DCFDD478758A4 /* PINRemoteImageCategoryManager.m */; };
+		CAF2A5EEB0A3F3F41DD3B66E /* UIImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = D589031A9F40C24BC3F91E2C /* UIImageView+PINRemoteImage.m */; };
+		CF747EC355F3B03B536A935E /* Pods-PINRemoteImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 730CD23B2028D171065EFBB1 /* Pods-PINRemoteImage-dummy.m */; };
+		D09F6A1A51130F1B0F577E5B /* demux.c in Sources */ = {isa = PBXBuildFile; fileRef = B159B32D332AF016E70CC8A7 /* demux.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		D0B3598596C081BEEDE60E91 /* PINDiskCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 70A29F94C3D7EC574411A698 /* PINDiskCache.h */; };
+		D12933ACCBA622692D91EC80 /* Pods-PINRemoteImage Tests-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 8ECB0F950577E472909F8CA2 /* Pods-PINRemoteImage Tests-dummy.m */; };
+		D1D58EDAF30BA9075EA9B332 /* PINDataTaskOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = AEA8EBA769657A40B841BFE5 /* PINDataTaskOperation.m */; };
+		DA0B41B0F7D59A7693E6F290 /* vp8li.h in Headers */ = {isa = PBXBuildFile; fileRef = 09602DE75A7F36878BAADD97 /* vp8li.h */; };
+		DA98678757C16FA051ADDE77 /* PINRemoteImageProcessorTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8D0CCC325790418BBABC259E /* PINRemoteImageProcessorTask.h */; };
+		DB9E5C57D3BF3088EC0D78B5 /* vp8l.c in Sources */ = {isa = PBXBuildFile; fileRef = 19B8D39ED8093F36DF9F382D /* vp8l.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		DD513B72568EC3ACCAFD4D23 /* picture_rescale.c in Sources */ = {isa = PBXBuildFile; fileRef = 2A68B633A9B63D05D54F7358 /* picture_rescale.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		DDE7286232CD71975B8D6A31 /* UIImageView+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = D589031A9F40C24BC3F91E2C /* UIImageView+PINRemoteImage.m */; };
+		DF146B610A0EC07A72F1634C /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A4CBCD20720278A05CA0C78 /* ImageIO.framework */; };
+		DF7F2F3253A99A8D2BE97E73 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		E07225ACF06EEC18220A1951 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3981A1DB34D746BA358AD6DF /* utils.h */; };
+		E37F2350F376B3689338A609 /* PINRemoteImageTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 2322476F62E9FE70B93A7FE4 /* PINRemoteImageTask.m */; };
+		E3B0C202AD4EDB1B78C25F3A /* PINRemoteImageProcessorTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 6ED575F1C4CD6FCE15444090 /* PINRemoteImageProcessorTask.m */; };
+		E6099205A1758D5D261D2159 /* frame.c in Sources */ = {isa = PBXBuildFile; fileRef = 0E5ADED30F4B5ECFBA3A2076 /* frame.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		E6CBA266FF64CACB89E6D084 /* Pods-PINRemoteImage-PINRemoteImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 51790811C2EEE503E2031E1D /* Pods-PINRemoteImage-PINRemoteImage-dummy.m */; };
+		E6FEF052E18CCCB6F1E7B9FD /* picture_tools.c in Sources */ = {isa = PBXBuildFile; fileRef = 1D62CC401B2276FAD3786167 /* picture_tools.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		E7FB8896DB8267925DE74239 /* PINRemoteImageTask.h in Headers */ = {isa = PBXBuildFile; fileRef = E460DEF575B8F9BFC53BF9B8 /* PINRemoteImageTask.h */; };
+		E8EBD27D0602DF32F300058D /* mux_types.h in Headers */ = {isa = PBXBuildFile; fileRef = C17930DB6FDF1427E200BA52 /* mux_types.h */; };
+		EA49D86AC8590CAD09094908 /* PINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 20922081B66F6E8488BBED5E /* PINCache.h */; };
+		EA711583816BBD350522D33F /* enc.c in Sources */ = {isa = PBXBuildFile; fileRef = ADF57DAB5977E73C90D1628B /* enc.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		EBD374552AAF9593CAB237F2 /* UIImage+WebP.m in Sources */ = {isa = PBXBuildFile; fileRef = 5268DA59BDABF99F1AD0944A /* UIImage+WebP.m */; };
+		EC700733C07B0DC23CF0DB42 /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1632451F317F81C5837DCBA3 /* MobileCoreServices.framework */; };
+		ED97598DCB5583CC12003275 /* PINRemoteImageManagerResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 850102C71DEEB6F3A7FC2952 /* PINRemoteImageManagerResult.h */; };
+		EE9C6CEE3D4EA6093D39C2FB /* thread.h in Headers */ = {isa = PBXBuildFile; fileRef = 21697AE0C2D3BD3331E18C7C /* thread.h */; };
+		F0C67C2A76BD7E9E99D3BA79 /* lossless.c in Sources */ = {isa = PBXBuildFile; fileRef = 27890A631E38C8E36DB85EBE /* lossless.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F16607BACDA2BC9800E5398F /* backward_references.c in Sources */ = {isa = PBXBuildFile; fileRef = 72FB8FF76B65337D08585714 /* backward_references.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F1AC3F7D7A76846C2ACDB15F /* UIImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = FB881F69DBA9F64C9FD4F986 /* UIImageView+PINRemoteImage.h */; };
+		F1BC71D3175D615B0FB8BE47 /* Pods-PINRemoteImage-libwebp-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F548010F5CB34AB5B8F95F36 /* Pods-PINRemoteImage-libwebp-dummy.m */; };
+		F2D3193EE3A321CB5C0CE19E /* PINCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 20922081B66F6E8488BBED5E /* PINCache.h */; };
+		F4524C0190785A5A78C03F06 /* yuv_mips32.c in Sources */ = {isa = PBXBuildFile; fileRef = CA246AF1170C21E027452AA1 /* yuv_mips32.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F55E2979D60FD4FADB78A0F1 /* PINProgressiveImage.m in Sources */ = {isa = PBXBuildFile; fileRef = BDFF42ED8EBE906CEE3C19D5 /* PINProgressiveImage.m */; };
+		F55E6B101CB9CEB25291F3AC /* token.c in Sources */ = {isa = PBXBuildFile; fileRef = F44130EC03CBF7485A3893D5 /* token.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F5A4CF9C039719E3A8F20F61 /* tree.c in Sources */ = {isa = PBXBuildFile; fileRef = B69567060D158C1F209886F5 /* tree.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F61EE4D207C7F926AADC5845 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4E9DF33F209E9DDA0E8645CB /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m */; };
+		F624CDA46624B431F3446050 /* quant.c in Sources */ = {isa = PBXBuildFile; fileRef = CBF83526B47596AF555F3568 /* quant.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F68999095CEA5AF0D090A4F6 /* webpenc.c in Sources */ = {isa = PBXBuildFile; fileRef = F0439236E5F84F76084E03DE /* webpenc.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		F7D4A49A55F04288B8BB4267 /* UIImage+WebP.h in Headers */ = {isa = PBXBuildFile; fileRef = 128080C5B8DAE97C307F48AA /* UIImage+WebP.h */; };
+		F9BCA97E9C7FE86C4178A058 /* rescaler.c in Sources */ = {isa = PBXBuildFile; fileRef = 1407EC64D8C7B5EEECE36E92 /* rescaler.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		FACEAF29E9A03EE64FDAC472 /* dec_sse2.c in Sources */ = {isa = PBXBuildFile; fileRef = 5C860D45E8FE4BF05BF3E511 /* dec_sse2.c */; settings = {COMPILER_FLAGS = "-D_THREAD_SAFE -fno-objc-arc"; }; };
+		FAE53B5BA4810E35FFA40C76 /* format_constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A37BD8B210E04F1107DF9D /* format_constants.h */; };
+		FE4FA9A2E8248F24BBD05AB0 /* decode_vp8.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D0F3B0D1C60C69878B2E614 /* decode_vp8.h */; };
+		FF4052E6307251AB65BA643E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
+		FFAD1D96A346615C01F27092 /* PINURLSessionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = D4E03FC9CE520645EAC61E08 /* PINURLSessionManager.m */; };
+		FFDA1ABBB20FCD3C2A160DB7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7DDD4A665ABFB6E734094C9 /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		19118B7BC1BAD5D3E168EC52 /* PBXContainerItemProxy */ = {
+		0685A433F67D1AE4514B6806 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = E6C155F0A4EA8DC094A3DF98;
-			remoteInfo = "Pods-PINRemoteImage-PINRemoteImage";
-		};
-		270FAF9B3CE8E11B858FA530 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 822D6AA9F3EEB56D9A1868C7;
-			remoteInfo = "Pods-PINRemoteImage Tests-FLAnimatedImage";
-		};
-		4DB640D8733D5197E4A1D5EE /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 3091AE0AB69637A0D4873AB2;
-			remoteInfo = "Pods-PINRemoteImage-FLAnimatedImage";
-		};
-		597D5B479FB32FF01887A250 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F87A88BDC23AD1F92436E1A8;
-			remoteInfo = "Pods-PINRemoteImage-PINCache";
-		};
-		6936FAE5E07F4A3F56207603 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F87A88BDC23AD1F92436E1A8;
-			remoteInfo = "Pods-PINRemoteImage-PINCache";
-		};
-		99B5DAA78C94EE4EE1070E01 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9C0680BEE34556A8023EB5DB;
-			remoteInfo = "Pods-PINRemoteImage Tests-PINRemoteImage";
-		};
-		9E014BEDD222D1050FBC30AB /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = F5893B7048FAF770D6678D64;
-			remoteInfo = "Pods-PINRemoteImage Tests-PINCache";
-		};
-		C53F9EA083D887EAC0C675FA /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = FD5C94A81700C30D9BE32245;
+			remoteGlobalIDString = 2C24A84F297BD8FD6532997F;
 			remoteInfo = "Pods-PINRemoteImage-libwebp";
 		};
-		DDE224E51AC17F3B477DB629 /* PBXContainerItemProxy */ = {
+		0DFC3DE7B49DAB2BDFED6C79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3091AE0AB69637A0D4873AB2;
+			remoteGlobalIDString = F5BD80853C6CC61691FF8C4E;
+			remoteInfo = "Pods-PINRemoteImage-PINCache";
+		};
+		1F8F5CA0C515A349A769B21F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9D5D69DDEABF36FE56E607B6;
+			remoteInfo = "Pods-PINRemoteImage Tests-PINRemoteImage";
+		};
+		3BB02AE8F3956A822DA2A57F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ADE1074A6F3EBF9B00A11E22;
 			remoteInfo = "Pods-PINRemoteImage-FLAnimatedImage";
 		};
-		FDBABB577A085676825DF2EF /* PBXContainerItemProxy */ = {
+		712249F35521B3EF4E35AD74 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 822D6AA9F3EEB56D9A1868C7;
+			remoteGlobalIDString = C82F0D26AC43E8178B238108;
 			remoteInfo = "Pods-PINRemoteImage Tests-FLAnimatedImage";
 		};
-		FE49B4B3F8E7E2177552F4CB /* PBXContainerItemProxy */ = {
+		86F607CC32C813741ABA5CB8 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 96ACB2D0C4443E8617339972 /* Project object */;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = F5893B7048FAF770D6678D64;
+			remoteGlobalIDString = 940E8008C17E41E278D7FE97;
 			remoteInfo = "Pods-PINRemoteImage Tests-PINCache";
+		};
+		CB8BEE33FDD53A709779FD4C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0739948874D2178089A48DAB;
+			remoteInfo = "Pods-PINRemoteImage-PINRemoteImage";
+		};
+		CBFADFDC029524D8D76D885D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C82F0D26AC43E8178B238108;
+			remoteInfo = "Pods-PINRemoteImage Tests-FLAnimatedImage";
+		};
+		D1552148CBD05F2B3BD59700 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 940E8008C17E41E278D7FE97;
+			remoteInfo = "Pods-PINRemoteImage Tests-PINCache";
+		};
+		EB0652CEA74598B03A444E54 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F5BD80853C6CC61691FF8C4E;
+			remoteInfo = "Pods-PINRemoteImage-PINCache";
+		};
+		ED27D78494A259DA9052E722 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A3672C3787DE3FDF78D98167 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = ADE1074A6F3EBF9B00A11E22;
+			remoteInfo = "Pods-PINRemoteImage-FLAnimatedImage";
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		018FA8B5BC6377615A5FD0BC /* analysis.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = analysis.c; path = src/enc/analysis.c; sourceTree = "<group>"; };
-		020E9CCFD42B5BE529C5AB36 /* vp8enci.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8enci.h; path = src/enc/vp8enci.h; sourceTree = "<group>"; };
-		03DDB62B993FD5786D674298 /* decode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = decode.h; path = src/webp/decode.h; sourceTree = "<group>"; };
-		03E781702445143853DE9F1E /* enc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc.c; path = src/dsp/enc.c; sourceTree = "<group>"; };
-		04AE64E18B08566BA7299D6C /* alpha.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha.c; path = src/enc/alpha.c; sourceTree = "<group>"; };
-		04F5C5C2992F9E133C44716F /* Pods-PINRemoteImage Tests-PINCache-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-PINCache-dummy.m"; sourceTree = "<group>"; };
-		0848E937F532D50A98429553 /* encode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = encode.h; path = src/webp/encode.h; sourceTree = "<group>"; };
-		08824028B560E91F8052A59F /* utils.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = utils.c; path = src/utils/utils.c; sourceTree = "<group>"; };
-		0A9C5EF34D159CF774C6C837 /* Pods-PINRemoteImage-FLAnimatedImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-PINRemoteImage-FLAnimatedImage-prefix.pch"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-prefix.pch"; sourceTree = "<group>"; };
-		0B8D02298330B527A6514B03 /* libPods-PINRemoteImage Tests-FLAnimatedImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests-FLAnimatedImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		0C59AFEDC7708E422C40C308 /* dec_clip_tables.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_clip_tables.c; path = src/dsp/dec_clip_tables.c; sourceTree = "<group>"; };
-		0DF089FD37A6C428D2BE6103 /* UIImageView+PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImageView+PINRemoteImage.h"; sourceTree = "<group>"; };
-		0E5112E3F64D019481017388 /* histogram.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = histogram.c; path = src/enc/histogram.c; sourceTree = "<group>"; };
-		0F74BC9058274E76220B55AD /* huffman_encode.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = huffman_encode.c; path = src/utils/huffman_encode.c; sourceTree = "<group>"; };
-		1010DE4B40B56944F11337A5 /* Pods-PINRemoteImage-PINRemoteImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-PINRemoteImage-PINRemoteImage-prefix.pch"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-prefix.pch"; sourceTree = "<group>"; };
-		119A4B22020382EBCE5A5360 /* mux.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mux.h; path = src/webp/mux.h; sourceTree = "<group>"; };
-		1411ED0557A87A5DB30002D6 /* PINRemoteImageProcessorTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageProcessorTask.h; sourceTree = "<group>"; };
-		15CA334D42BBF9C400E5060F /* PINRemoteImageDownloadTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageDownloadTask.h; sourceTree = "<group>"; };
-		1707FEF548099A39B521E414 /* neon.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = neon.h; path = src/dsp/neon.h; sourceTree = "<group>"; };
-		17F827E32C8D00DCF280EA65 /* picture_psnr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_psnr.c; path = src/enc/picture_psnr.c; sourceTree = "<group>"; };
-		184233F9F26C7BCC6EA083CD /* tree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tree.c; path = src/enc/tree.c; sourceTree = "<group>"; };
-		18B6A3115CEB5BC85ACABA43 /* yuv_tables_sse2.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yuv_tables_sse2.h; path = src/dsp/yuv_tables_sse2.h; sourceTree = "<group>"; };
-		18F4BA910200CFFFE21F8243 /* PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImage.h; sourceTree = "<group>"; };
-		19F749861852615E04CD2119 /* token.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = token.c; path = src/enc/token.c; sourceTree = "<group>"; };
-		1AEBCB8495D272312B6F79A2 /* muxedit.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = muxedit.c; path = src/mux/muxedit.c; sourceTree = "<group>"; };
-		1B4938CFE6128496CCA09AAE /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig"; sourceTree = "<group>"; };
-		1C5C982457EF61D029DB3BE8 /* Pods-PINRemoteImage Tests-FLAnimatedImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-FLAnimatedImage.xcconfig"; sourceTree = "<group>"; };
-		1C924F20DEF8A1EC8D661176 /* bit_reader.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bit_reader.c; path = src/utils/bit_reader.c; sourceTree = "<group>"; };
-		1E12298E3A9B94FB34DD582F /* huffman.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = huffman.h; path = src/utils/huffman.h; sourceTree = "<group>"; };
-		1EACD96D29F76543863D3569 /* libPods-PINRemoteImage-FLAnimatedImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-FLAnimatedImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		200458B913EBE688641585E6 /* Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch"; sourceTree = "<group>"; };
-		2106867C7D4FC0B39EB23833 /* UIButton+PINRemoteImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIButton+PINRemoteImage.m"; sourceTree = "<group>"; };
-		213BE7CA6607FA9AEE970348 /* cost.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cost.c; path = src/enc/cost.c; sourceTree = "<group>"; };
-		227D1B42D0C08BE81AEC079B /* yuv.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = yuv.c; path = src/dsp/yuv.c; sourceTree = "<group>"; };
-		23F0490B87B4E6252878FBEB /* FLAnimatedImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FLAnimatedImage.m; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m; sourceTree = "<group>"; };
-		24C6EA16777643D6C626154D /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-PINRemoteImage-FLAnimatedImage-dummy.m"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-dummy.m"; sourceTree = "<group>"; };
-		2503E7DC56549A7F5FCB3801 /* UIButton+PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIButton+PINRemoteImage.h"; sourceTree = "<group>"; };
-		26C2F935E2AC495D401540C9 /* config.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = config.c; path = src/enc/config.c; sourceTree = "<group>"; };
-		28D7D0A5B7D11970BDD94AEF /* PINProgressiveImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINProgressiveImage.h; sourceTree = "<group>"; };
-		291680B33C1A5ACB978C3084 /* tree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tree.c; path = src/dec/tree.c; sourceTree = "<group>"; };
-		2D2DA78D9E2F3326F53A1042 /* webpi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = webpi.h; path = src/dec/webpi.h; sourceTree = "<group>"; };
-		2DFC6394E19E6ADB6E1B259F /* decode_vp8.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = decode_vp8.h; path = src/dec/decode_vp8.h; sourceTree = "<group>"; };
-		2EC5505BE7AEAB2C00193557 /* PINMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINMemoryCache.h; path = PINCache/PINMemoryCache.h; sourceTree = "<group>"; };
-		2EEA4C04C3D3B4300C80329B /* FLAnimatedImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FLAnimatedImageView.m; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m; sourceTree = "<group>"; };
-		2F528C47A9C3F7EA24BDA087 /* libPods-PINRemoteImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		300B82EB41148F1B20C9882B /* random.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = random.h; path = src/utils/random.h; sourceTree = "<group>"; };
-		30ACEB879D47301F32AF62B7 /* Nullability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nullability.h; path = PINCache/Nullability.h; sourceTree = "<group>"; };
-		30F62A9719C9EF432B6E037D /* bit_writer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bit_writer.h; path = src/utils/bit_writer.h; sourceTree = "<group>"; };
-		3285143675C23ECB420F2903 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINCache-Private.xcconfig"; sourceTree = "<group>"; };
-		330EA627D53C757F18E55C48 /* Pods-PINRemoteImage-libwebp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage-libwebp-dummy.m"; sourceTree = "<group>"; };
-		33C8C9F82FFF8FFE3893195F /* PINURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINURLSessionManager.m; sourceTree = "<group>"; };
-		346173EF458AB3CC7954C971 /* demux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = demux.c; path = src/demux/demux.c; sourceTree = "<group>"; };
-		34FB4D5F529754FE0EED4259 /* UIImage+WebP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImage+WebP.h"; sourceTree = "<group>"; };
-		36D625A1C5722E002DF529B7 /* lossless_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless_sse2.c; path = src/dsp/lossless_sse2.c; sourceTree = "<group>"; };
-		374C287B05CB292AB10E0200 /* Pods-PINRemoteImage Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PINRemoteImage Tests-acknowledgements.plist"; sourceTree = "<group>"; };
-		38D01CF812A4A0CD416EDE45 /* enc_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_sse2.c; path = src/dsp/enc_sse2.c; sourceTree = "<group>"; };
-		3A07BC1E88ECB3A7A9754AD8 /* PINRemoteImageDownloadTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageDownloadTask.m; sourceTree = "<group>"; };
-		3A1A79E582688E787DA8E5E8 /* endian_inl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = endian_inl.h; path = src/utils/endian_inl.h; sourceTree = "<group>"; };
-		3C9D37AAD05886CCB8209DC8 /* utils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = utils.h; path = src/utils/utils.h; sourceTree = "<group>"; };
-		3DC294E892A7361403ED88E0 /* buffer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = buffer.c; path = src/dec/buffer.c; sourceTree = "<group>"; };
-		3E177572CA15AC09235B9CC3 /* Pods-PINRemoteImage-PINCache-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-PINRemoteImage-PINCache-dummy.m"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-dummy.m"; sourceTree = "<group>"; };
-		3E92039A90C94272C2A02B76 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/ImageIO.framework; sourceTree = DEVELOPER_DIR; };
-		3F6EF3E8BFFE91E6DBE1FCF9 /* Pods-PINRemoteImage Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests.release.xcconfig"; sourceTree = "<group>"; };
-		4154A2D9D14B75CC098E5348 /* dsp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = dsp.h; path = src/dsp/dsp.h; sourceTree = "<group>"; };
-		4229FF266ED020C34ADE3FF4 /* libPods-PINRemoteImage-PINRemoteImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-PINRemoteImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4421D7C6260A68BAA7A591AD /* PINCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PINCache.m; path = PINCache/PINCache.m; sourceTree = "<group>"; };
-		460EE0E2DB475B09746A6B99 /* backward_references.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = backward_references.h; path = src/enc/backward_references.h; sourceTree = "<group>"; };
-		46C17FAB98D60BA7B4144046 /* dec_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_sse2.c; path = src/dsp/dec_sse2.c; sourceTree = "<group>"; };
-		475D1E03B71A8A388B890757 /* bit_reader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bit_reader.h; path = src/utils/bit_reader.h; sourceTree = "<group>"; };
-		4905DDAE71A14D8336691112 /* lossless.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless.c; path = src/dsp/lossless.c; sourceTree = "<group>"; };
-		4A145FA49DADFFF932CDC5D8 /* libPods-PINRemoteImage Tests-PINRemoteImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests-PINRemoteImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		4B1DCA626F9F48C92F3DE418 /* filters.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = filters.c; path = src/utils/filters.c; sourceTree = "<group>"; };
-		4DF809949EDDEFD1C5DCC4EF /* quant.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant.c; path = src/dec/quant.c; sourceTree = "<group>"; };
-		4F5A7A8B06DB59D227A30337 /* dec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec.c; path = src/dsp/dec.c; sourceTree = "<group>"; };
-		518940E1EAB1CF8C819D29A6 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINCache-Private.xcconfig"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-Private.xcconfig"; sourceTree = "<group>"; };
-		528709200F12486986039B5B /* vp8.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vp8.c; path = src/dec/vp8.c; sourceTree = "<group>"; };
-		5375BF29A50FE83DD5D40CB4 /* dec_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_mips32.c; path = src/dsp/dec_mips32.c; sourceTree = "<group>"; };
-		552E2501DEA1D5FF4D546641 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
-		56D4238DC06664AE9784A9B4 /* Pods-PINRemoteImage-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PINRemoteImage-acknowledgements.markdown"; sourceTree = "<group>"; };
-		58CDA5997CD4B853F48AAC21 /* PINRemoteImageTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageTask.m; sourceTree = "<group>"; };
-		5A8EBA7E7FBC35B9A8A30394 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
-		5AB7D7B18F8FBFCDB96DEEEE /* alphai.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = alphai.h; path = src/dec/alphai.h; sourceTree = "<group>"; };
-		5B25276ADCAF13177E8879D7 /* Pods-PINRemoteImage Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests.debug.xcconfig"; sourceTree = "<group>"; };
-		5BF3B35E85B47A9786C12825 /* PINDataTaskOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINDataTaskOperation.h; sourceTree = "<group>"; };
-		5EA8E94BD7BAD9DE33E88FA2 /* upsampling_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = upsampling_neon.c; path = src/dsp/upsampling_neon.c; sourceTree = "<group>"; };
-		607B72386DFA740FF29A3D0E /* picture_csp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_csp.c; path = src/enc/picture_csp.c; sourceTree = "<group>"; };
-		614D2BAEC7D74F01CEF237DC /* Pods-PINRemoteImage Tests-PINCache.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINCache.xcconfig"; sourceTree = "<group>"; };
-		6157B1E2C571146A4BEE0AAC /* UIImage+DecodedImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIImage+DecodedImage.m"; sourceTree = "<group>"; };
-		6163A230B1990890702EA953 /* color_cache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = color_cache.h; path = src/utils/color_cache.h; sourceTree = "<group>"; };
-		62A29D0D154A41D24E174461 /* iterator.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = iterator.c; path = src/enc/iterator.c; sourceTree = "<group>"; };
-		6316705DB74586A8BFD65542 /* types.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = types.h; path = src/webp/types.h; sourceTree = "<group>"; };
-		6637574CFFC3A8608AFDC57B /* quant.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant.c; path = src/enc/quant.c; sourceTree = "<group>"; };
-		668813EB85E7836278E80DA0 /* thread.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = thread.c; path = src/utils/thread.c; sourceTree = "<group>"; };
-		69C2E5F2777D66B8795CC895 /* upsampling.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = upsampling.c; path = src/dsp/upsampling.c; sourceTree = "<group>"; };
-		6A473B0A3E09DDD102E55D0D /* bit_writer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bit_writer.c; path = src/utils/bit_writer.c; sourceTree = "<group>"; };
-		6CAACF882F1B9A78A6D72DE4 /* picture_rescale.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_rescale.c; path = src/enc/picture_rescale.c; sourceTree = "<group>"; };
-		6FAD3D1B72E92CCF17E8FD33 /* Pods-PINRemoteImage-PINRemoteImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-PINRemoteImage-PINRemoteImage-dummy.m"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-dummy.m"; sourceTree = "<group>"; };
-		70951C2B6487A163A5B0A3B4 /* UIImageView+PINRemoteImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+PINRemoteImage.m"; sourceTree = "<group>"; };
-		715BAE5F642853A4D2DDCB8D /* yuv_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = yuv_sse2.c; path = src/dsp/yuv_sse2.c; sourceTree = "<group>"; };
-		731F9F85DFDF7A4FF72C64FE /* huffman_encode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = huffman_encode.h; path = src/utils/huffman_encode.h; sourceTree = "<group>"; };
-		739A945AD4203B330E3ADC71 /* histogram.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = histogram.h; path = src/enc/histogram.h; sourceTree = "<group>"; };
-		750F9D26ECC12BD617C0C1BC /* FLAnimatedImageView+PINRemoteImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FLAnimatedImageView+PINRemoteImage.m"; sourceTree = "<group>"; };
-		76523450AB74E105E5672A90 /* webp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = webp.c; path = src/dec/webp.c; sourceTree = "<group>"; };
-		770CCC566BE67C32F422BF3A /* PINProgressiveImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINProgressiveImage.m; sourceTree = "<group>"; };
-		783DF441A2A951109941CDE6 /* enc_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_neon.c; path = src/dsp/enc_neon.c; sourceTree = "<group>"; };
-		78F1B339E533B9277943516F /* lossless_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless_neon.c; path = src/dsp/lossless_neon.c; sourceTree = "<group>"; };
-		793271E516D880963B2C8646 /* vp8l.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vp8l.c; path = src/dec/vp8l.c; sourceTree = "<group>"; };
-		79385154730CC54AC0179B27 /* Pods-PINRemoteImage-libwebp-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage-libwebp-prefix.pch"; sourceTree = "<group>"; };
-		79A0AD133AA88607F24D0F9C /* libPods-PINRemoteImage-PINCache.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-PINCache.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		79B7B5C3B3E806FF5E198A55 /* enc_avx2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_avx2.c; path = src/dsp/enc_avx2.c; sourceTree = "<group>"; };
-		7CDACEDED47F9E871576FDD5 /* yuv_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = yuv_mips32.c; path = src/dsp/yuv_mips32.c; sourceTree = "<group>"; };
-		7EF29D0AA847A39F6EA22781 /* FLAnimatedImageView+PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FLAnimatedImageView+PINRemoteImage.h"; sourceTree = "<group>"; };
-		7FB080497D6B2101FD22E882 /* PINRemoteImageCategoryManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageCategoryManager.m; sourceTree = "<group>"; };
-		809A42A4B7712F406A37B27F /* idec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = idec.c; path = src/dec/idec.c; sourceTree = "<group>"; };
-		8241AA46CE5E88509ABCC479 /* Pods-PINRemoteImage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage.debug.xcconfig"; sourceTree = "<group>"; };
-		82D0DF8AD08D326734224970 /* PINDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PINDiskCache.m; path = PINCache/PINDiskCache.m; sourceTree = "<group>"; };
-		82EE46510AD5F6B25870AA61 /* Pods-PINRemoteImage-FLAnimatedImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-FLAnimatedImage.xcconfig"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage.xcconfig"; sourceTree = "<group>"; };
-		84D3613B0081663D339FEB2B /* picture.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture.c; path = src/enc/picture.c; sourceTree = "<group>"; };
-		877050E43BA77C4B9CF4D73F /* cpu.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cpu.c; path = src/dsp/cpu.c; sourceTree = "<group>"; };
-		8836086BE0571D96DC238C49 /* libPods-PINRemoteImage Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		8839C73E910D9D4E92346929 /* bit_reader_inl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bit_reader_inl.h; path = src/utils/bit_reader_inl.h; sourceTree = "<group>"; };
-		88FF0BCA882181B2621D583C /* libPods-PINRemoteImage-libwebp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-libwebp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		895614D466331488DAD056BF /* lossless.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lossless.h; path = src/dsp/lossless.h; sourceTree = "<group>"; };
-		8ABE519B49C5229F197AA87F /* Pods-PINRemoteImage-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-PINRemoteImage-resources.sh"; sourceTree = "<group>"; };
-		8B8507BB0956AC4C0A042052 /* lossless_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless_mips32.c; path = src/dsp/lossless_mips32.c; sourceTree = "<group>"; };
-		8BFC45008AE493FAE4B094E4 /* rescaler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = rescaler.h; path = src/utils/rescaler.h; sourceTree = "<group>"; };
-		8C918AA802ABFAC8226860B6 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
-		8E3C1D49DE4368799CAEAAD0 /* Pods-PINRemoteImage Tests-PINRemoteImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINRemoteImage.xcconfig"; sourceTree = "<group>"; };
-		8FECF902E84AC3C2FCF0002D /* vp8li.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8li.h; path = src/dec/vp8li.h; sourceTree = "<group>"; };
-		900BFB3DBA86DD1F71A10A32 /* PINRemoteImageManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageManager.m; sourceTree = "<group>"; };
-		91514A996BB2EB5AD45AB033 /* PINRemoteImageProcessorTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageProcessorTask.m; sourceTree = "<group>"; };
-		92D46CA965D94804A6D2CAB4 /* webpenc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = webpenc.c; path = src/enc/webpenc.c; sourceTree = "<group>"; };
-		93AED93CB944AA28A3F1E957 /* Pods-PINRemoteImage-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PINRemoteImage-acknowledgements.plist"; sourceTree = "<group>"; };
-		96F24A2B6A1531C4005FC59E /* cost.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cost.h; path = src/enc/cost.h; sourceTree = "<group>"; };
-		98D6448ACE91F603138DCD99 /* vp8i.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8i.h; path = src/dec/vp8i.h; sourceTree = "<group>"; };
-		9DAD1717E22854E0A976F7A7 /* NSData+ImageDetectors.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSData+ImageDetectors.h"; sourceTree = "<group>"; };
-		9E2E138C150A2E033F7EA7F0 /* io.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = io.c; path = src/dec/io.c; sourceTree = "<group>"; };
-		9EC6EB5D912F8635EE261A96 /* Pods-PINRemoteImage Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-dummy.m"; sourceTree = "<group>"; };
-		9F24BC8343FE6CF0CEB0FB27 /* alpha_processing.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha_processing.c; path = src/dsp/alpha_processing.c; sourceTree = "<group>"; };
-		A630F2BD1F71D2770EDE64F1 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
-		A6CB42687C3924CA507FEB29 /* muxi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = muxi.h; path = src/mux/muxi.h; sourceTree = "<group>"; };
-		A8224771F2044567D187303A /* yuv.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yuv.h; path = src/dsp/yuv.h; sourceTree = "<group>"; };
-		A92D9362BBE2CC7A086BC6E9 /* PINRemoteImageCategoryManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageCategoryManager.h; sourceTree = "<group>"; };
-		AECE0F69954120DEF87DEF8F /* picture_tools.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_tools.c; path = src/enc/picture_tools.c; sourceTree = "<group>"; };
-		AEED084654AADAC9A365195A /* vp8l.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vp8l.c; path = src/enc/vp8l.c; sourceTree = "<group>"; };
-		AF597D47CB4B1E04C0C842AE /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreImage.framework; sourceTree = DEVELOPER_DIR; };
-		B13E2D603C55C02E09088BBC /* Pods-PINRemoteImage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage.release.xcconfig"; sourceTree = "<group>"; };
-		B26FDA93F54C889F5358DC4A /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m"; sourceTree = "<group>"; };
-		B56023D6F33AB318A2C726DE /* huffman.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = huffman.c; path = src/utils/huffman.c; sourceTree = "<group>"; };
-		B667E47AE90ADBB16875418E /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig"; sourceTree = "<group>"; };
-		B6A4A735A0502CC63C844C21 /* Pods-PINRemoteImage-PINCache-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-PINRemoteImage-PINCache-prefix.pch"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-prefix.pch"; sourceTree = "<group>"; };
-		BA0C344DEDA0F9DB769B8DC6 /* PINCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINCache.h; path = PINCache/PINCache.h; sourceTree = "<group>"; };
-		BA20EC564FE2895DBFBC18CC /* demux.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = demux.h; path = src/webp/demux.h; sourceTree = "<group>"; };
-		BA42CB9CB959CA72FE6A64F3 /* filters.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = filters.h; path = src/utils/filters.h; sourceTree = "<group>"; };
-		BAA3EB52BB5057B2FA36F643 /* Pods-PINRemoteImage Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PINRemoteImage Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
-		BD5D7CB93AA5767183969903 /* UIImage+WebP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIImage+WebP.m"; sourceTree = "<group>"; };
-		C002129DC8236BA0B2372424 /* PINMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PINMemoryCache.m; path = PINCache/PINMemoryCache.m; sourceTree = "<group>"; };
-		C01D6989F22F7BBB231E55C2 /* format_constants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = format_constants.h; path = src/webp/format_constants.h; sourceTree = "<group>"; };
-		C0978BC16828F75398D69C77 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m"; sourceTree = "<group>"; };
-		C15828D41EBF2FFBE09B5371 /* Pods-PINRemoteImage Tests-PINCache-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-PINCache-prefix.pch"; sourceTree = "<group>"; };
-		C2F9F8DF4033F87254BFE90D /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig"; sourceTree = "<group>"; };
-		C342AC4D0FD7748DBBB4EFB9 /* random.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = random.c; path = src/utils/random.c; sourceTree = "<group>"; };
-		C4123DE345C3893977C60A91 /* quant_levels_dec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant_levels_dec.c; path = src/utils/quant_levels_dec.c; sourceTree = "<group>"; };
-		C4485503ABDD09722DF3F543 /* quant_levels.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant_levels.c; path = src/utils/quant_levels.c; sourceTree = "<group>"; };
-		C62679E18F42525E931B17A1 /* Pods-PINRemoteImage-PINCache.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINCache.xcconfig"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache.xcconfig"; sourceTree = "<group>"; };
-		C6A268B8577C379C5B68409A /* muxinternal.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = muxinternal.c; path = src/mux/muxinternal.c; sourceTree = "<group>"; };
-		C8A5A9E6094F3487C55DFFBD /* Pods-PINRemoteImage Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-PINRemoteImage Tests-resources.sh"; sourceTree = "<group>"; };
-		C8CF2A64072E77BECF8EB922 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
-		CA56F921D428CB0F8C3CAD59 /* alpha_processing_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha_processing_sse2.c; path = src/dsp/alpha_processing_sse2.c; sourceTree = "<group>"; };
-		CC098641AD165A2604B4C561 /* PINRemoteImageTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageTask.h; sourceTree = "<group>"; };
-		CCBD8A8DA3A62E37ED1EAE61 /* syntax.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = syntax.c; path = src/enc/syntax.c; sourceTree = "<group>"; };
-		CDB47F1E1BEE88EC5F15D7F5 /* enc_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_mips32.c; path = src/dsp/enc_mips32.c; sourceTree = "<group>"; };
-		D29950B5A263A0F2A663EC9A /* PINRemoteImageCallbacks.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageCallbacks.h; sourceTree = "<group>"; };
-		D33C1A5B01870B4800B5235C /* libPods-PINRemoteImage Tests-PINCache.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests-PINCache.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		D402E4D0C8870B22B4CB4251 /* dec_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_neon.c; path = src/dsp/dec_neon.c; sourceTree = "<group>"; };
-		D46DEB83F9C07E0B042FD274 /* Pods-PINRemoteImage-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage-environment.h"; sourceTree = "<group>"; };
-		D5034A475CE1A83DBD5A266D /* FLAnimatedImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FLAnimatedImage.h; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h; sourceTree = "<group>"; };
-		D840FD9797CCDA096D1278AA /* PINRemoteImageManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageManager.h; sourceTree = "<group>"; };
-		D93FCE87CE01F32875005BEC /* thread.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = thread.h; path = src/utils/thread.h; sourceTree = "<group>"; };
-		D9B2D11922EF674312C603D6 /* Pods-PINRemoteImage Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-environment.h"; sourceTree = "<group>"; };
-		DA5BF7E6A2F099A7394B5B83 /* PINRemoteImageManagerResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageManagerResult.m; sourceTree = "<group>"; };
-		DA92D6C17316B55CF5905942 /* backward_references.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = backward_references.c; path = src/enc/backward_references.c; sourceTree = "<group>"; };
-		DE35B24C590D2183E148D03C /* PINURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINURLSessionManager.h; sourceTree = "<group>"; };
-		DE9188458BBD5EDBE7116F1A /* filter.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = filter.c; path = src/enc/filter.c; sourceTree = "<group>"; };
-		DFBD9176C89D30344D2B806F /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
-		DFC3CD908E9C2EE4B301B432 /* upsampling_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = upsampling_sse2.c; path = src/dsp/upsampling_sse2.c; sourceTree = "<group>"; };
-		E0C501993B3ECC8147FE9E10 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage-libwebp-Private.xcconfig"; sourceTree = "<group>"; };
-		E614AEE4EAF4BEB91D514A8D /* NSData+ImageDetectors.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSData+ImageDetectors.m"; sourceTree = "<group>"; };
-		E8165FCF32E8CF65F30108C5 /* PINDataTaskOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINDataTaskOperation.m; sourceTree = "<group>"; };
-		E902F4F9D0DB309C93FA57B4 /* muxread.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = muxread.c; path = src/mux/muxread.c; sourceTree = "<group>"; };
-		E9F091AD0EF9EC3CCD15CB7F /* rescaler.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rescaler.c; path = src/utils/rescaler.c; sourceTree = "<group>"; };
-		EAFBBDBB1B69F77478524F03 /* quant_levels_dec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = quant_levels_dec.h; path = src/utils/quant_levels_dec.h; sourceTree = "<group>"; };
-		EB058DE67218FE36A48A45E8 /* color_cache.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = color_cache.c; path = src/utils/color_cache.c; sourceTree = "<group>"; };
-		EB7639592B4A22DFD17D33BA /* Pods-PINRemoteImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage-dummy.m"; sourceTree = "<group>"; };
-		EC221F41DB75CBE8333E26C6 /* Pods-PINRemoteImage-libwebp.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage-libwebp.xcconfig"; sourceTree = "<group>"; };
-		ED048724AABCA3AE496D39FA /* frame.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = frame.c; path = src/dec/frame.c; sourceTree = "<group>"; };
-		EDEC353FB8A8155C91681269 /* Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch"; sourceTree = "<group>"; };
-		F1A09D9946BF95D39936F81A /* PINRemoteImageCallbacks.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageCallbacks.m; sourceTree = "<group>"; };
-		F274C0F4ECBAA2C7F6999BAB /* frame.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = frame.c; path = src/enc/frame.c; sourceTree = "<group>"; };
-		F2A7F6385B5C12F6E745363F /* FLAnimatedImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FLAnimatedImageView.h; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.h; sourceTree = "<group>"; };
-		F8222347FFCA6E4E0086D3E7 /* PINDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINDiskCache.h; path = PINCache/PINDiskCache.h; sourceTree = "<group>"; };
-		F8922D4AD691C9578CAC76AE /* UIImage+DecodedImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImage+DecodedImage.h"; sourceTree = "<group>"; };
-		F937251E72F8D803DF740FD1 /* quant_levels.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = quant_levels.h; path = src/utils/quant_levels.h; sourceTree = "<group>"; };
-		FA5DAF75968DABCF7713A109 /* PINRemoteImageManagerResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageManagerResult.h; sourceTree = "<group>"; };
-		FAA3D1842FEE008C3C15D04A /* Pods-PINRemoteImage-PINRemoteImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINRemoteImage.xcconfig"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage.xcconfig"; sourceTree = "<group>"; };
-		FC4FFBA1FEF5D4C4143ACC54 /* mux_types.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mux_types.h; path = src/webp/mux_types.h; sourceTree = "<group>"; };
-		FCB69CB08EB887067B347EED /* vp8li.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8li.h; path = src/enc/vp8li.h; sourceTree = "<group>"; };
-		FDC25C6EEC0F714AB6FF163F /* alpha.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha.c; path = src/dec/alpha.c; sourceTree = "<group>"; };
-		FF61C3873B4B3A2C9EFDBE21 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig"; sourceTree = "<group>"; };
+		002E645F13D022F93A6F4741 /* PINDiskCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PINDiskCache.m; path = PINCache/PINDiskCache.m; sourceTree = "<group>"; };
+		00442EC78AA26C4CFE848CC9 /* Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch"; sourceTree = "<group>"; };
+		02331317D3899B0E6DD8320D /* UIButton+PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIButton+PINRemoteImage.h"; sourceTree = "<group>"; };
+		0501ADF0577B48BF70AA9AB8 /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig"; sourceTree = "<group>"; };
+		07C35A427B16AD45795C6335 /* analysis.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = analysis.c; path = src/enc/analysis.c; sourceTree = "<group>"; };
+		087F18EDDE14738AFA0DDE34 /* quant_levels_dec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = quant_levels_dec.h; path = src/utils/quant_levels_dec.h; sourceTree = "<group>"; };
+		09602DE75A7F36878BAADD97 /* vp8li.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8li.h; path = src/enc/vp8li.h; sourceTree = "<group>"; };
+		0A2EC7121145E3C367671823 /* yuv.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yuv.h; path = src/dsp/yuv.h; sourceTree = "<group>"; };
+		0B7ABD9330244439263A3473 /* libPods-PINRemoteImage Tests-FLAnimatedImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests-FLAnimatedImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BFA2A814C50BED72995DFC5 /* muxi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = muxi.h; path = src/mux/muxi.h; sourceTree = "<group>"; };
+		0C6FDE0B01639746C4190D2C /* libPods-PINRemoteImage Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0D286EEF4E6D07BC5C0E67CE /* lossless_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless_neon.c; path = src/dsp/lossless_neon.c; sourceTree = "<group>"; };
+		0D45CF433191B090268D502A /* iterator.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = iterator.c; path = src/enc/iterator.c; sourceTree = "<group>"; };
+		0D616041EDA8195E90AA3B12 /* PINCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PINCache.m; path = PINCache/PINCache.m; sourceTree = "<group>"; };
+		0E5ADED30F4B5ECFBA3A2076 /* frame.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = frame.c; path = src/enc/frame.c; sourceTree = "<group>"; };
+		0EAD94C9C22F68324F90913C /* PINProgressiveImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINProgressiveImage.h; sourceTree = "<group>"; };
+		0F80CA4B5153F6B519765BB2 /* color_cache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = color_cache.h; path = src/utils/color_cache.h; sourceTree = "<group>"; };
+		128080C5B8DAE97C307F48AA /* UIImage+WebP.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImage+WebP.h"; sourceTree = "<group>"; };
+		1407EC64D8C7B5EEECE36E92 /* rescaler.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = rescaler.c; path = src/utils/rescaler.c; sourceTree = "<group>"; };
+		144925D10E355A3E8BE1A241 /* yuv_tables_sse2.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = yuv_tables_sse2.h; path = src/dsp/yuv_tables_sse2.h; sourceTree = "<group>"; };
+		15E7C95802E6DE69BEE8E5AD /* syntax.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = syntax.c; path = src/enc/syntax.c; sourceTree = "<group>"; };
+		1632451F317F81C5837DCBA3 /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/MobileCoreServices.framework; sourceTree = DEVELOPER_DIR; };
+		16BFCE71127012C5092825D3 /* alpha.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha.c; path = src/dec/alpha.c; sourceTree = "<group>"; };
+		1926CAD4D9B3CBD0A16EEFB0 /* Pods-PINRemoteImage-FLAnimatedImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-PINRemoteImage-FLAnimatedImage-prefix.pch"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-prefix.pch"; sourceTree = "<group>"; };
+		19B8D39ED8093F36DF9F382D /* vp8l.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vp8l.c; path = src/dec/vp8l.c; sourceTree = "<group>"; };
+		1C5E54F58258FC163E9DB58D /* thread.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = thread.c; path = src/utils/thread.c; sourceTree = "<group>"; };
+		1D62CC401B2276FAD3786167 /* picture_tools.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_tools.c; path = src/enc/picture_tools.c; sourceTree = "<group>"; };
+		1DA341475E29949E9E1F1FD2 /* upsampling_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = upsampling_neon.c; path = src/dsp/upsampling_neon.c; sourceTree = "<group>"; };
+		1E036357C7BE69A4A8411CC8 /* decode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = decode.h; path = src/webp/decode.h; sourceTree = "<group>"; };
+		1E28CE552687BB01D8CE5625 /* Pods-PINRemoteImage-PINRemoteImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-PINRemoteImage-PINRemoteImage-prefix.pch"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-prefix.pch"; sourceTree = "<group>"; };
+		1F87CB2EF8EC4EA3200DF097 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINCache-Private.xcconfig"; sourceTree = "<group>"; };
+		1F99244BFB5A12D8FC97DD05 /* yuv.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = yuv.c; path = src/dsp/yuv.c; sourceTree = "<group>"; };
+		1FD581AECE86AD9191C4B153 /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig"; sourceTree = "<group>"; };
+		20922081B66F6E8488BBED5E /* PINCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINCache.h; path = PINCache/PINCache.h; sourceTree = "<group>"; };
+		214C502BB1A4BC420B333D5C /* alphai.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = alphai.h; path = src/dec/alphai.h; sourceTree = "<group>"; };
+		21697AE0C2D3BD3331E18C7C /* thread.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = thread.h; path = src/utils/thread.h; sourceTree = "<group>"; };
+		2322476F62E9FE70B93A7FE4 /* PINRemoteImageTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageTask.m; sourceTree = "<group>"; };
+		27660C96717E354C3A699167 /* Pods-PINRemoteImage-libwebp.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage-libwebp.xcconfig"; sourceTree = "<group>"; };
+		27890A631E38C8E36DB85EBE /* lossless.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless.c; path = src/dsp/lossless.c; sourceTree = "<group>"; };
+		289B4490633CB580D96ED8FE /* PINURLSessionManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINURLSessionManager.h; sourceTree = "<group>"; };
+		2904117440C98966700B86A8 /* PINRemoteImageManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageManager.m; sourceTree = "<group>"; };
+		2A68B633A9B63D05D54F7358 /* picture_rescale.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_rescale.c; path = src/enc/picture_rescale.c; sourceTree = "<group>"; };
+		2CB0A5712FDDBFC13AF90EAE /* PINRemoteImageCallbacks.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageCallbacks.h; sourceTree = "<group>"; };
+		2D7F5B80A8DCACEAAF77F899 /* config.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = config.c; path = src/enc/config.c; sourceTree = "<group>"; };
+		31F01E43660702EA2B7C74BE /* buffer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = buffer.c; path = src/dec/buffer.c; sourceTree = "<group>"; };
+		33AEF73E9E68A8B37765FFE7 /* NSData+ImageDetectors.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "NSData+ImageDetectors.m"; sourceTree = "<group>"; };
+		33E104AB4034A41A4255712F /* libPods-PINRemoteImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		3417B803A0BB3EF3FF1E53FA /* Pods-PINRemoteImage-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PINRemoteImage-acknowledgements.plist"; sourceTree = "<group>"; };
+		36D9D70985B2DBDD0E5AE903 /* alpha_processing.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha_processing.c; path = src/dsp/alpha_processing.c; sourceTree = "<group>"; };
+		3981A1DB34D746BA358AD6DF /* utils.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = utils.h; path = src/utils/utils.h; sourceTree = "<group>"; };
+		3A38D134C79DA4234655EAE2 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig"; sourceTree = "<group>"; };
+		3A427A2D8751ABE66D62D763 /* cost.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = cost.h; path = src/enc/cost.h; sourceTree = "<group>"; };
+		3BF09DF1C61D0B047C34C79B /* muxread.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = muxread.c; path = src/mux/muxread.c; sourceTree = "<group>"; };
+		3CABF8EC83146EB980B2682C /* bit_reader.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bit_reader.c; path = src/utils/bit_reader.c; sourceTree = "<group>"; };
+		3CAEBBDAFF40D717D2F7737B /* Pods-PINRemoteImage-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PINRemoteImage-acknowledgements.markdown"; sourceTree = "<group>"; };
+		3D62B62CDE89409F44639F82 /* Pods-PINRemoteImage-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage-environment.h"; sourceTree = "<group>"; };
+		3E680AE1CCDE78F1DCADC0E9 /* libPods-PINRemoteImage Tests-PINRemoteImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests-PINRemoteImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		440A712A234F860C66C1F6F7 /* Pods-PINRemoteImage Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests.debug.xcconfig"; sourceTree = "<group>"; };
+		44C213D9012C09902F626D8D /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/QuartzCore.framework; sourceTree = DEVELOPER_DIR; };
+		452ABBFF35FBCE2401926EE0 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m"; sourceTree = "<group>"; };
+		452AF2D9D8C6FA4DC879F251 /* Pods-PINRemoteImage-PINCache.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINCache.xcconfig"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache.xcconfig"; sourceTree = "<group>"; };
+		4583E5264A6F29FD1B54BF58 /* picture.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture.c; path = src/enc/picture.c; sourceTree = "<group>"; };
+		4A4CBCD20720278A05CA0C78 /* ImageIO.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ImageIO.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/ImageIO.framework; sourceTree = DEVELOPER_DIR; };
+		4CA4E371A1D3FC1E9FCD2C4A /* FLAnimatedImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FLAnimatedImage.m; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.m; sourceTree = "<group>"; };
+		4D04F2F9D359D731DFD9D5BB /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreImage.framework; sourceTree = DEVELOPER_DIR; };
+		4D52F0AA9E1BE0A1A5CD6D20 /* alpha.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha.c; path = src/enc/alpha.c; sourceTree = "<group>"; };
+		4D91327C87EB06EEFDC048AB /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/CoreGraphics.framework; sourceTree = DEVELOPER_DIR; };
+		4E9DF33F209E9DDA0E8645CB /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m"; sourceTree = "<group>"; };
+		51167217F5890A290529558F /* idec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = idec.c; path = src/dec/idec.c; sourceTree = "<group>"; };
+		51790811C2EEE503E2031E1D /* Pods-PINRemoteImage-PINRemoteImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-PINRemoteImage-PINRemoteImage-dummy.m"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-dummy.m"; sourceTree = "<group>"; };
+		517D7FE0A9689D78AB10B680 /* picture_psnr.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_psnr.c; path = src/enc/picture_psnr.c; sourceTree = "<group>"; };
+		51A93AF501FD138663F4431F /* io.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = io.c; path = src/dec/io.c; sourceTree = "<group>"; };
+		5268DA59BDABF99F1AD0944A /* UIImage+WebP.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIImage+WebP.m"; sourceTree = "<group>"; };
+		5400A05E3878D813E75EF8E7 /* Podfile */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		55A7198EEE01380E97EB3B91 /* lossless_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless_sse2.c; path = src/dsp/lossless_sse2.c; sourceTree = "<group>"; };
+		5C860D45E8FE4BF05BF3E511 /* dec_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_sse2.c; path = src/dsp/dec_sse2.c; sourceTree = "<group>"; };
+		5D0F3B0D1C60C69878B2E614 /* decode_vp8.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = decode_vp8.h; path = src/dec/decode_vp8.h; sourceTree = "<group>"; };
+		5DDB41864DCBD565EAE3BB86 /* huffman.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = huffman.h; path = src/utils/huffman.h; sourceTree = "<group>"; };
+		5E7BB51F9DACED26FD180CC8 /* mux.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mux.h; path = src/webp/mux.h; sourceTree = "<group>"; };
+		622677490FE95BF8855EEA3F /* picture_csp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = picture_csp.c; path = src/enc/picture_csp.c; sourceTree = "<group>"; };
+		62AD0673C84961F5598B388F /* FLAnimatedImageView.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FLAnimatedImageView.h; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.h; sourceTree = "<group>"; };
+		6340D3CAA7D6DAF3C71B35F2 /* libPods-PINRemoteImage-FLAnimatedImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-FLAnimatedImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		6474AA66BB8A5F68F4A1C58C /* PINMemoryCache.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = PINMemoryCache.m; path = PINCache/PINMemoryCache.m; sourceTree = "<group>"; };
+		64B1DE7C5BA3B54BDE19602D /* muxinternal.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = muxinternal.c; path = src/mux/muxinternal.c; sourceTree = "<group>"; };
+		669D3865F40A9F17B8FD48E0 /* Pods-PINRemoteImage Tests-PINRemoteImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINRemoteImage.xcconfig"; sourceTree = "<group>"; };
+		689E7A7FD0DBD72E2A442847 /* tree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tree.c; path = src/dec/tree.c; sourceTree = "<group>"; };
+		68F6EA37D82944A4D73413DB /* UIImage+DecodedImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIImage+DecodedImage.m"; sourceTree = "<group>"; };
+		6B666F75709BC40C9919CE52 /* vp8.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vp8.c; path = src/dec/vp8.c; sourceTree = "<group>"; };
+		6C07892512E3B23951EFA616 /* bit_writer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bit_writer.h; path = src/utils/bit_writer.h; sourceTree = "<group>"; };
+		6CD425DF49D7A58E10942A2C /* dsp.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = dsp.h; path = src/dsp/dsp.h; sourceTree = "<group>"; };
+		6D216038D4F2854B984836EC /* random.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = random.h; path = src/utils/random.h; sourceTree = "<group>"; };
+		6ED575F1C4CD6FCE15444090 /* PINRemoteImageProcessorTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageProcessorTask.m; sourceTree = "<group>"; };
+		703C6BD0871A9BF3BC4875B1 /* enc_avx2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_avx2.c; path = src/dsp/enc_avx2.c; sourceTree = "<group>"; };
+		7057648BB45CA7E897825284 /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig"; sourceTree = "<group>"; };
+		70A29F94C3D7EC574411A698 /* PINDiskCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINDiskCache.h; path = PINCache/PINDiskCache.h; sourceTree = "<group>"; };
+		70EB8DE515C61A5D8FC9E7A7 /* huffman_encode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = huffman_encode.h; path = src/utils/huffman_encode.h; sourceTree = "<group>"; };
+		714E51E3AE4DE85982C50E85 /* libPods-PINRemoteImage Tests-PINCache.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage Tests-PINCache.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		72FB8FF76B65337D08585714 /* backward_references.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = backward_references.c; path = src/enc/backward_references.c; sourceTree = "<group>"; };
+		730CD23B2028D171065EFBB1 /* Pods-PINRemoteImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage-dummy.m"; sourceTree = "<group>"; };
+		76A92B34446E65667CFB54E7 /* yuv_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = yuv_sse2.c; path = src/dsp/yuv_sse2.c; sourceTree = "<group>"; };
+		7A8F88E15EC0E4363C413E89 /* huffman.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = huffman.c; path = src/utils/huffman.c; sourceTree = "<group>"; };
+		7C5102A86DCDF791157E6EFF /* demux.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = demux.h; path = src/webp/demux.h; sourceTree = "<group>"; };
+		7DFFAA3048BA40173308AD34 /* filters.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = filters.c; path = src/utils/filters.c; sourceTree = "<group>"; };
+		7F747586855B2B08D80E8C65 /* enc_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_neon.c; path = src/dsp/enc_neon.c; sourceTree = "<group>"; };
+		80D2FDEA75A66CAAF4F92883 /* vp8enci.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8enci.h; path = src/enc/vp8enci.h; sourceTree = "<group>"; };
+		82A985679CA3614B0380C3FE /* quant_levels.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = quant_levels.h; path = src/utils/quant_levels.h; sourceTree = "<group>"; };
+		84D938F086044D0CD475B145 /* Pods-PINRemoteImage-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-PINRemoteImage-resources.sh"; sourceTree = "<group>"; };
+		850102C71DEEB6F3A7FC2952 /* PINRemoteImageManagerResult.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageManagerResult.h; sourceTree = "<group>"; };
+		88196ECF9F8595430B476F75 /* Pods-PINRemoteImage-PINCache-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "Pods-PINRemoteImage-PINCache-prefix.pch"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-prefix.pch"; sourceTree = "<group>"; };
+		881B11A1811D862A5B0EAB6A /* Pods-PINRemoteImage Tests-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-PINRemoteImage Tests-acknowledgements.plist"; sourceTree = "<group>"; };
+		8A2850CDB3C10F3465131AAA /* enc_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_sse2.c; path = src/dsp/enc_sse2.c; sourceTree = "<group>"; };
+		8B1BB990497563B941D74F4B /* lossless.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = lossless.h; path = src/dsp/lossless.h; sourceTree = "<group>"; };
+		8C3EE5B1F1C82C2F15B396AE /* Pods-PINRemoteImage.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage.release.xcconfig"; sourceTree = "<group>"; };
+		8C4BDEBFF116A14AC84B3F93 /* Pods-PINRemoteImage-libwebp-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage-libwebp-prefix.pch"; sourceTree = "<group>"; };
+		8D0CCC325790418BBABC259E /* PINRemoteImageProcessorTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageProcessorTask.h; sourceTree = "<group>"; };
+		8D9EF65B27D6DBFAB1EF44A0 /* FLAnimatedImageView+PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "FLAnimatedImageView+PINRemoteImage.h"; sourceTree = "<group>"; };
+		8ECB0F950577E472909F8CA2 /* Pods-PINRemoteImage Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-dummy.m"; sourceTree = "<group>"; };
+		8F0B93E9AFF81CBDC1DF67FF /* rescaler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = rescaler.h; path = src/utils/rescaler.h; sourceTree = "<group>"; };
+		9365CD6EBAC0F4CA89A3DC9E /* bit_reader_inl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bit_reader_inl.h; path = src/utils/bit_reader_inl.h; sourceTree = "<group>"; };
+		938490304538811C80D06E0C /* huffman_encode.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = huffman_encode.c; path = src/utils/huffman_encode.c; sourceTree = "<group>"; };
+		93E33A749AD14EB35FF0FA31 /* quant_levels.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant_levels.c; path = src/utils/quant_levels.c; sourceTree = "<group>"; };
+		97A37BD8B210E04F1107DF9D /* format_constants.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = format_constants.h; path = src/webp/format_constants.h; sourceTree = "<group>"; };
+		987701B44446E0D53697C62F /* dec_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_mips32.c; path = src/dsp/dec_mips32.c; sourceTree = "<group>"; };
+		9A7645820E7854F8AC76D80B /* endian_inl.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = endian_inl.h; path = src/utils/endian_inl.h; sourceTree = "<group>"; };
+		9AAAAF6BBCE87AE120DE0390 /* Pods-PINRemoteImage Tests-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-PINRemoteImage Tests-acknowledgements.markdown"; sourceTree = "<group>"; };
+		9B029AC1FDB4099426F5535A /* alpha_processing_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = alpha_processing_sse2.c; path = src/dsp/alpha_processing_sse2.c; sourceTree = "<group>"; };
+		9B5629341AF914E376F66313 /* PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImage.h; sourceTree = "<group>"; };
+		9D5283C4C58CEC815EC2756D /* color_cache.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = color_cache.c; path = src/utils/color_cache.c; sourceTree = "<group>"; };
+		A1B80DDF56CC435E81311BAD /* Pods-PINRemoteImage-PINRemoteImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINRemoteImage.xcconfig"; path = "../Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage.xcconfig"; sourceTree = "<group>"; };
+		A1EAC63C315E4C32D45957BF /* FLAnimatedImageView+PINRemoteImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "FLAnimatedImageView+PINRemoteImage.m"; sourceTree = "<group>"; };
+		A2B6E7196058ABCD9E9F93AD /* PINRemoteImageCallbacks.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageCallbacks.m; sourceTree = "<group>"; };
+		A3BCD15CA8A565B85FF6030C /* libPods-PINRemoteImage-PINCache.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-PINCache.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5E6C843B0FFCDC59978F0CD /* UIImage+DecodedImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImage+DecodedImage.h"; sourceTree = "<group>"; };
+		A6140A8032385E6E49B60591 /* types.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = types.h; path = src/webp/types.h; sourceTree = "<group>"; };
+		A7DBA32B5F1BC2B095B58DE4 /* PINRemoteImageDownloadTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageDownloadTask.h; sourceTree = "<group>"; };
+		A85C8E416E3F2A3322F763B4 /* Pods-PINRemoteImage Tests-FLAnimatedImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-FLAnimatedImage.xcconfig"; sourceTree = "<group>"; };
+		AA888CEC0DC517F377C4F2FB /* lossless_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = lossless_mips32.c; path = src/dsp/lossless_mips32.c; sourceTree = "<group>"; };
+		AB453112F686E9F6925C8D28 /* Pods-PINRemoteImage Tests-PINCache.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests-PINCache.xcconfig"; sourceTree = "<group>"; };
+		AC256EE7D2F70048CF7A868C /* UIButton+PINRemoteImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIButton+PINRemoteImage.m"; sourceTree = "<group>"; };
+		ADEAE7778146D46205A810E9 /* webp.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = webp.c; path = src/dec/webp.c; sourceTree = "<group>"; };
+		ADF57DAB5977E73C90D1628B /* enc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc.c; path = src/dsp/enc.c; sourceTree = "<group>"; };
+		AEA8EBA769657A40B841BFE5 /* PINDataTaskOperation.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINDataTaskOperation.m; sourceTree = "<group>"; };
+		B08D8CE04C3AFA9CF050F9BF /* dec_clip_tables.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_clip_tables.c; path = src/dsp/dec_clip_tables.c; sourceTree = "<group>"; };
+		B0BF246114FB26A8A30DC0AD /* PINRemoteImageCategoryManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageCategoryManager.h; sourceTree = "<group>"; };
+		B159B32D332AF016E70CC8A7 /* demux.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = demux.c; path = src/demux/demux.c; sourceTree = "<group>"; };
+		B3B218256231422D79A11C84 /* FLAnimatedImageView.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = FLAnimatedImageView.m; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImageView.m; sourceTree = "<group>"; };
+		B6753CEF9354FFBF78BD5589 /* webpi.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = webpi.h; path = src/dec/webpi.h; sourceTree = "<group>"; };
+		B69567060D158C1F209886F5 /* tree.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = tree.c; path = src/enc/tree.c; sourceTree = "<group>"; };
+		B734C7A2E54ADBFA07676BC4 /* utils.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = utils.c; path = src/utils/utils.c; sourceTree = "<group>"; };
+		B78C15E8DFA5C1B3EF25452F /* FLAnimatedImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = FLAnimatedImage.h; path = FLAnimatedImageDemo/FLAnimatedImage/FLAnimatedImage.h; sourceTree = "<group>"; };
+		B96957A211BE67A256453E66 /* enc_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = enc_mips32.c; path = src/dsp/enc_mips32.c; sourceTree = "<group>"; };
+		BDFF42ED8EBE906CEE3C19D5 /* PINProgressiveImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINProgressiveImage.m; sourceTree = "<group>"; };
+		BF043BD628437EE79D702598 /* PINDataTaskOperation.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINDataTaskOperation.h; sourceTree = "<group>"; };
+		C06C732A3E3DCFDD478758A4 /* PINRemoteImageCategoryManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageCategoryManager.m; sourceTree = "<group>"; };
+		C079A820E26E81694890DFB6 /* bit_reader.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = bit_reader.h; path = src/utils/bit_reader.h; sourceTree = "<group>"; };
+		C0CB102BF6E2999E137D39C9 /* cpu.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cpu.c; path = src/dsp/cpu.c; sourceTree = "<group>"; };
+		C17930DB6FDF1427E200BA52 /* mux_types.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mux_types.h; path = src/webp/mux_types.h; sourceTree = "<group>"; };
+		C1C4102260B5CB9D40248207 /* Pods-PINRemoteImage-PINCache-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-PINRemoteImage-PINCache-dummy.m"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-dummy.m"; sourceTree = "<group>"; };
+		C29AB40A97197DF7640E91FB /* Pods-PINRemoteImage Tests-PINCache-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage Tests-PINCache-dummy.m"; sourceTree = "<group>"; };
+		C2EC6F4FC8AFC72A09A33FD9 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		C5FF526DD09A158931D49CD7 /* histogram.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = histogram.h; path = src/enc/histogram.h; sourceTree = "<group>"; };
+		C78E22C338D867D6C222CA61 /* Pods-PINRemoteImage Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-PINRemoteImage Tests-resources.sh"; sourceTree = "<group>"; };
+		C7DDD4A665ABFB6E734094C9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.3.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		C979F6E3D7BDAB2715BBFB51 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage-libwebp-Private.xcconfig"; sourceTree = "<group>"; };
+		CA17741002D92724228EF02E /* vp8li.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8li.h; path = src/dec/vp8li.h; sourceTree = "<group>"; };
+		CA246AF1170C21E027452AA1 /* yuv_mips32.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = yuv_mips32.c; path = src/dsp/yuv_mips32.c; sourceTree = "<group>"; };
+		CBF83526B47596AF555F3568 /* quant.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant.c; path = src/dec/quant.c; sourceTree = "<group>"; };
+		CC3C5C952139B91BC45E75CE /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "Pods-PINRemoteImage-FLAnimatedImage-dummy.m"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-dummy.m"; sourceTree = "<group>"; };
+		CD3777DB27D91C006537BFC6 /* histogram.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = histogram.c; path = src/enc/histogram.c; sourceTree = "<group>"; };
+		CD4111DE5C2F3E6C4DB3DB0A /* libPods-PINRemoteImage-PINRemoteImage.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-PINRemoteImage.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D1E2D98F066F7A496238AF3D /* frame.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = frame.c; path = src/dec/frame.c; sourceTree = "<group>"; };
+		D1F29B2317039A4575417574 /* bit_writer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = bit_writer.c; path = src/utils/bit_writer.c; sourceTree = "<group>"; };
+		D25E81CB296EC9A0E46E868C /* NSData+ImageDetectors.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "NSData+ImageDetectors.h"; sourceTree = "<group>"; };
+		D3246710D21CD09EECB84A49 /* vp8l.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = vp8l.c; path = src/enc/vp8l.c; sourceTree = "<group>"; };
+		D349EBBA19654B57707F1E74 /* filter.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = filter.c; path = src/enc/filter.c; sourceTree = "<group>"; };
+		D43D339120D8E934C652C8E6 /* neon.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = neon.h; path = src/dsp/neon.h; sourceTree = "<group>"; };
+		D4E03FC9CE520645EAC61E08 /* PINURLSessionManager.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINURLSessionManager.m; sourceTree = "<group>"; };
+		D51C15928903038BE170073F /* cost.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = cost.c; path = src/enc/cost.c; sourceTree = "<group>"; };
+		D589031A9F40C24BC3F91E2C /* UIImageView+PINRemoteImage.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "UIImageView+PINRemoteImage.m"; sourceTree = "<group>"; };
+		D5F74434FF1207341EDE81EA /* libPods-PINRemoteImage-libwebp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-PINRemoteImage-libwebp.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		D6B3E488C2E32A71EEBCB2AD /* PINRemoteImageManagerResult.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageManagerResult.m; sourceTree = "<group>"; };
+		D85E879D0A985F460758ABF3 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-PINCache-Private.xcconfig"; path = "../Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-Private.xcconfig"; sourceTree = "<group>"; };
+		D934B71E11DC1BF1BE3AA2C0 /* Pods-PINRemoteImage Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage Tests.release.xcconfig"; sourceTree = "<group>"; };
+		D9547159833CBC732CCB3812 /* upsampling.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = upsampling.c; path = src/dsp/upsampling.c; sourceTree = "<group>"; };
+		D9E72BE5473A801CF9ACAFFB /* dec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec.c; path = src/dsp/dec.c; sourceTree = "<group>"; };
+		DAD14ABBC1257F8801CCED50 /* dec_neon.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = dec_neon.c; path = src/dsp/dec_neon.c; sourceTree = "<group>"; };
+		E1203C33444213664EFBBA4A /* Nullability.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nullability.h; path = PINCache/Nullability.h; sourceTree = "<group>"; };
+		E3C23298A493BD61270A2A54 /* Pods-PINRemoteImage-FLAnimatedImage.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PINRemoteImage-FLAnimatedImage.xcconfig"; path = "../Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage.xcconfig"; sourceTree = "<group>"; };
+		E3E3AB245A8B79CE36BEC5FD /* random.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = random.c; path = src/utils/random.c; sourceTree = "<group>"; };
+		E460DEF575B8F9BFC53BF9B8 /* PINRemoteImageTask.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageTask.h; sourceTree = "<group>"; };
+		E555643519C3F9702B28F5F5 /* backward_references.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = backward_references.h; path = src/enc/backward_references.h; sourceTree = "<group>"; };
+		E5E1351EB7476614C4336ED0 /* quant.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant.c; path = src/enc/quant.c; sourceTree = "<group>"; };
+		E6544E961CD3AA752071B6B5 /* Pods-PINRemoteImage Tests-PINCache-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-PINCache-prefix.pch"; sourceTree = "<group>"; };
+		E69527D0E662AAD95A395610 /* PINRemoteImageDownloadTask.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageDownloadTask.m; sourceTree = "<group>"; };
+		E7948655905AE1A3F8780C97 /* muxedit.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = muxedit.c; path = src/mux/muxedit.c; sourceTree = "<group>"; };
+		E9306DBC766A410DEB9FE244 /* quant_levels_dec.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = quant_levels_dec.c; path = src/utils/quant_levels_dec.c; sourceTree = "<group>"; };
+		EE4738DAFE61C4D6FE1A50BC /* Pods-PINRemoteImage Tests-environment.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-environment.h"; sourceTree = "<group>"; };
+		F0439236E5F84F76084E03DE /* webpenc.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = webpenc.c; path = src/enc/webpenc.c; sourceTree = "<group>"; };
+		F050B9E2172D157403ECB532 /* PINRemoteImageManager.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageManager.h; sourceTree = "<group>"; };
+		F22C803B44692927AA234CAB /* filters.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = filters.h; path = src/utils/filters.h; sourceTree = "<group>"; };
+		F35DA2684502C2DCA27B2622 /* PINMemoryCache.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = PINMemoryCache.h; path = PINCache/PINMemoryCache.h; sourceTree = "<group>"; };
+		F44130EC03CBF7485A3893D5 /* token.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = token.c; path = src/enc/token.c; sourceTree = "<group>"; };
+		F4C27D5F2DA9483AA8197661 /* encode.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = encode.h; path = src/webp/encode.h; sourceTree = "<group>"; };
+		F5205CC8732530BFC8C5AC6C /* Pods-PINRemoteImage.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-PINRemoteImage.debug.xcconfig"; sourceTree = "<group>"; };
+		F548010F5CB34AB5B8F95F36 /* Pods-PINRemoteImage-libwebp-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-PINRemoteImage-libwebp-dummy.m"; sourceTree = "<group>"; };
+		F780C4175B359297C380147F /* Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch"; sourceTree = "<group>"; };
+		F848FF815F6381B4598A4754 /* vp8i.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = vp8i.h; path = src/dec/vp8i.h; sourceTree = "<group>"; };
+		FB881F69DBA9F64C9FD4F986 /* UIImageView+PINRemoteImage.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "UIImageView+PINRemoteImage.h"; sourceTree = "<group>"; };
+		FF1697F345EAFE9BAB87FA57 /* upsampling_sse2.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = upsampling_sse2.c; path = src/dsp/upsampling_sse2.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		0DCC6ACE6F99432CD3EFDAB3 /* Frameworks */ = {
+		185C03DD2EF8082EB1D0BECC /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76E261E1AE58EE46272FA54E /* CoreGraphics.framework in Frameworks */,
-				60BB65D453CAD94357BA0FD2 /* Foundation.framework in Frameworks */,
-				E360F7BE022956F35F0B769D /* ImageIO.framework in Frameworks */,
-				FD0F5378EA5B299F9F21BE04 /* MobileCoreServices.framework in Frameworks */,
-				AB8BEB9FC6ABF4576BDA2FF5 /* QuartzCore.framework in Frameworks */,
+				0B079D7B9B1F41E67CECF87B /* CoreImage.framework in Frameworks */,
+				776B979D8F64366767EBEC77 /* Foundation.framework in Frameworks */,
+				1B8C7BAD3FBDDDBD18D0974D /* ImageIO.framework in Frameworks */,
+				C2B7CA39236DF09D4A5CA89C /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4C7D950DC0A94C34FD450F22 /* Frameworks */ = {
+		264AD7C9BFFD7F59FDE49DED /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76391DC9C03685DDF2D74EA0 /* CoreImage.framework in Frameworks */,
-				C0FC4DA26A488F1E5E39E47B /* Foundation.framework in Frameworks */,
-				B3F6EF8583AC30B704335F77 /* ImageIO.framework in Frameworks */,
-				F8D7DE2B94BB4E3028700DF7 /* UIKit.framework in Frameworks */,
+				FF4052E6307251AB65BA643E /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6BFC97E1971876D775E63628 /* Frameworks */ = {
+		272EC8A4CCEDC9AE0DE180C2 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				58DEBCA6B2459CBB3F7D14D5 /* Foundation.framework in Frameworks */,
+				39FF73D7A5F174BD76D2EFED /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		75D1BE51C9E2A1F66B964D53 /* Frameworks */ = {
+		547FA4E24C38B1DCE5C91716 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				11E1A01C2DE010ED64CB47F7 /* Foundation.framework in Frameworks */,
+				210784816A2E1EC651E40B62 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A289FB48945394243379119D /* Frameworks */ = {
+		9E489CBDFFEA8227BEA9EA54 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4AF583F33E18D2FEB45DC6DD /* Foundation.framework in Frameworks */,
+				8699DE23E681DA098677B62C /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AD062D9023A7A4627CD8C89D /* Frameworks */ = {
+		BF61F3AC74100665B93EFA34 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D3D60405B1B607C7186C9B76 /* Foundation.framework in Frameworks */,
+				A7DB4C297733CD1DDE35951D /* CoreImage.framework in Frameworks */,
+				B64099DA25B3745FA3C16D30 /* Foundation.framework in Frameworks */,
+				19EF258AF4167780E663707B /* ImageIO.framework in Frameworks */,
+				9C022A01F08119B8F21D1CDD /* UIKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CB21B6A54B45FF22AAFE5402 /* Frameworks */ = {
+		D5D85E8FAB9A4251B04904C9 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				84715579BE2DC4A31C994357 /* CoreGraphics.framework in Frameworks */,
-				5CE53C9962D4D7C96CA9D76D /* Foundation.framework in Frameworks */,
-				D99834E4173775B590A5612B /* ImageIO.framework in Frameworks */,
-				0DC2B39F813E84F3D544673D /* MobileCoreServices.framework in Frameworks */,
-				C847837DCB682806B0B5E1F1 /* QuartzCore.framework in Frameworks */,
+				DF7F2F3253A99A8D2BE97E73 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		D0CEE17379E8B518A0869D68 /* Frameworks */ = {
+		F509AD47812FD39DEB427EFB /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				15F7DC5B1E9649C8E18604BC /* Foundation.framework in Frameworks */,
+				4A3019984EBBCB734D1851EC /* CoreGraphics.framework in Frameworks */,
+				1EB40AFB1329F397E6EBA9FA /* Foundation.framework in Frameworks */,
+				4422E64C539E6D071CF7C366 /* ImageIO.framework in Frameworks */,
+				EC700733C07B0DC23CF0DB42 /* MobileCoreServices.framework in Frameworks */,
+				0B51B9CA0CE0CEAA9E44FA0B /* QuartzCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		F466A43CACA5C18FA42092D0 /* Frameworks */ = {
+		F6E9111C7A379B3D805ED398 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FC7A930BB3C048B6E3D2ABDB /* CoreImage.framework in Frameworks */,
-				658332F9F0E99B8F629A34BD /* Foundation.framework in Frameworks */,
-				FA039AFC75E91F3A5347D847 /* ImageIO.framework in Frameworks */,
-				479C19D8971CA2E6224579F0 /* UIKit.framework in Frameworks */,
+				B3B407A31B47C66B7317E5AB /* CoreGraphics.framework in Frameworks */,
+				FFDA1ABBB20FCD3C2A160DB7 /* Foundation.framework in Frameworks */,
+				DF146B610A0EC07A72F1634C /* ImageIO.framework in Frameworks */,
+				8A8BC971BC87A639003EEE25 /* MobileCoreServices.framework in Frameworks */,
+				36CB2E4C71AEFE7702819E48 /* QuartzCore.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		06B1B89D58240E019B6BECB6 /* Support Files */ = {
+		047D003FCC5B22BFBA6BD894 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				614D2BAEC7D74F01CEF237DC /* Pods-PINRemoteImage Tests-PINCache.xcconfig */,
-				3285143675C23ECB420F2903 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */,
-				04F5C5C2992F9E133C44716F /* Pods-PINRemoteImage Tests-PINCache-dummy.m */,
-				C15828D41EBF2FFBE09B5371 /* Pods-PINRemoteImage Tests-PINCache-prefix.pch */,
-				C62679E18F42525E931B17A1 /* Pods-PINRemoteImage-PINCache.xcconfig */,
-				518940E1EAB1CF8C819D29A6 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */,
-				3E177572CA15AC09235B9CC3 /* Pods-PINRemoteImage-PINCache-dummy.m */,
-				B6A4A735A0502CC63C844C21 /* Pods-PINRemoteImage-PINCache-prefix.pch */,
-			);
-			name = "Support Files";
-			path = "../Target Support Files/Pods-PINRemoteImage Tests-PINCache";
-			sourceTree = "<group>";
-		};
-		122DFF1E3D916EB5326B19CB /* Pod */ = {
-			isa = PBXGroup;
-			children = (
-				3081C6530F09C087BB151A85 /* Classes */,
-			);
-			path = Pod;
-			sourceTree = "<group>";
-		};
-		1882C16303FDBFA19DE57D14 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				2F528C47A9C3F7EA24BDA087 /* libPods-PINRemoteImage.a */,
-				8836086BE0571D96DC238C49 /* libPods-PINRemoteImage Tests.a */,
-				0B8D02298330B527A6514B03 /* libPods-PINRemoteImage Tests-FLAnimatedImage.a */,
-				D33C1A5B01870B4800B5235C /* libPods-PINRemoteImage Tests-PINCache.a */,
-				4A145FA49DADFFF932CDC5D8 /* libPods-PINRemoteImage Tests-PINRemoteImage.a */,
-				1EACD96D29F76543863D3569 /* libPods-PINRemoteImage-FLAnimatedImage.a */,
-				79A0AD133AA88607F24D0F9C /* libPods-PINRemoteImage-PINCache.a */,
-				4229FF266ED020C34ADE3FF4 /* libPods-PINRemoteImage-PINRemoteImage.a */,
-				88FF0BCA882181B2621D583C /* libPods-PINRemoteImage-libwebp.a */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		241A438B67536288ADFBDAC9 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				EC221F41DB75CBE8333E26C6 /* Pods-PINRemoteImage-libwebp.xcconfig */,
-				E0C501993B3ECC8147FE9E10 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */,
-				330EA627D53C757F18E55C48 /* Pods-PINRemoteImage-libwebp-dummy.m */,
-				79385154730CC54AC0179B27 /* Pods-PINRemoteImage-libwebp-prefix.pch */,
+				27660C96717E354C3A699167 /* Pods-PINRemoteImage-libwebp.xcconfig */,
+				C979F6E3D7BDAB2715BBFB51 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */,
+				F548010F5CB34AB5B8F95F36 /* Pods-PINRemoteImage-libwebp-dummy.m */,
+				8C4BDEBFF116A14AC84B3F93 /* Pods-PINRemoteImage-libwebp-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-PINRemoteImage-libwebp";
 			sourceTree = "<group>";
 		};
-		253FA58B8A7E1AF36DE6BBC2 /* Categories */ = {
+		0C724182A5C7452AEDA21A4E /* Pod */ = {
 			isa = PBXGroup;
 			children = (
-				9DAD1717E22854E0A976F7A7 /* NSData+ImageDetectors.h */,
-				E614AEE4EAF4BEB91D514A8D /* NSData+ImageDetectors.m */,
-				F8922D4AD691C9578CAC76AE /* UIImage+DecodedImage.h */,
-				6157B1E2C571146A4BEE0AAC /* UIImage+DecodedImage.m */,
-				34FB4D5F529754FE0EED4259 /* UIImage+WebP.h */,
-				BD5D7CB93AA5767183969903 /* UIImage+WebP.m */,
+				ED7FC02E12719EFDB1976458 /* Classes */,
 			);
-			path = Categories;
+			path = Pod;
 			sourceTree = "<group>";
 		};
-		2D53354F481A370D0E8FB97E /* Support Files */ = {
+		17B6CD3E93D772ED295F4B1E /* Image Categories */ = {
 			isa = PBXGroup;
 			children = (
-				1C5C982457EF61D029DB3BE8 /* Pods-PINRemoteImage Tests-FLAnimatedImage.xcconfig */,
-				C2F9F8DF4033F87254BFE90D /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */,
-				B26FDA93F54C889F5358DC4A /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m */,
-				EDEC353FB8A8155C91681269 /* Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch */,
-				82EE46510AD5F6B25870AA61 /* Pods-PINRemoteImage-FLAnimatedImage.xcconfig */,
-				1B4938CFE6128496CCA09AAE /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */,
-				24C6EA16777643D6C626154D /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m */,
-				0A9C5EF34D159CF774C6C837 /* Pods-PINRemoteImage-FLAnimatedImage-prefix.pch */,
+				8D9EF65B27D6DBFAB1EF44A0 /* FLAnimatedImageView+PINRemoteImage.h */,
+				A1EAC63C315E4C32D45957BF /* FLAnimatedImageView+PINRemoteImage.m */,
+			);
+			path = "Image Categories";
+			sourceTree = "<group>";
+		};
+		19E38D61BC8D128CF20DCD10 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				A85C8E416E3F2A3322F763B4 /* Pods-PINRemoteImage Tests-FLAnimatedImage.xcconfig */,
+				0501ADF0577B48BF70AA9AB8 /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */,
+				452ABBFF35FBCE2401926EE0 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m */,
+				F780C4175B359297C380147F /* Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch */,
+				E3C23298A493BD61270A2A54 /* Pods-PINRemoteImage-FLAnimatedImage.xcconfig */,
+				1FD581AECE86AD9191C4B153 /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */,
+				CC3C5C952139B91BC45E75CE /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m */,
+				1926CAD4D9B3CBD0A16EEFB0 /* Pods-PINRemoteImage-FLAnimatedImage-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Pods-PINRemoteImage Tests-FLAnimatedImage";
 			sourceTree = "<group>";
 		};
-		2EC98876E3B85C453A7F2EE7 /* Targets Support Files */ = {
+		1B6D33994F2345AAF8BF88CB /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				8E06728F0C9A4301545A72A7 /* Pods-PINRemoteImage */,
-				BD5967D385E525C97BB9B99D /* Pods-PINRemoteImage Tests */,
+				4D91327C87EB06EEFDC048AB /* CoreGraphics.framework */,
+				4D04F2F9D359D731DFD9D5BB /* CoreImage.framework */,
+				C7DDD4A665ABFB6E734094C9 /* Foundation.framework */,
+				4A4CBCD20720278A05CA0C78 /* ImageIO.framework */,
+				1632451F317F81C5837DCBA3 /* MobileCoreServices.framework */,
+				44C213D9012C09902F626D8D /* QuartzCore.framework */,
+				C2EC6F4FC8AFC72A09A33FD9 /* UIKit.framework */,
 			);
-			name = "Targets Support Files";
+			name = iOS;
 			sourceTree = "<group>";
 		};
-		3081C6530F09C087BB151A85 /* Classes */ = {
+		2A54D088E20828909A586A91 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				5BF3B35E85B47A9786C12825 /* PINDataTaskOperation.h */,
-				E8165FCF32E8CF65F30108C5 /* PINDataTaskOperation.m */,
-				28D7D0A5B7D11970BDD94AEF /* PINProgressiveImage.h */,
-				770CCC566BE67C32F422BF3A /* PINProgressiveImage.m */,
-				18F4BA910200CFFFE21F8243 /* PINRemoteImage.h */,
-				D29950B5A263A0F2A663EC9A /* PINRemoteImageCallbacks.h */,
-				F1A09D9946BF95D39936F81A /* PINRemoteImageCallbacks.m */,
-				A92D9362BBE2CC7A086BC6E9 /* PINRemoteImageCategoryManager.h */,
-				7FB080497D6B2101FD22E882 /* PINRemoteImageCategoryManager.m */,
-				15CA334D42BBF9C400E5060F /* PINRemoteImageDownloadTask.h */,
-				3A07BC1E88ECB3A7A9754AD8 /* PINRemoteImageDownloadTask.m */,
-				D840FD9797CCDA096D1278AA /* PINRemoteImageManager.h */,
-				900BFB3DBA86DD1F71A10A32 /* PINRemoteImageManager.m */,
-				FA5DAF75968DABCF7713A109 /* PINRemoteImageManagerResult.h */,
-				DA5BF7E6A2F099A7394B5B83 /* PINRemoteImageManagerResult.m */,
-				1411ED0557A87A5DB30002D6 /* PINRemoteImageProcessorTask.h */,
-				91514A996BB2EB5AD45AB033 /* PINRemoteImageProcessorTask.m */,
-				CC098641AD165A2604B4C561 /* PINRemoteImageTask.h */,
-				58CDA5997CD4B853F48AAC21 /* PINRemoteImageTask.m */,
-				DE35B24C590D2183E148D03C /* PINURLSessionManager.h */,
-				33C8C9F82FFF8FFE3893195F /* PINURLSessionManager.m */,
-				253FA58B8A7E1AF36DE6BBC2 /* Categories */,
-				884B0F165073892C6FC7687E /* Image Categories */,
+				408719889F1F1DB4F4C9FEBE /* FLAnimatedImage */,
+				B2F5D34663113574FDD05E06 /* PINCache */,
+				E5059A54D4A9FD6B68F41F4C /* libwebp */,
 			);
-			path = Classes;
+			name = Pods;
 			sourceTree = "<group>";
 		};
-		5FC3B5CC379DF3768C79E14B /* PINCache */ = {
+		408719889F1F1DB4F4C9FEBE /* FLAnimatedImage */ = {
 			isa = PBXGroup;
 			children = (
-				30ACEB879D47301F32AF62B7 /* Nullability.h */,
-				BA0C344DEDA0F9DB769B8DC6 /* PINCache.h */,
-				4421D7C6260A68BAA7A591AD /* PINCache.m */,
-				F8222347FFCA6E4E0086D3E7 /* PINDiskCache.h */,
-				82D0DF8AD08D326734224970 /* PINDiskCache.m */,
-				2EC5505BE7AEAB2C00193557 /* PINMemoryCache.h */,
-				C002129DC8236BA0B2372424 /* PINMemoryCache.m */,
-				06B1B89D58240E019B6BECB6 /* Support Files */,
+				B78C15E8DFA5C1B3EF25452F /* FLAnimatedImage.h */,
+				4CA4E371A1D3FC1E9FCD2C4A /* FLAnimatedImage.m */,
+				62AD0673C84961F5598B388F /* FLAnimatedImageView.h */,
+				B3B218256231422D79A11C84 /* FLAnimatedImageView.m */,
+				19E38D61BC8D128CF20DCD10 /* Support Files */,
 			);
-			path = PINCache;
+			path = FLAnimatedImage;
 			sourceTree = "<group>";
 		};
-		6690184308740A30C40D81DA /* Development Pods */ = {
+		42BB7BE536CB2427913220D3 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				8ECC12559033BD6502F58824 /* PINRemoteImage */,
-			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		67E8D4830747FFAE1EEFB6E9 /* mux */ = {
-			isa = PBXGroup;
-			children = (
-				1AEBCB8495D272312B6F79A2 /* muxedit.c */,
-				A6CB42687C3924CA507FEB29 /* muxi.h */,
-				C6A268B8577C379C5B68409A /* muxinternal.c */,
-				E902F4F9D0DB309C93FA57B4 /* muxread.c */,
-			);
-			name = mux;
-			sourceTree = "<group>";
-		};
-		6F9A3C6213E6F719D9BF6FF3 /* Support Files */ = {
-			isa = PBXGroup;
-			children = (
-				8E3C1D49DE4368799CAEAAD0 /* Pods-PINRemoteImage Tests-PINRemoteImage.xcconfig */,
-				B667E47AE90ADBB16875418E /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */,
-				C0978BC16828F75398D69C77 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m */,
-				200458B913EBE688641585E6 /* Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch */,
-				FAA3D1842FEE008C3C15D04A /* Pods-PINRemoteImage-PINRemoteImage.xcconfig */,
-				FF61C3873B4B3A2C9EFDBE21 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */,
-				6FAD3D1B72E92CCF17E8FD33 /* Pods-PINRemoteImage-PINRemoteImage-dummy.m */,
-				1010DE4B40B56944F11337A5 /* Pods-PINRemoteImage-PINRemoteImage-prefix.pch */,
+				669D3865F40A9F17B8FD48E0 /* Pods-PINRemoteImage Tests-PINRemoteImage.xcconfig */,
+				7057648BB45CA7E897825284 /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */,
+				4E9DF33F209E9DDA0E8645CB /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m */,
+				00442EC78AA26C4CFE848CC9 /* Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch */,
+				A1B80DDF56CC435E81311BAD /* Pods-PINRemoteImage-PINRemoteImage.xcconfig */,
+				3A38D134C79DA4234655EAE2 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */,
+				51790811C2EEE503E2031E1D /* Pods-PINRemoteImage-PINRemoteImage-dummy.m */,
+				1E28CE552687BB01D8CE5625 /* Pods-PINRemoteImage-PINRemoteImage-prefix.pch */,
 			);
 			name = "Support Files";
 			path = "Example/Pods/Target Support Files/Pods-PINRemoteImage Tests-PINRemoteImage";
 			sourceTree = "<group>";
 		};
-		79BF96393208AC52F3C024F3 /* core */ = {
+		43424CB078126B7B191FCA02 /* webp */ = {
 			isa = PBXGroup;
 			children = (
-				FDC25C6EEC0F714AB6FF163F /* alpha.c */,
-				04AE64E18B08566BA7299D6C /* alpha.c */,
-				9F24BC8343FE6CF0CEB0FB27 /* alpha_processing.c */,
-				CA56F921D428CB0F8C3CAD59 /* alpha_processing_sse2.c */,
-				5AB7D7B18F8FBFCDB96DEEEE /* alphai.h */,
-				018FA8B5BC6377615A5FD0BC /* analysis.c */,
-				DA92D6C17316B55CF5905942 /* backward_references.c */,
-				460EE0E2DB475B09746A6B99 /* backward_references.h */,
-				1C924F20DEF8A1EC8D661176 /* bit_reader.c */,
-				475D1E03B71A8A388B890757 /* bit_reader.h */,
-				8839C73E910D9D4E92346929 /* bit_reader_inl.h */,
-				6A473B0A3E09DDD102E55D0D /* bit_writer.c */,
-				30F62A9719C9EF432B6E037D /* bit_writer.h */,
-				3DC294E892A7361403ED88E0 /* buffer.c */,
-				EB058DE67218FE36A48A45E8 /* color_cache.c */,
-				6163A230B1990890702EA953 /* color_cache.h */,
-				26C2F935E2AC495D401540C9 /* config.c */,
-				213BE7CA6607FA9AEE970348 /* cost.c */,
-				96F24A2B6A1531C4005FC59E /* cost.h */,
-				877050E43BA77C4B9CF4D73F /* cpu.c */,
-				4F5A7A8B06DB59D227A30337 /* dec.c */,
-				0C59AFEDC7708E422C40C308 /* dec_clip_tables.c */,
-				5375BF29A50FE83DD5D40CB4 /* dec_mips32.c */,
-				D402E4D0C8870B22B4CB4251 /* dec_neon.c */,
-				46C17FAB98D60BA7B4144046 /* dec_sse2.c */,
-				2DFC6394E19E6ADB6E1B259F /* decode_vp8.h */,
-				4154A2D9D14B75CC098E5348 /* dsp.h */,
-				03E781702445143853DE9F1E /* enc.c */,
-				79B7B5C3B3E806FF5E198A55 /* enc_avx2.c */,
-				CDB47F1E1BEE88EC5F15D7F5 /* enc_mips32.c */,
-				783DF441A2A951109941CDE6 /* enc_neon.c */,
-				38D01CF812A4A0CD416EDE45 /* enc_sse2.c */,
-				3A1A79E582688E787DA8E5E8 /* endian_inl.h */,
-				DE9188458BBD5EDBE7116F1A /* filter.c */,
-				4B1DCA626F9F48C92F3DE418 /* filters.c */,
-				BA42CB9CB959CA72FE6A64F3 /* filters.h */,
-				ED048724AABCA3AE496D39FA /* frame.c */,
-				F274C0F4ECBAA2C7F6999BAB /* frame.c */,
-				0E5112E3F64D019481017388 /* histogram.c */,
-				739A945AD4203B330E3ADC71 /* histogram.h */,
-				B56023D6F33AB318A2C726DE /* huffman.c */,
-				1E12298E3A9B94FB34DD582F /* huffman.h */,
-				0F74BC9058274E76220B55AD /* huffman_encode.c */,
-				731F9F85DFDF7A4FF72C64FE /* huffman_encode.h */,
-				809A42A4B7712F406A37B27F /* idec.c */,
-				9E2E138C150A2E033F7EA7F0 /* io.c */,
-				62A29D0D154A41D24E174461 /* iterator.c */,
-				4905DDAE71A14D8336691112 /* lossless.c */,
-				895614D466331488DAD056BF /* lossless.h */,
-				8B8507BB0956AC4C0A042052 /* lossless_mips32.c */,
-				78F1B339E533B9277943516F /* lossless_neon.c */,
-				36D625A1C5722E002DF529B7 /* lossless_sse2.c */,
-				1707FEF548099A39B521E414 /* neon.h */,
-				84D3613B0081663D339FEB2B /* picture.c */,
-				607B72386DFA740FF29A3D0E /* picture_csp.c */,
-				17F827E32C8D00DCF280EA65 /* picture_psnr.c */,
-				6CAACF882F1B9A78A6D72DE4 /* picture_rescale.c */,
-				AECE0F69954120DEF87DEF8F /* picture_tools.c */,
-				6637574CFFC3A8608AFDC57B /* quant.c */,
-				4DF809949EDDEFD1C5DCC4EF /* quant.c */,
-				C4485503ABDD09722DF3F543 /* quant_levels.c */,
-				F937251E72F8D803DF740FD1 /* quant_levels.h */,
-				C4123DE345C3893977C60A91 /* quant_levels_dec.c */,
-				EAFBBDBB1B69F77478524F03 /* quant_levels_dec.h */,
-				C342AC4D0FD7748DBBB4EFB9 /* random.c */,
-				300B82EB41148F1B20C9882B /* random.h */,
-				E9F091AD0EF9EC3CCD15CB7F /* rescaler.c */,
-				8BFC45008AE493FAE4B094E4 /* rescaler.h */,
-				CCBD8A8DA3A62E37ED1EAE61 /* syntax.c */,
-				668813EB85E7836278E80DA0 /* thread.c */,
-				D93FCE87CE01F32875005BEC /* thread.h */,
-				19F749861852615E04CD2119 /* token.c */,
-				291680B33C1A5ACB978C3084 /* tree.c */,
-				184233F9F26C7BCC6EA083CD /* tree.c */,
-				69C2E5F2777D66B8795CC895 /* upsampling.c */,
-				5EA8E94BD7BAD9DE33E88FA2 /* upsampling_neon.c */,
-				DFC3CD908E9C2EE4B301B432 /* upsampling_sse2.c */,
-				08824028B560E91F8052A59F /* utils.c */,
-				3C9D37AAD05886CCB8209DC8 /* utils.h */,
-				528709200F12486986039B5B /* vp8.c */,
-				020E9CCFD42B5BE529C5AB36 /* vp8enci.h */,
-				98D6448ACE91F603138DCD99 /* vp8i.h */,
-				AEED084654AADAC9A365195A /* vp8l.c */,
-				793271E516D880963B2C8646 /* vp8l.c */,
-				FCB69CB08EB887067B347EED /* vp8li.h */,
-				8FECF902E84AC3C2FCF0002D /* vp8li.h */,
-				76523450AB74E105E5672A90 /* webp.c */,
-				92D46CA965D94804A6D2CAB4 /* webpenc.c */,
-				2D2DA78D9E2F3326F53A1042 /* webpi.h */,
-				227D1B42D0C08BE81AEC079B /* yuv.c */,
-				A8224771F2044567D187303A /* yuv.h */,
-				7CDACEDED47F9E871576FDD5 /* yuv_mips32.c */,
-				715BAE5F642853A4D2DDCB8D /* yuv_sse2.c */,
-				18B6A3115CEB5BC85ACABA43 /* yuv_tables_sse2.h */,
+				1E036357C7BE69A4A8411CC8 /* decode.h */,
+				7C5102A86DCDF791157E6EFF /* demux.h */,
+				F4C27D5F2DA9483AA8197661 /* encode.h */,
+				97A37BD8B210E04F1107DF9D /* format_constants.h */,
+				5E7BB51F9DACED26FD180CC8 /* mux.h */,
+				C17930DB6FDF1427E200BA52 /* mux_types.h */,
+				A6140A8032385E6E49B60591 /* types.h */,
 			);
-			name = core;
+			name = webp;
 			sourceTree = "<group>";
 		};
-		884B0F165073892C6FC7687E /* Image Categories */ = {
+		4B78C17BBEE78978530A7D9F /* PINRemoteImage */ = {
 			isa = PBXGroup;
 			children = (
-				7EF29D0AA847A39F6EA22781 /* FLAnimatedImageView+PINRemoteImage.h */,
-				750F9D26ECC12BD617C0C1BC /* FLAnimatedImageView+PINRemoteImage.m */,
-				2503E7DC56549A7F5FCB3801 /* UIButton+PINRemoteImage.h */,
-				2106867C7D4FC0B39EB23833 /* UIButton+PINRemoteImage.m */,
-				0DF089FD37A6C428D2BE6103 /* UIImageView+PINRemoteImage.h */,
-				70951C2B6487A163A5B0A3B4 /* UIImageView+PINRemoteImage.m */,
-			);
-			path = "Image Categories";
-			sourceTree = "<group>";
-		};
-		8E06728F0C9A4301545A72A7 /* Pods-PINRemoteImage */ = {
-			isa = PBXGroup;
-			children = (
-				56D4238DC06664AE9784A9B4 /* Pods-PINRemoteImage-acknowledgements.markdown */,
-				93AED93CB944AA28A3F1E957 /* Pods-PINRemoteImage-acknowledgements.plist */,
-				EB7639592B4A22DFD17D33BA /* Pods-PINRemoteImage-dummy.m */,
-				D46DEB83F9C07E0B042FD274 /* Pods-PINRemoteImage-environment.h */,
-				8ABE519B49C5229F197AA87F /* Pods-PINRemoteImage-resources.sh */,
-				8241AA46CE5E88509ABCC479 /* Pods-PINRemoteImage.debug.xcconfig */,
-				B13E2D603C55C02E09088BBC /* Pods-PINRemoteImage.release.xcconfig */,
-			);
-			name = "Pods-PINRemoteImage";
-			path = "Target Support Files/Pods-PINRemoteImage";
-			sourceTree = "<group>";
-		};
-		8ECC12559033BD6502F58824 /* PINRemoteImage */ = {
-			isa = PBXGroup;
-			children = (
-				122DFF1E3D916EB5326B19CB /* Pod */,
-				6F9A3C6213E6F719D9BF6FF3 /* Support Files */,
+				7BC11DED1EF9FCC377A51A8B /* Core */,
+				DDC2A8DA20DD3A4507EA6456 /* FLAnimatedImage */,
+				42BB7BE536CB2427913220D3 /* Support Files */,
 			);
 			name = PINRemoteImage;
 			path = ../..;
 			sourceTree = "<group>";
 		};
-		8FA046C2BC8A9164B8E96301 /* libwebp */ = {
+		4D033860B0A0D190DBB4FDC3 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
-				241A438B67536288ADFBDAC9 /* Support Files */,
-				79BF96393208AC52F3C024F3 /* core */,
-				CE7C2F76BE52852C0CAAE2B4 /* demux */,
-				67E8D4830747FFAE1EEFB6E9 /* mux */,
-				B53F92B0553D02F079B4FDAA /* webp */,
+				97CBCC5FD3D0FD96FB34650B /* Pods-PINRemoteImage */,
+				6AF6C06EDB16376D8A679C69 /* Pods-PINRemoteImage Tests */,
 			);
-			path = libwebp;
+			name = "Targets Support Files";
 			sourceTree = "<group>";
 		};
-		AACDF0401FA2FB956483F3E1 /* Pods */ = {
+		6400C9EA86DF56F7142704E2 /* Image Categories */ = {
 			isa = PBXGroup;
 			children = (
-				F7CACD4BB65B267056016BD9 /* FLAnimatedImage */,
-				5FC3B5CC379DF3768C79E14B /* PINCache */,
-				8FA046C2BC8A9164B8E96301 /* libwebp */,
+				02331317D3899B0E6DD8320D /* UIButton+PINRemoteImage.h */,
+				AC256EE7D2F70048CF7A868C /* UIButton+PINRemoteImage.m */,
+				FB881F69DBA9F64C9FD4F986 /* UIImageView+PINRemoteImage.h */,
+				D589031A9F40C24BC3F91E2C /* UIImageView+PINRemoteImage.m */,
 			);
-			name = Pods;
+			path = "Image Categories";
 			sourceTree = "<group>";
 		};
-		B35571BC9AE21DD5D7F121E7 = {
+		67476A58FDCE141B9ABE71B0 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				C8CF2A64072E77BECF8EB922 /* Podfile */,
-				6690184308740A30C40D81DA /* Development Pods */,
-				C7946DFD34D333614249B493 /* Frameworks */,
-				AACDF0401FA2FB956483F3E1 /* Pods */,
-				1882C16303FDBFA19DE57D14 /* Products */,
-				2EC98876E3B85C453A7F2EE7 /* Targets Support Files */,
+				BF043BD628437EE79D702598 /* PINDataTaskOperation.h */,
+				AEA8EBA769657A40B841BFE5 /* PINDataTaskOperation.m */,
+				0EAD94C9C22F68324F90913C /* PINProgressiveImage.h */,
+				BDFF42ED8EBE906CEE3C19D5 /* PINProgressiveImage.m */,
+				9B5629341AF914E376F66313 /* PINRemoteImage.h */,
+				2CB0A5712FDDBFC13AF90EAE /* PINRemoteImageCallbacks.h */,
+				A2B6E7196058ABCD9E9F93AD /* PINRemoteImageCallbacks.m */,
+				B0BF246114FB26A8A30DC0AD /* PINRemoteImageCategoryManager.h */,
+				C06C732A3E3DCFDD478758A4 /* PINRemoteImageCategoryManager.m */,
+				A7DBA32B5F1BC2B095B58DE4 /* PINRemoteImageDownloadTask.h */,
+				E69527D0E662AAD95A395610 /* PINRemoteImageDownloadTask.m */,
+				F050B9E2172D157403ECB532 /* PINRemoteImageManager.h */,
+				2904117440C98966700B86A8 /* PINRemoteImageManager.m */,
+				850102C71DEEB6F3A7FC2952 /* PINRemoteImageManagerResult.h */,
+				D6B3E488C2E32A71EEBCB2AD /* PINRemoteImageManagerResult.m */,
+				8D0CCC325790418BBABC259E /* PINRemoteImageProcessorTask.h */,
+				6ED575F1C4CD6FCE15444090 /* PINRemoteImageProcessorTask.m */,
+				E460DEF575B8F9BFC53BF9B8 /* PINRemoteImageTask.h */,
+				2322476F62E9FE70B93A7FE4 /* PINRemoteImageTask.m */,
+				289B4490633CB580D96ED8FE /* PINURLSessionManager.h */,
+				D4E03FC9CE520645EAC61E08 /* PINURLSessionManager.m */,
+				AA3E21DC3EF693E168738A16 /* Categories */,
+				6400C9EA86DF56F7142704E2 /* Image Categories */,
 			);
+			path = Classes;
 			sourceTree = "<group>";
 		};
-		B53F92B0553D02F079B4FDAA /* webp */ = {
+		6AF6C06EDB16376D8A679C69 /* Pods-PINRemoteImage Tests */ = {
 			isa = PBXGroup;
 			children = (
-				03DDB62B993FD5786D674298 /* decode.h */,
-				BA20EC564FE2895DBFBC18CC /* demux.h */,
-				0848E937F532D50A98429553 /* encode.h */,
-				C01D6989F22F7BBB231E55C2 /* format_constants.h */,
-				119A4B22020382EBCE5A5360 /* mux.h */,
-				FC4FFBA1FEF5D4C4143ACC54 /* mux_types.h */,
-				6316705DB74586A8BFD65542 /* types.h */,
-			);
-			name = webp;
-			sourceTree = "<group>";
-		};
-		BD5967D385E525C97BB9B99D /* Pods-PINRemoteImage Tests */ = {
-			isa = PBXGroup;
-			children = (
-				BAA3EB52BB5057B2FA36F643 /* Pods-PINRemoteImage Tests-acknowledgements.markdown */,
-				374C287B05CB292AB10E0200 /* Pods-PINRemoteImage Tests-acknowledgements.plist */,
-				9EC6EB5D912F8635EE261A96 /* Pods-PINRemoteImage Tests-dummy.m */,
-				D9B2D11922EF674312C603D6 /* Pods-PINRemoteImage Tests-environment.h */,
-				C8A5A9E6094F3487C55DFFBD /* Pods-PINRemoteImage Tests-resources.sh */,
-				5B25276ADCAF13177E8879D7 /* Pods-PINRemoteImage Tests.debug.xcconfig */,
-				3F6EF3E8BFFE91E6DBE1FCF9 /* Pods-PINRemoteImage Tests.release.xcconfig */,
+				9AAAAF6BBCE87AE120DE0390 /* Pods-PINRemoteImage Tests-acknowledgements.markdown */,
+				881B11A1811D862A5B0EAB6A /* Pods-PINRemoteImage Tests-acknowledgements.plist */,
+				8ECB0F950577E472909F8CA2 /* Pods-PINRemoteImage Tests-dummy.m */,
+				EE4738DAFE61C4D6FE1A50BC /* Pods-PINRemoteImage Tests-environment.h */,
+				C78E22C338D867D6C222CA61 /* Pods-PINRemoteImage Tests-resources.sh */,
+				440A712A234F860C66C1F6F7 /* Pods-PINRemoteImage Tests.debug.xcconfig */,
+				D934B71E11DC1BF1BE3AA2C0 /* Pods-PINRemoteImage Tests.release.xcconfig */,
 			);
 			name = "Pods-PINRemoteImage Tests";
 			path = "Target Support Files/Pods-PINRemoteImage Tests";
 			sourceTree = "<group>";
 		};
-		C7946DFD34D333614249B493 /* Frameworks */ = {
+		77637823CD5CEE91C19734EE /* mux */ = {
 			isa = PBXGroup;
 			children = (
-				C98218DABDF70E628459711D /* iOS */,
+				E7948655905AE1A3F8780C97 /* muxedit.c */,
+				0BFA2A814C50BED72995DFC5 /* muxi.h */,
+				64B1DE7C5BA3B54BDE19602D /* muxinternal.c */,
+				3BF09DF1C61D0B047C34C79B /* muxread.c */,
+			);
+			name = mux;
+			sourceTree = "<group>";
+		};
+		7BC11DED1EF9FCC377A51A8B /* Core */ = {
+			isa = PBXGroup;
+			children = (
+				92A300F048B5FD1A58C229BA /* Pod */,
+			);
+			name = Core;
+			sourceTree = "<group>";
+		};
+		7D791E2E41CA4D83D6C110DF /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				AB453112F686E9F6925C8D28 /* Pods-PINRemoteImage Tests-PINCache.xcconfig */,
+				1F87CB2EF8EC4EA3200DF097 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */,
+				C29AB40A97197DF7640E91FB /* Pods-PINRemoteImage Tests-PINCache-dummy.m */,
+				E6544E961CD3AA752071B6B5 /* Pods-PINRemoteImage Tests-PINCache-prefix.pch */,
+				452AF2D9D8C6FA4DC879F251 /* Pods-PINRemoteImage-PINCache.xcconfig */,
+				D85E879D0A985F460758ABF3 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */,
+				C1C4102260B5CB9D40248207 /* Pods-PINRemoteImage-PINCache-dummy.m */,
+				88196ECF9F8595430B476F75 /* Pods-PINRemoteImage-PINCache-prefix.pch */,
+			);
+			name = "Support Files";
+			path = "../Target Support Files/Pods-PINRemoteImage Tests-PINCache";
+			sourceTree = "<group>";
+		};
+		7E2DB78B2628F08A868D6133 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33E104AB4034A41A4255712F /* libPods-PINRemoteImage.a */,
+				0C6FDE0B01639746C4190D2C /* libPods-PINRemoteImage Tests.a */,
+				0B7ABD9330244439263A3473 /* libPods-PINRemoteImage Tests-FLAnimatedImage.a */,
+				714E51E3AE4DE85982C50E85 /* libPods-PINRemoteImage Tests-PINCache.a */,
+				3E680AE1CCDE78F1DCADC0E9 /* libPods-PINRemoteImage Tests-PINRemoteImage.a */,
+				6340D3CAA7D6DAF3C71B35F2 /* libPods-PINRemoteImage-FLAnimatedImage.a */,
+				A3BCD15CA8A565B85FF6030C /* libPods-PINRemoteImage-PINCache.a */,
+				CD4111DE5C2F3E6C4DB3DB0A /* libPods-PINRemoteImage-PINRemoteImage.a */,
+				D5F74434FF1207341EDE81EA /* libPods-PINRemoteImage-libwebp.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		92A300F048B5FD1A58C229BA /* Pod */ = {
+			isa = PBXGroup;
+			children = (
+				67476A58FDCE141B9ABE71B0 /* Classes */,
+			);
+			path = Pod;
+			sourceTree = "<group>";
+		};
+		97CBCC5FD3D0FD96FB34650B /* Pods-PINRemoteImage */ = {
+			isa = PBXGroup;
+			children = (
+				3CAEBBDAFF40D717D2F7737B /* Pods-PINRemoteImage-acknowledgements.markdown */,
+				3417B803A0BB3EF3FF1E53FA /* Pods-PINRemoteImage-acknowledgements.plist */,
+				730CD23B2028D171065EFBB1 /* Pods-PINRemoteImage-dummy.m */,
+				3D62B62CDE89409F44639F82 /* Pods-PINRemoteImage-environment.h */,
+				84D938F086044D0CD475B145 /* Pods-PINRemoteImage-resources.sh */,
+				F5205CC8732530BFC8C5AC6C /* Pods-PINRemoteImage.debug.xcconfig */,
+				8C3EE5B1F1C82C2F15B396AE /* Pods-PINRemoteImage.release.xcconfig */,
+			);
+			name = "Pods-PINRemoteImage";
+			path = "Target Support Files/Pods-PINRemoteImage";
+			sourceTree = "<group>";
+		};
+		AA3E21DC3EF693E168738A16 /* Categories */ = {
+			isa = PBXGroup;
+			children = (
+				D25E81CB296EC9A0E46E868C /* NSData+ImageDetectors.h */,
+				33AEF73E9E68A8B37765FFE7 /* NSData+ImageDetectors.m */,
+				A5E6C843B0FFCDC59978F0CD /* UIImage+DecodedImage.h */,
+				68F6EA37D82944A4D73413DB /* UIImage+DecodedImage.m */,
+				128080C5B8DAE97C307F48AA /* UIImage+WebP.h */,
+				5268DA59BDABF99F1AD0944A /* UIImage+WebP.m */,
+			);
+			path = Categories;
+			sourceTree = "<group>";
+		};
+		AC3399B6329F6CCCB31BC38C /* core */ = {
+			isa = PBXGroup;
+			children = (
+				16BFCE71127012C5092825D3 /* alpha.c */,
+				4D52F0AA9E1BE0A1A5CD6D20 /* alpha.c */,
+				36D9D70985B2DBDD0E5AE903 /* alpha_processing.c */,
+				9B029AC1FDB4099426F5535A /* alpha_processing_sse2.c */,
+				214C502BB1A4BC420B333D5C /* alphai.h */,
+				07C35A427B16AD45795C6335 /* analysis.c */,
+				72FB8FF76B65337D08585714 /* backward_references.c */,
+				E555643519C3F9702B28F5F5 /* backward_references.h */,
+				3CABF8EC83146EB980B2682C /* bit_reader.c */,
+				C079A820E26E81694890DFB6 /* bit_reader.h */,
+				9365CD6EBAC0F4CA89A3DC9E /* bit_reader_inl.h */,
+				D1F29B2317039A4575417574 /* bit_writer.c */,
+				6C07892512E3B23951EFA616 /* bit_writer.h */,
+				31F01E43660702EA2B7C74BE /* buffer.c */,
+				9D5283C4C58CEC815EC2756D /* color_cache.c */,
+				0F80CA4B5153F6B519765BB2 /* color_cache.h */,
+				2D7F5B80A8DCACEAAF77F899 /* config.c */,
+				D51C15928903038BE170073F /* cost.c */,
+				3A427A2D8751ABE66D62D763 /* cost.h */,
+				C0CB102BF6E2999E137D39C9 /* cpu.c */,
+				D9E72BE5473A801CF9ACAFFB /* dec.c */,
+				B08D8CE04C3AFA9CF050F9BF /* dec_clip_tables.c */,
+				987701B44446E0D53697C62F /* dec_mips32.c */,
+				DAD14ABBC1257F8801CCED50 /* dec_neon.c */,
+				5C860D45E8FE4BF05BF3E511 /* dec_sse2.c */,
+				5D0F3B0D1C60C69878B2E614 /* decode_vp8.h */,
+				6CD425DF49D7A58E10942A2C /* dsp.h */,
+				ADF57DAB5977E73C90D1628B /* enc.c */,
+				703C6BD0871A9BF3BC4875B1 /* enc_avx2.c */,
+				B96957A211BE67A256453E66 /* enc_mips32.c */,
+				7F747586855B2B08D80E8C65 /* enc_neon.c */,
+				8A2850CDB3C10F3465131AAA /* enc_sse2.c */,
+				9A7645820E7854F8AC76D80B /* endian_inl.h */,
+				D349EBBA19654B57707F1E74 /* filter.c */,
+				7DFFAA3048BA40173308AD34 /* filters.c */,
+				F22C803B44692927AA234CAB /* filters.h */,
+				D1E2D98F066F7A496238AF3D /* frame.c */,
+				0E5ADED30F4B5ECFBA3A2076 /* frame.c */,
+				CD3777DB27D91C006537BFC6 /* histogram.c */,
+				C5FF526DD09A158931D49CD7 /* histogram.h */,
+				7A8F88E15EC0E4363C413E89 /* huffman.c */,
+				5DDB41864DCBD565EAE3BB86 /* huffman.h */,
+				938490304538811C80D06E0C /* huffman_encode.c */,
+				70EB8DE515C61A5D8FC9E7A7 /* huffman_encode.h */,
+				51167217F5890A290529558F /* idec.c */,
+				51A93AF501FD138663F4431F /* io.c */,
+				0D45CF433191B090268D502A /* iterator.c */,
+				27890A631E38C8E36DB85EBE /* lossless.c */,
+				8B1BB990497563B941D74F4B /* lossless.h */,
+				AA888CEC0DC517F377C4F2FB /* lossless_mips32.c */,
+				0D286EEF4E6D07BC5C0E67CE /* lossless_neon.c */,
+				55A7198EEE01380E97EB3B91 /* lossless_sse2.c */,
+				D43D339120D8E934C652C8E6 /* neon.h */,
+				4583E5264A6F29FD1B54BF58 /* picture.c */,
+				622677490FE95BF8855EEA3F /* picture_csp.c */,
+				517D7FE0A9689D78AB10B680 /* picture_psnr.c */,
+				2A68B633A9B63D05D54F7358 /* picture_rescale.c */,
+				1D62CC401B2276FAD3786167 /* picture_tools.c */,
+				E5E1351EB7476614C4336ED0 /* quant.c */,
+				CBF83526B47596AF555F3568 /* quant.c */,
+				93E33A749AD14EB35FF0FA31 /* quant_levels.c */,
+				82A985679CA3614B0380C3FE /* quant_levels.h */,
+				E9306DBC766A410DEB9FE244 /* quant_levels_dec.c */,
+				087F18EDDE14738AFA0DDE34 /* quant_levels_dec.h */,
+				E3E3AB245A8B79CE36BEC5FD /* random.c */,
+				6D216038D4F2854B984836EC /* random.h */,
+				1407EC64D8C7B5EEECE36E92 /* rescaler.c */,
+				8F0B93E9AFF81CBDC1DF67FF /* rescaler.h */,
+				15E7C95802E6DE69BEE8E5AD /* syntax.c */,
+				1C5E54F58258FC163E9DB58D /* thread.c */,
+				21697AE0C2D3BD3331E18C7C /* thread.h */,
+				F44130EC03CBF7485A3893D5 /* token.c */,
+				689E7A7FD0DBD72E2A442847 /* tree.c */,
+				B69567060D158C1F209886F5 /* tree.c */,
+				D9547159833CBC732CCB3812 /* upsampling.c */,
+				1DA341475E29949E9E1F1FD2 /* upsampling_neon.c */,
+				FF1697F345EAFE9BAB87FA57 /* upsampling_sse2.c */,
+				B734C7A2E54ADBFA07676BC4 /* utils.c */,
+				3981A1DB34D746BA358AD6DF /* utils.h */,
+				6B666F75709BC40C9919CE52 /* vp8.c */,
+				80D2FDEA75A66CAAF4F92883 /* vp8enci.h */,
+				F848FF815F6381B4598A4754 /* vp8i.h */,
+				D3246710D21CD09EECB84A49 /* vp8l.c */,
+				19B8D39ED8093F36DF9F382D /* vp8l.c */,
+				09602DE75A7F36878BAADD97 /* vp8li.h */,
+				CA17741002D92724228EF02E /* vp8li.h */,
+				ADEAE7778146D46205A810E9 /* webp.c */,
+				F0439236E5F84F76084E03DE /* webpenc.c */,
+				B6753CEF9354FFBF78BD5589 /* webpi.h */,
+				1F99244BFB5A12D8FC97DD05 /* yuv.c */,
+				0A2EC7121145E3C367671823 /* yuv.h */,
+				CA246AF1170C21E027452AA1 /* yuv_mips32.c */,
+				76A92B34446E65667CFB54E7 /* yuv_sse2.c */,
+				144925D10E355A3E8BE1A241 /* yuv_tables_sse2.h */,
+			);
+			name = core;
+			sourceTree = "<group>";
+		};
+		B2F5D34663113574FDD05E06 /* PINCache */ = {
+			isa = PBXGroup;
+			children = (
+				E1203C33444213664EFBBA4A /* Nullability.h */,
+				20922081B66F6E8488BBED5E /* PINCache.h */,
+				0D616041EDA8195E90AA3B12 /* PINCache.m */,
+				70A29F94C3D7EC574411A698 /* PINDiskCache.h */,
+				002E645F13D022F93A6F4741 /* PINDiskCache.m */,
+				F35DA2684502C2DCA27B2622 /* PINMemoryCache.h */,
+				6474AA66BB8A5F68F4A1C58C /* PINMemoryCache.m */,
+				7D791E2E41CA4D83D6C110DF /* Support Files */,
+			);
+			path = PINCache;
+			sourceTree = "<group>";
+		};
+		B8E7B9418A5D88DB68DEF102 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				1B6D33994F2345AAF8BF88CB /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		C98218DABDF70E628459711D /* iOS */ = {
+		CE50ECDFB216E87421C17E9E = {
 			isa = PBXGroup;
 			children = (
-				552E2501DEA1D5FF4D546641 /* CoreGraphics.framework */,
-				AF597D47CB4B1E04C0C842AE /* CoreImage.framework */,
-				A630F2BD1F71D2770EDE64F1 /* Foundation.framework */,
-				3E92039A90C94272C2A02B76 /* ImageIO.framework */,
-				8C918AA802ABFAC8226860B6 /* MobileCoreServices.framework */,
-				DFBD9176C89D30344D2B806F /* QuartzCore.framework */,
-				5A8EBA7E7FBC35B9A8A30394 /* UIKit.framework */,
+				5400A05E3878D813E75EF8E7 /* Podfile */,
+				F0B448D649CCC4C0B6EC3464 /* Development Pods */,
+				B8E7B9418A5D88DB68DEF102 /* Frameworks */,
+				2A54D088E20828909A586A91 /* Pods */,
+				7E2DB78B2628F08A868D6133 /* Products */,
+				4D033860B0A0D190DBB4FDC3 /* Targets Support Files */,
 			);
-			name = iOS;
 			sourceTree = "<group>";
 		};
-		CE7C2F76BE52852C0CAAE2B4 /* demux */ = {
+		DDC2A8DA20DD3A4507EA6456 /* FLAnimatedImage */ = {
 			isa = PBXGroup;
 			children = (
-				346173EF458AB3CC7954C971 /* demux.c */,
+				0C724182A5C7452AEDA21A4E /* Pod */,
+			);
+			name = FLAnimatedImage;
+			sourceTree = "<group>";
+		};
+		E4F34FA4EA18DEA591065B0E /* demux */ = {
+			isa = PBXGroup;
+			children = (
+				B159B32D332AF016E70CC8A7 /* demux.c */,
 			);
 			name = demux;
 			sourceTree = "<group>";
 		};
-		F7CACD4BB65B267056016BD9 /* FLAnimatedImage */ = {
+		E5059A54D4A9FD6B68F41F4C /* libwebp */ = {
 			isa = PBXGroup;
 			children = (
-				D5034A475CE1A83DBD5A266D /* FLAnimatedImage.h */,
-				23F0490B87B4E6252878FBEB /* FLAnimatedImage.m */,
-				F2A7F6385B5C12F6E745363F /* FLAnimatedImageView.h */,
-				2EEA4C04C3D3B4300C80329B /* FLAnimatedImageView.m */,
-				2D53354F481A370D0E8FB97E /* Support Files */,
+				047D003FCC5B22BFBA6BD894 /* Support Files */,
+				AC3399B6329F6CCCB31BC38C /* core */,
+				E4F34FA4EA18DEA591065B0E /* demux */,
+				77637823CD5CEE91C19734EE /* mux */,
+				43424CB078126B7B191FCA02 /* webp */,
 			);
-			path = FLAnimatedImage;
+			path = libwebp;
+			sourceTree = "<group>";
+		};
+		ED7FC02E12719EFDB1976458 /* Classes */ = {
+			isa = PBXGroup;
+			children = (
+				17B6CD3E93D772ED295F4B1E /* Image Categories */,
+			);
+			path = Classes;
+			sourceTree = "<group>";
+		};
+		F0B448D649CCC4C0B6EC3464 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				4B78C17BBEE78978530A7D9F /* PINRemoteImage */,
+			);
+			name = "Development Pods";
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		02B01EBDC310F780D3048567 /* Headers */ = {
+		2B9725413C8DBD4891A12D87 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B4638F1ADF6217E591D734B9 /* FLAnimatedImage.h in Headers */,
-				EFF6C10276463A52A6716DAE /* FLAnimatedImageView.h in Headers */,
+				A52D4E44A79B321DEBE77B67 /* FLAnimatedImageView+PINRemoteImage.h in Headers */,
+				768951F25AACC4C5700F1063 /* NSData+ImageDetectors.h in Headers */,
+				2B1BC64717D178330CFC578A /* PINDataTaskOperation.h in Headers */,
+				31FE5C2018CF8D763F811E9A /* PINProgressiveImage.h in Headers */,
+				0F0776A8ED667DFE43F929AC /* PINRemoteImage.h in Headers */,
+				834DE17ACBF8F7DF47502529 /* PINRemoteImageCallbacks.h in Headers */,
+				290BFE8937FB52B0278319EF /* PINRemoteImageCategoryManager.h in Headers */,
+				429FB969ADDF192DAF1908E6 /* PINRemoteImageDownloadTask.h in Headers */,
+				17FDB2E0321B5C77B4660C84 /* PINRemoteImageManager.h in Headers */,
+				A7D06AA24B82C419510E8C95 /* PINRemoteImageManagerResult.h in Headers */,
+				DA98678757C16FA051ADDE77 /* PINRemoteImageProcessorTask.h in Headers */,
+				E7FB8896DB8267925DE74239 /* PINRemoteImageTask.h in Headers */,
+				6A74A0FC7FBD2F1E170F0555 /* PINURLSessionManager.h in Headers */,
+				B3881C4B6507049757C03E7B /* UIButton+PINRemoteImage.h in Headers */,
+				3A667F5DB9EAA37E3E82430D /* UIImage+DecodedImage.h in Headers */,
+				F7D4A49A55F04288B8BB4267 /* UIImage+WebP.h in Headers */,
+				B26C0C30161901317C2180D0 /* UIImageView+PINRemoteImage.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		258F85000B39B866AE688031 /* Headers */ = {
+		3AC6F166729196AFAE8749ED /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F77E440DD7BB095548FE87B /* alphai.h in Headers */,
-				6DEB8D6D7721862B77E8A5BD /* backward_references.h in Headers */,
-				340B3059EF0755A4E8825E40 /* bit_reader.h in Headers */,
-				DBD7A7FAC4662D051090FE92 /* bit_reader_inl.h in Headers */,
-				ABC0E892EF6CC46D1CDFF1A2 /* bit_writer.h in Headers */,
-				9C16E59B13D9D76F15B56FA4 /* color_cache.h in Headers */,
-				81E788130BC000A57FD4644B /* cost.h in Headers */,
-				C8242C1CB93BCDF55AF0FCB4 /* decode.h in Headers */,
-				70F08C4452062BD2F6BD6B31 /* decode_vp8.h in Headers */,
-				0B800FFA419BE7E44FDF7C44 /* demux.h in Headers */,
-				1D5FBEDA3E96670F25C103BE /* dsp.h in Headers */,
-				FD6A6971FE246D8429F967EE /* encode.h in Headers */,
-				71C6D3D6C19E9D3FE859323F /* endian_inl.h in Headers */,
-				9FFEEDB7EADA66A7FC83D5F5 /* filters.h in Headers */,
-				3E5BE37A2E6CB447344BE483 /* format_constants.h in Headers */,
-				F4906FF2987F2F0C21FC2E33 /* histogram.h in Headers */,
-				765B868DE0740CC3F4D4C3FC /* huffman.h in Headers */,
-				19AB195DCDE1CB2027D0AC27 /* huffman_encode.h in Headers */,
-				74294FD7FCE7FD3FE8B4EFF6 /* lossless.h in Headers */,
-				7749C2E2A627DB14EFD50599 /* mux.h in Headers */,
-				EC1E5FB40654D64036F81695 /* mux_types.h in Headers */,
-				651B38ED00E99D242CB50E33 /* muxi.h in Headers */,
-				4B33CB767CBB664BA94349BB /* neon.h in Headers */,
-				CA8407E30DF275F352A0D37E /* quant_levels.h in Headers */,
-				5FEBFA9AAF8D6AAB05FEC5EB /* quant_levels_dec.h in Headers */,
-				B62EC6867B80887DCE72C303 /* random.h in Headers */,
-				C7E6F559B263FB2FCB824DC2 /* rescaler.h in Headers */,
-				1F21EF06F42D05B5AF8008AD /* thread.h in Headers */,
-				9F3E1B812C1144840576267D /* types.h in Headers */,
-				81070459F2657F4CA4D7C764 /* utils.h in Headers */,
-				071394E9A2D7E90AB453B61F /* vp8enci.h in Headers */,
-				A9A5E530578D4D45A35D71D7 /* vp8i.h in Headers */,
-				D39C8A6403AC467B20D41AB2 /* vp8li.h in Headers */,
-				FB863628DF97264623E1E2D2 /* vp8li.h in Headers */,
-				75CC8BD0F7142BD54977A577 /* webpi.h in Headers */,
-				F7FA1D61E8C733C1320F20C2 /* yuv.h in Headers */,
-				DDEA111953BE877A78C9C7D1 /* yuv_tables_sse2.h in Headers */,
+				5F373ABF4818F0C7504A4511 /* Nullability.h in Headers */,
+				F2D3193EE3A321CB5C0CE19E /* PINCache.h in Headers */,
+				B4732C21CF338F14B670C8B5 /* PINDiskCache.h in Headers */,
+				44FE2AD3DD8D8B2C929AE88F /* PINMemoryCache.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		31C55D2EAE2A3DE27E75848B /* Headers */ = {
+		3EDA6A3658B5C1F32F81A255 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C4877E8D985BC3B401661D01 /* Nullability.h in Headers */,
-				D70CC57C9C8388C257E675F5 /* PINCache.h in Headers */,
-				DB7A2A7F9B8FBBB663A5B941 /* PINDiskCache.h in Headers */,
-				3EB55E1FE95A40BCB71E1F3D /* PINMemoryCache.h in Headers */,
+				4ADD232FBE2F89BC5ADFD682 /* FLAnimatedImage.h in Headers */,
+				71CE3F7BC83FB693C9949743 /* FLAnimatedImageView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		6EF1DDE1D515A4A3EBA4ABC3 /* Headers */ = {
+		5B6A8D0F5056F5E4A0BC3CA9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3D47A9C56E09B2F9FB3D7A6A /* Nullability.h in Headers */,
-				CB3FE2781B31BE4381BF0836 /* PINCache.h in Headers */,
-				05A44ACCF1D4B12E5D08BB82 /* PINDiskCache.h in Headers */,
-				C41AD8E758852CB0AF390918 /* PINMemoryCache.h in Headers */,
+				4D9F41FAE0E55A61575CB6C0 /* FLAnimatedImageView+PINRemoteImage.h in Headers */,
+				2718C7039BD569D2D72CBE15 /* NSData+ImageDetectors.h in Headers */,
+				9CC58478CEB46E74482FB72E /* PINDataTaskOperation.h in Headers */,
+				28A7A89FFF79424001E7B4E8 /* PINProgressiveImage.h in Headers */,
+				1039361A8DC38000BC3F0B54 /* PINRemoteImage.h in Headers */,
+				9CBA24A5AD4D7E979FED7351 /* PINRemoteImageCallbacks.h in Headers */,
+				6BECB8DAA9022040EF9BD60B /* PINRemoteImageCategoryManager.h in Headers */,
+				1ED0BA8F53C46113B4CE8CD0 /* PINRemoteImageDownloadTask.h in Headers */,
+				8FE78EF57EA97BA8DD25F70B /* PINRemoteImageManager.h in Headers */,
+				ED97598DCB5583CC12003275 /* PINRemoteImageManagerResult.h in Headers */,
+				1639EB89362F26983A3ADAB1 /* PINRemoteImageProcessorTask.h in Headers */,
+				AE3652CD1F191E9C0FFFC663 /* PINRemoteImageTask.h in Headers */,
+				4D46AA2D4BE43932E44F1813 /* PINURLSessionManager.h in Headers */,
+				5F834A5AA2C65DE1D99706A5 /* UIButton+PINRemoteImage.h in Headers */,
+				449422162A22BEF80CE6340A /* UIImage+DecodedImage.h in Headers */,
+				AC9A2BC35B1AE01CF9A13688 /* UIImage+WebP.h in Headers */,
+				F1AC3F7D7A76846C2ACDB15F /* UIImageView+PINRemoteImage.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		72309B769381AB0B8122BF1D /* Headers */ = {
+		6AFB8E519AEDB3B2E529C698 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9E6D22EDBA54DC6B2C76F448 /* FLAnimatedImage.h in Headers */,
-				36440D4539BBEF9AEC547538 /* FLAnimatedImageView.h in Headers */,
+				975BD3E7D212A71A7B8D530C /* Nullability.h in Headers */,
+				EA49D86AC8590CAD09094908 /* PINCache.h in Headers */,
+				D0B3598596C081BEEDE60E91 /* PINDiskCache.h in Headers */,
+				734D71CA72D6C3256C05B1B5 /* PINMemoryCache.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		97F79D23F9C3D185180D04EE /* Headers */ = {
+		A64052F698DB68379D4047C9 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				6C9225359621B71E106B3F09 /* FLAnimatedImageView+PINRemoteImage.h in Headers */,
-				8CCC709D28D8201C416A9F32 /* NSData+ImageDetectors.h in Headers */,
-				24CBC6A66DBBBEA6521169CB /* PINDataTaskOperation.h in Headers */,
-				DA083E9EAFE7D36F9D112CDF /* PINProgressiveImage.h in Headers */,
-				83CE5381D7DFB92A632AEF96 /* PINRemoteImage.h in Headers */,
-				B550F567643922FC52BDAB1F /* PINRemoteImageCallbacks.h in Headers */,
-				061A9040BEBAC4289EC7067F /* PINRemoteImageCategoryManager.h in Headers */,
-				2D9614617591E28BAF49AFBB /* PINRemoteImageDownloadTask.h in Headers */,
-				E01855C898ACEFF3AF632E0A /* PINRemoteImageManager.h in Headers */,
-				B45B4F8CB1585F6921184A1F /* PINRemoteImageManagerResult.h in Headers */,
-				736F1C1F357DEE6B98B253DA /* PINRemoteImageProcessorTask.h in Headers */,
-				9DF27DD7993B1C1940CE84B5 /* PINRemoteImageTask.h in Headers */,
-				9AA558573975E619CB64AA2F /* PINURLSessionManager.h in Headers */,
-				DA567EF5C549B7A2F6EC9A03 /* UIButton+PINRemoteImage.h in Headers */,
-				51EC3814C66CFBF2DB052389 /* UIImage+DecodedImage.h in Headers */,
-				63E534AA9FE752F1318D01EE /* UIImage+WebP.h in Headers */,
-				B97D3BAE3154F0FD9D503CDB /* UIImageView+PINRemoteImage.h in Headers */,
+				B99582F0E55F42083AD849BA /* alphai.h in Headers */,
+				502F76EDFB4C686E216EC1A4 /* backward_references.h in Headers */,
+				776A69B0D76AB664F7F8C2C5 /* bit_reader.h in Headers */,
+				5F80A9CA3FEB4E7A2D9DAB43 /* bit_reader_inl.h in Headers */,
+				2C7926679D9F093E5B5E7872 /* bit_writer.h in Headers */,
+				ABC8D6E481B0526AB6E698EA /* color_cache.h in Headers */,
+				1309A2B6B06085B3B355C0E0 /* cost.h in Headers */,
+				1BA6BD982BEF6F7C3B283233 /* decode.h in Headers */,
+				FE4FA9A2E8248F24BBD05AB0 /* decode_vp8.h in Headers */,
+				A34BA2AA2669AA6867E3B7FD /* demux.h in Headers */,
+				B8E04E8257B101C8A6FA8DD3 /* dsp.h in Headers */,
+				AAF9FA05021E7AB39F6A5874 /* encode.h in Headers */,
+				6C073AC6E70647AB6F0B14CB /* endian_inl.h in Headers */,
+				C5DDC4B7EC3D4BC785475E68 /* filters.h in Headers */,
+				FAE53B5BA4810E35FFA40C76 /* format_constants.h in Headers */,
+				2D6D90420C4593D3D172F715 /* histogram.h in Headers */,
+				4A646D1FCB9EB587E7E6A944 /* huffman.h in Headers */,
+				18DEFCF80BC5FDAD7911AF18 /* huffman_encode.h in Headers */,
+				67CBBC11C09F58F097DC7CF9 /* lossless.h in Headers */,
+				9B5A7F03545E3300D5F34D21 /* mux.h in Headers */,
+				E8EBD27D0602DF32F300058D /* mux_types.h in Headers */,
+				88407AE3419406A8E423CC94 /* muxi.h in Headers */,
+				9F5B7696626644B235148F67 /* neon.h in Headers */,
+				7D607B4AE983AB06DF907CD9 /* quant_levels.h in Headers */,
+				19A4848B0874302A689A112D /* quant_levels_dec.h in Headers */,
+				B7E111BBD287134CEE234D0D /* random.h in Headers */,
+				2897134AD66AA1968F4E53D9 /* rescaler.h in Headers */,
+				EE9C6CEE3D4EA6093D39C2FB /* thread.h in Headers */,
+				A3E1DBF32A0F147009038347 /* types.h in Headers */,
+				E07225ACF06EEC18220A1951 /* utils.h in Headers */,
+				0C27D04DBE80E4B0A415AF87 /* vp8enci.h in Headers */,
+				426DB38A5E431594FBA1251F /* vp8i.h in Headers */,
+				DA0B41B0F7D59A7693E6F290 /* vp8li.h in Headers */,
+				60DCCF537097A8ECF30C9DE1 /* vp8li.h in Headers */,
+				C6CC8E22A26ED28CF6924883 /* webpi.h in Headers */,
+				3D5C2A89984D602525598E79 /* yuv.h in Headers */,
+				1784D7E77879218E94E0B882 /* yuv_tables_sse2.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A2587605568E530D5FB16DD4 /* Headers */ = {
+		F76EB747D4F8AFB902B7BE6F /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C1FC43AB9056822941E1D4FC /* FLAnimatedImageView+PINRemoteImage.h in Headers */,
-				7EEC24F009FF8C7727816E0F /* NSData+ImageDetectors.h in Headers */,
-				97253DF7650256EDB9125FC4 /* PINDataTaskOperation.h in Headers */,
-				E2BD09BC5C2745EE7BDA3AB9 /* PINProgressiveImage.h in Headers */,
-				0EAC1A52B33B6BA85FF07B61 /* PINRemoteImage.h in Headers */,
-				B33FBBD67D54D89DA7CF305A /* PINRemoteImageCallbacks.h in Headers */,
-				72AF1E7CF3B95FB29B34057F /* PINRemoteImageCategoryManager.h in Headers */,
-				21496AE6AB151B4DB7EF0B83 /* PINRemoteImageDownloadTask.h in Headers */,
-				CBA6BCBA6E28729E5AF0E0AC /* PINRemoteImageManager.h in Headers */,
-				29FC2389E4DE15D2F14CD4E4 /* PINRemoteImageManagerResult.h in Headers */,
-				B5B956331152ED3C3536E8A5 /* PINRemoteImageProcessorTask.h in Headers */,
-				6F11D0DCD64802E800D6D3EA /* PINRemoteImageTask.h in Headers */,
-				887469D6291AE451CA98A703 /* PINURLSessionManager.h in Headers */,
-				0197CBC730CF67F7323448F1 /* UIButton+PINRemoteImage.h in Headers */,
-				F3B32880B6C5F4BF91409903 /* UIImage+DecodedImage.h in Headers */,
-				338BBEC9C9DE309682D8B684 /* UIImage+WebP.h in Headers */,
-				58342E5F6C37034E21B64361 /* UIImageView+PINRemoteImage.h in Headers */,
+				220E2C72171C43F2995C09C4 /* FLAnimatedImage.h in Headers */,
+				B1D51A993DB2AF1352E7FE85 /* FLAnimatedImageView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		3091AE0AB69637A0D4873AB2 /* Pods-PINRemoteImage-FLAnimatedImage */ = {
+		0739948874D2178089A48DAB /* Pods-PINRemoteImage-PINRemoteImage */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 75547B89AF6DD2C86CBBE6E4 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-FLAnimatedImage" */;
+			buildConfigurationList = A9B09B70693E901D91217F70 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINRemoteImage" */;
 			buildPhases = (
-				33EE0F287B3BA5F457351474 /* Sources */,
-				CB21B6A54B45FF22AAFE5402 /* Frameworks */,
-				02B01EBDC310F780D3048567 /* Headers */,
+				F477C3FA3B0EFF5E47674C52 /* Sources */,
+				185C03DD2EF8082EB1D0BECC /* Frameworks */,
+				2B9725413C8DBD4891A12D87 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-			);
-			name = "Pods-PINRemoteImage-FLAnimatedImage";
-			productName = "Pods-PINRemoteImage-FLAnimatedImage";
-			productReference = 1EACD96D29F76543863D3569 /* libPods-PINRemoteImage-FLAnimatedImage.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		822D6AA9F3EEB56D9A1868C7 /* Pods-PINRemoteImage Tests-FLAnimatedImage */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = BC019F4DBE5BDE83695BB8C5 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-FLAnimatedImage" */;
-			buildPhases = (
-				AF86B0BA5B8FD80DA96626B4 /* Sources */,
-				0DCC6ACE6F99432CD3EFDAB3 /* Frameworks */,
-				72309B769381AB0B8122BF1D /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-PINRemoteImage Tests-FLAnimatedImage";
-			productName = "Pods-PINRemoteImage Tests-FLAnimatedImage";
-			productReference = 0B8D02298330B527A6514B03 /* libPods-PINRemoteImage Tests-FLAnimatedImage.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		9C0680BEE34556A8023EB5DB /* Pods-PINRemoteImage Tests-PINRemoteImage */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = B7EA2295E687812B213E3D2F /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINRemoteImage" */;
-			buildPhases = (
-				5EF5218F4E18E6AFFB60B328 /* Sources */,
-				F466A43CACA5C18FA42092D0 /* Frameworks */,
-				A2587605568E530D5FB16DD4 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				1E8FA8D730984ABBE6750582 /* PBXTargetDependency */,
-				721872E31F9769FCA457482A /* PBXTargetDependency */,
-			);
-			name = "Pods-PINRemoteImage Tests-PINRemoteImage";
-			productName = "Pods-PINRemoteImage Tests-PINRemoteImage";
-			productReference = 4A145FA49DADFFF932CDC5D8 /* libPods-PINRemoteImage Tests-PINRemoteImage.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		CC94048850625CD07E3A98AF /* Pods-PINRemoteImage */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = D03E483EC878F703DBE412FB /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage" */;
-			buildPhases = (
-				DD71D3B78E58FF2B1AE9687C /* Sources */,
-				A289FB48945394243379119D /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				5376B5ACE40A358E125E6ECB /* PBXTargetDependency */,
-				9CD46119887C572C01EA9E9C /* PBXTargetDependency */,
-				580BCF913BD34F693C827590 /* PBXTargetDependency */,
-				09A0E5DD6198192BCD132C48 /* PBXTargetDependency */,
-			);
-			name = "Pods-PINRemoteImage";
-			productName = "Pods-PINRemoteImage";
-			productReference = 2F528C47A9C3F7EA24BDA087 /* libPods-PINRemoteImage.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		E2D5B251DE893D5F1C3EE94E /* Pods-PINRemoteImage Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 32AAFE41438F2B0B7BEA013F /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests" */;
-			buildPhases = (
-				BE94098258B7313EE31894FA /* Sources */,
-				6BFC97E1971876D775E63628 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				0456C70A339CEDB6876AE88B /* PBXTargetDependency */,
-				01ABA40276E6ED582397117C /* PBXTargetDependency */,
-				7BD1A0A1B8AA49C5FC8A06A9 /* PBXTargetDependency */,
-			);
-			name = "Pods-PINRemoteImage Tests";
-			productName = "Pods-PINRemoteImage Tests";
-			productReference = 8836086BE0571D96DC238C49 /* libPods-PINRemoteImage Tests.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		E6C155F0A4EA8DC094A3DF98 /* Pods-PINRemoteImage-PINRemoteImage */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 06DB3B8C0FC88028ACA801AF /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINRemoteImage" */;
-			buildPhases = (
-				9DE3D333E5B6ECB0B6385577 /* Sources */,
-				4C7D950DC0A94C34FD450F22 /* Frameworks */,
-				97F79D23F9C3D185180D04EE /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				27916BE8F9D2300947238600 /* PBXTargetDependency */,
-				B39F85DE3BD404CA8197EA63 /* PBXTargetDependency */,
+				1C3160C8EA921646EACF5C66 /* PBXTargetDependency */,
+				2D162B68D1B4D8F6BAA9D0AA /* PBXTargetDependency */,
 			);
 			name = "Pods-PINRemoteImage-PINRemoteImage";
 			productName = "Pods-PINRemoteImage-PINRemoteImage";
-			productReference = 4229FF266ED020C34ADE3FF4 /* libPods-PINRemoteImage-PINRemoteImage.a */;
+			productReference = CD4111DE5C2F3E6C4DB3DB0A /* libPods-PINRemoteImage-PINRemoteImage.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		F5893B7048FAF770D6678D64 /* Pods-PINRemoteImage Tests-PINCache */ = {
+		14B3D7A15815181781AE6658 /* Pods-PINRemoteImage */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9711009A1C86EE5C927B6C7F /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINCache" */;
+			buildConfigurationList = EE0FFB1BDD036DB92A01C5BA /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage" */;
 			buildPhases = (
-				A08F9719ED91879299FE5298 /* Sources */,
-				AD062D9023A7A4627CD8C89D /* Frameworks */,
-				31C55D2EAE2A3DE27E75848B /* Headers */,
+				50C6979908A2C9ABD86C14B5 /* Sources */,
+				D5D85E8FAB9A4251B04904C9 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				85500A0B211E12E801ACED38 /* PBXTargetDependency */,
+				1DF13F402798A780A1596CA5 /* PBXTargetDependency */,
+				F62EA02C01638BDBFD23FE79 /* PBXTargetDependency */,
+				C4C839404F8D54DA46F45E12 /* PBXTargetDependency */,
 			);
-			name = "Pods-PINRemoteImage Tests-PINCache";
-			productName = "Pods-PINRemoteImage Tests-PINCache";
-			productReference = D33C1A5B01870B4800B5235C /* libPods-PINRemoteImage Tests-PINCache.a */;
+			name = "Pods-PINRemoteImage";
+			productName = "Pods-PINRemoteImage";
+			productReference = 33E104AB4034A41A4255712F /* libPods-PINRemoteImage.a */;
 			productType = "com.apple.product-type.library.static";
 		};
-		F87A88BDC23AD1F92436E1A8 /* Pods-PINRemoteImage-PINCache */ = {
+		2C24A84F297BD8FD6532997F /* Pods-PINRemoteImage-libwebp */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = CE90B53799B6BB173134A8DC /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINCache" */;
+			buildConfigurationList = 765CB9E84250CC6DFE96ED58 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-libwebp" */;
 			buildPhases = (
-				B7821E1C2DBC66EEDFCD98A0 /* Sources */,
-				75D1BE51C9E2A1F66B964D53 /* Frameworks */,
-				6EF1DDE1D515A4A3EBA4ABC3 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Pods-PINRemoteImage-PINCache";
-			productName = "Pods-PINRemoteImage-PINCache";
-			productReference = 79A0AD133AA88607F24D0F9C /* libPods-PINRemoteImage-PINCache.a */;
-			productType = "com.apple.product-type.library.static";
-		};
-		FD5C94A81700C30D9BE32245 /* Pods-PINRemoteImage-libwebp */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 3B15CF5C66B260D0C7328CD1 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-libwebp" */;
-			buildPhases = (
-				9ECD4AE567C4F53B1862DDCE /* Sources */,
-				D0CEE17379E8B518A0869D68 /* Frameworks */,
-				258F85000B39B866AE688031 /* Headers */,
+				1A47F58E87C074A2EA774ED0 /* Sources */,
+				272EC8A4CCEDC9AE0DE180C2 /* Frameworks */,
+				A64052F698DB68379D4047C9 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1328,477 +1262,405 @@
 			);
 			name = "Pods-PINRemoteImage-libwebp";
 			productName = "Pods-PINRemoteImage-libwebp";
-			productReference = 88FF0BCA882181B2621D583C /* libPods-PINRemoteImage-libwebp.a */;
+			productReference = D5F74434FF1207341EDE81EA /* libPods-PINRemoteImage-libwebp.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		940E8008C17E41E278D7FE97 /* Pods-PINRemoteImage Tests-PINCache */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DEE42D991AE0D8C0C421AC04 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINCache" */;
+			buildPhases = (
+				36DC0FF597E38BEAB1DF164B /* Sources */,
+				547FA4E24C38B1DCE5C91716 /* Frameworks */,
+				6AFB8E519AEDB3B2E529C698 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-PINRemoteImage Tests-PINCache";
+			productName = "Pods-PINRemoteImage Tests-PINCache";
+			productReference = 714E51E3AE4DE85982C50E85 /* libPods-PINRemoteImage Tests-PINCache.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		9D5D69DDEABF36FE56E607B6 /* Pods-PINRemoteImage Tests-PINRemoteImage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B72860EB4AD5B2CDA814A1C9 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINRemoteImage" */;
+			buildPhases = (
+				FD50C1DF3E0D1590BCBFC179 /* Sources */,
+				BF61F3AC74100665B93EFA34 /* Frameworks */,
+				5B6A8D0F5056F5E4A0BC3CA9 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				115F19B3FD68A2D4A0491173 /* PBXTargetDependency */,
+				28DCEB90912B4F8FFA780F41 /* PBXTargetDependency */,
+			);
+			name = "Pods-PINRemoteImage Tests-PINRemoteImage";
+			productName = "Pods-PINRemoteImage Tests-PINRemoteImage";
+			productReference = 3E680AE1CCDE78F1DCADC0E9 /* libPods-PINRemoteImage Tests-PINRemoteImage.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		ADE1074A6F3EBF9B00A11E22 /* Pods-PINRemoteImage-FLAnimatedImage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA0956AAD29CC7F7AC2BAEE9 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-FLAnimatedImage" */;
+			buildPhases = (
+				C84AC49BDC745DB340AA56D7 /* Sources */,
+				F6E9111C7A379B3D805ED398 /* Frameworks */,
+				F76EB747D4F8AFB902B7BE6F /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-PINRemoteImage-FLAnimatedImage";
+			productName = "Pods-PINRemoteImage-FLAnimatedImage";
+			productReference = 6340D3CAA7D6DAF3C71B35F2 /* libPods-PINRemoteImage-FLAnimatedImage.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		C82F0D26AC43E8178B238108 /* Pods-PINRemoteImage Tests-FLAnimatedImage */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 78BBD5380B17B654FC72304B /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-FLAnimatedImage" */;
+			buildPhases = (
+				5778CB3C46CD5AB456632447 /* Sources */,
+				F509AD47812FD39DEB427EFB /* Frameworks */,
+				3EDA6A3658B5C1F32F81A255 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-PINRemoteImage Tests-FLAnimatedImage";
+			productName = "Pods-PINRemoteImage Tests-FLAnimatedImage";
+			productReference = 0B7ABD9330244439263A3473 /* libPods-PINRemoteImage Tests-FLAnimatedImage.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F5BD80853C6CC61691FF8C4E /* Pods-PINRemoteImage-PINCache */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 6DBB7297281F7BEBE00AC8A1 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINCache" */;
+			buildPhases = (
+				358BE68D1B1F57677C041DEF /* Sources */,
+				264AD7C9BFFD7F59FDE49DED /* Frameworks */,
+				3AC6F166729196AFAE8749ED /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Pods-PINRemoteImage-PINCache";
+			productName = "Pods-PINRemoteImage-PINCache";
+			productReference = A3BCD15CA8A565B85FF6030C /* libPods-PINRemoteImage-PINCache.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		F813C1702E7DCE89D65A2779 /* Pods-PINRemoteImage Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5DA8D032C2B20B395A2DF610 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests" */;
+			buildPhases = (
+				F53D748E2E579F06CD9D9531 /* Sources */,
+				9E489CBDFFEA8227BEA9EA54 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BF3CB6A7508919A47C5F5029 /* PBXTargetDependency */,
+				A7FA5DDDDEA406B97F32A240 /* PBXTargetDependency */,
+				7DCA461E9362EB5D7BCF7893 /* PBXTargetDependency */,
+			);
+			name = "Pods-PINRemoteImage Tests";
+			productName = "Pods-PINRemoteImage Tests";
+			productReference = 0C6FDE0B01639746C4190D2C /* libPods-PINRemoteImage Tests.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		96ACB2D0C4443E8617339972 /* Project object */ = {
+		A3672C3787DE3FDF78D98167 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 0640;
 			};
-			buildConfigurationList = 8191C0C1E6C7B487BB5C7690 /* Build configuration list for PBXProject "Pods" */;
+			buildConfigurationList = 581D14EC287103D51B5EB83C /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = B35571BC9AE21DD5D7F121E7;
-			productRefGroup = 1882C16303FDBFA19DE57D14 /* Products */;
+			mainGroup = CE50ECDFB216E87421C17E9E;
+			productRefGroup = 7E2DB78B2628F08A868D6133 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				CC94048850625CD07E3A98AF /* Pods-PINRemoteImage */,
-				E2D5B251DE893D5F1C3EE94E /* Pods-PINRemoteImage Tests */,
-				822D6AA9F3EEB56D9A1868C7 /* Pods-PINRemoteImage Tests-FLAnimatedImage */,
-				F5893B7048FAF770D6678D64 /* Pods-PINRemoteImage Tests-PINCache */,
-				9C0680BEE34556A8023EB5DB /* Pods-PINRemoteImage Tests-PINRemoteImage */,
-				3091AE0AB69637A0D4873AB2 /* Pods-PINRemoteImage-FLAnimatedImage */,
-				F87A88BDC23AD1F92436E1A8 /* Pods-PINRemoteImage-PINCache */,
-				E6C155F0A4EA8DC094A3DF98 /* Pods-PINRemoteImage-PINRemoteImage */,
-				FD5C94A81700C30D9BE32245 /* Pods-PINRemoteImage-libwebp */,
+				14B3D7A15815181781AE6658 /* Pods-PINRemoteImage */,
+				F813C1702E7DCE89D65A2779 /* Pods-PINRemoteImage Tests */,
+				C82F0D26AC43E8178B238108 /* Pods-PINRemoteImage Tests-FLAnimatedImage */,
+				940E8008C17E41E278D7FE97 /* Pods-PINRemoteImage Tests-PINCache */,
+				9D5D69DDEABF36FE56E607B6 /* Pods-PINRemoteImage Tests-PINRemoteImage */,
+				ADE1074A6F3EBF9B00A11E22 /* Pods-PINRemoteImage-FLAnimatedImage */,
+				F5BD80853C6CC61691FF8C4E /* Pods-PINRemoteImage-PINCache */,
+				0739948874D2178089A48DAB /* Pods-PINRemoteImage-PINRemoteImage */,
+				2C24A84F297BD8FD6532997F /* Pods-PINRemoteImage-libwebp */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		33EE0F287B3BA5F457351474 /* Sources */ = {
+		1A47F58E87C074A2EA774ED0 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				76BCE3E059394D6D1D347307 /* FLAnimatedImage.m in Sources */,
-				ED852B868D28A078173D81CB /* FLAnimatedImageView.m in Sources */,
-				8BAAA5770646EB41DF287D35 /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m in Sources */,
+				F1BC71D3175D615B0FB8BE47 /* Pods-PINRemoteImage-libwebp-dummy.m in Sources */,
+				B1FAAA2CBFFC1D0C3CF91F06 /* alpha.c in Sources */,
+				67034F7E2233E37A66BE3DDB /* alpha.c in Sources */,
+				616B2FCF4511787570111153 /* alpha_processing.c in Sources */,
+				BF8F9334AEDC834BE8A7485B /* alpha_processing_sse2.c in Sources */,
+				1D4D8D1639B7AB607CA699A1 /* analysis.c in Sources */,
+				F16607BACDA2BC9800E5398F /* backward_references.c in Sources */,
+				0DFB6C60173C5C15AC1D38FA /* bit_reader.c in Sources */,
+				546349EC44AB83AD2DC304B1 /* bit_writer.c in Sources */,
+				10EAB51384E3B2D4C9F4BBE9 /* buffer.c in Sources */,
+				1FACE7CE823B276307026136 /* color_cache.c in Sources */,
+				B55C9CD7F56C8FED4EB7D2DA /* config.c in Sources */,
+				2A087E8B391B049CA817FCD2 /* cost.c in Sources */,
+				3A4B90587C21DC8496CDFD12 /* cpu.c in Sources */,
+				9341A3EE4770A2021A623010 /* dec.c in Sources */,
+				81A1CD9E587FBC1C6CF60B9B /* dec_clip_tables.c in Sources */,
+				CA4B0E08B2FF8828E16F1570 /* dec_mips32.c in Sources */,
+				C4CCABFB7C66748AA8395BFB /* dec_neon.c in Sources */,
+				FACEAF29E9A03EE64FDAC472 /* dec_sse2.c in Sources */,
+				D09F6A1A51130F1B0F577E5B /* demux.c in Sources */,
+				EA711583816BBD350522D33F /* enc.c in Sources */,
+				37EFF193DB0A6A78E2144770 /* enc_avx2.c in Sources */,
+				B2CB50EAD4222C724FCC01A7 /* enc_mips32.c in Sources */,
+				B047434439BD4FF516543A66 /* enc_neon.c in Sources */,
+				245FEDF49A2C07CA2BBAD55E /* enc_sse2.c in Sources */,
+				2F1E6CC7F0BCE1057F635633 /* filter.c in Sources */,
+				7EA616756699A10416E952B1 /* filters.c in Sources */,
+				E6099205A1758D5D261D2159 /* frame.c in Sources */,
+				3886C351B66F121EBA77F5A0 /* frame.c in Sources */,
+				0DDB67CBD31E957A1AA82891 /* histogram.c in Sources */,
+				8C0006D0E8AD20967D4F2F73 /* huffman.c in Sources */,
+				C344DDFD6F51C162504063B9 /* huffman_encode.c in Sources */,
+				82D38B2A74C164F43EA2BCAB /* idec.c in Sources */,
+				9D0BC4366F4100E4AC85E6C2 /* io.c in Sources */,
+				A3ACFF80485590ABBAEA7043 /* iterator.c in Sources */,
+				F0C67C2A76BD7E9E99D3BA79 /* lossless.c in Sources */,
+				7B3984A5D367736F91291CDA /* lossless_mips32.c in Sources */,
+				6561FD67E4707F4742AF9812 /* lossless_neon.c in Sources */,
+				29DC979FA0B3C7FA5A05BE4C /* lossless_sse2.c in Sources */,
+				6847D302FC602C48B3399690 /* muxedit.c in Sources */,
+				4BBA352FCE81C71575A35CE0 /* muxinternal.c in Sources */,
+				C9DA08DBB631C364EBBEEA3B /* muxread.c in Sources */,
+				6FDEDCE96DB77348636C7DE8 /* picture.c in Sources */,
+				4D1B6E32A0C3637DAD34F225 /* picture_csp.c in Sources */,
+				4E52E9A0E8A4D891289C3821 /* picture_psnr.c in Sources */,
+				DD513B72568EC3ACCAFD4D23 /* picture_rescale.c in Sources */,
+				E6FEF052E18CCCB6F1E7B9FD /* picture_tools.c in Sources */,
+				73C566B103CEEB928E544F6F /* quant.c in Sources */,
+				F624CDA46624B431F3446050 /* quant.c in Sources */,
+				02C1EE7FC16C22DA88F43AD4 /* quant_levels.c in Sources */,
+				9A1177D25D105D82B7A2610D /* quant_levels_dec.c in Sources */,
+				1348C1D2629B33669915412E /* random.c in Sources */,
+				F9BCA97E9C7FE86C4178A058 /* rescaler.c in Sources */,
+				5BC17DB97C1FD22F67B50F34 /* syntax.c in Sources */,
+				32FC3007865289C23440A2C0 /* thread.c in Sources */,
+				F55E6B101CB9CEB25291F3AC /* token.c in Sources */,
+				F5A4CF9C039719E3A8F20F61 /* tree.c in Sources */,
+				262D233C01550535D6D1CE4D /* tree.c in Sources */,
+				8020BBCD52795F3276BDAEE5 /* upsampling.c in Sources */,
+				697E010A1FA49E1BD1A8A9E3 /* upsampling_neon.c in Sources */,
+				AF1D1309009C5DE1E51386E1 /* upsampling_sse2.c in Sources */,
+				509111ECA6C28ECAF777D66C /* utils.c in Sources */,
+				1E3276533A42252EF7D6A489 /* vp8.c in Sources */,
+				60A0677FE279166C645FC670 /* vp8l.c in Sources */,
+				DB9E5C57D3BF3088EC0D78B5 /* vp8l.c in Sources */,
+				C1DBB812E7CA2BB22FF11E72 /* webp.c in Sources */,
+				F68999095CEA5AF0D090A4F6 /* webpenc.c in Sources */,
+				80FA61337C72D7F2F6918CBE /* yuv.c in Sources */,
+				F4524C0190785A5A78C03F06 /* yuv_mips32.c in Sources */,
+				7FEB47D533CA4FA748FB1264 /* yuv_sse2.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		5EF5218F4E18E6AFFB60B328 /* Sources */ = {
+		358BE68D1B1F57677C041DEF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B54F57EC41A5E476D363157F /* FLAnimatedImageView+PINRemoteImage.m in Sources */,
-				4E6B930997A66BA7B1043388 /* NSData+ImageDetectors.m in Sources */,
-				0054C6CE337A84AD0E622BB9 /* PINDataTaskOperation.m in Sources */,
-				F7955440CC4FE43ED916D3A0 /* PINProgressiveImage.m in Sources */,
-				3DC2CE1C38110A804983DF30 /* PINRemoteImageCallbacks.m in Sources */,
-				4C5CE323C43126945C820B36 /* PINRemoteImageCategoryManager.m in Sources */,
-				3B859B648C0D5320EFCF60A1 /* PINRemoteImageDownloadTask.m in Sources */,
-				D1A158A58AFDBB0A530C3C43 /* PINRemoteImageManager.m in Sources */,
-				0266B36A5E3F5E755360D8EC /* PINRemoteImageManagerResult.m in Sources */,
-				79DA0463AB996C09E6963D5E /* PINRemoteImageProcessorTask.m in Sources */,
-				0AEFC96CA9A31A0CB782452F /* PINRemoteImageTask.m in Sources */,
-				30F0C2A194B72D5585C0CD80 /* PINURLSessionManager.m in Sources */,
-				4EE91A61A934450B3FDE9123 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m in Sources */,
-				B7244A5E9AA190E7EB7A3792 /* UIButton+PINRemoteImage.m in Sources */,
-				F93487AE0A0B97F4F9F4982E /* UIImage+DecodedImage.m in Sources */,
-				4D0F029BB2138036CD5AB328 /* UIImage+WebP.m in Sources */,
-				3834D239A0D8E4B37E9D1320 /* UIImageView+PINRemoteImage.m in Sources */,
+				1CBB8A57DECE7D1B5F13984C /* PINCache.m in Sources */,
+				C48E04228AE5C0764981017F /* PINDiskCache.m in Sources */,
+				5C0E9B49BB49AB0AA590F74F /* PINMemoryCache.m in Sources */,
+				169164E70734BBCFED790329 /* Pods-PINRemoteImage-PINCache-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9DE3D333E5B6ECB0B6385577 /* Sources */ = {
+		36DC0FF597E38BEAB1DF164B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1B73DDCEAB20A277E973A274 /* FLAnimatedImageView+PINRemoteImage.m in Sources */,
-				960C42E79E722B5C103DE7B9 /* NSData+ImageDetectors.m in Sources */,
-				CBC69E75C94F773998E1F3DA /* PINDataTaskOperation.m in Sources */,
-				84AE9536EED15E60A415E543 /* PINProgressiveImage.m in Sources */,
-				94AAE24E56F0BDA7521CEE43 /* PINRemoteImageCallbacks.m in Sources */,
-				CF4B2B37B54BB80AC7C3308A /* PINRemoteImageCategoryManager.m in Sources */,
-				0178EC08ADD2B294DFC39917 /* PINRemoteImageDownloadTask.m in Sources */,
-				4B40953986B40CA0E596A041 /* PINRemoteImageManager.m in Sources */,
-				947D194A3B367DDBBCE50BF1 /* PINRemoteImageManagerResult.m in Sources */,
-				5E071786A135F50D42E3DA5C /* PINRemoteImageProcessorTask.m in Sources */,
-				CCDACA97E4B42AF015F6B610 /* PINRemoteImageTask.m in Sources */,
-				E12118E4BE51B81623038E4F /* PINURLSessionManager.m in Sources */,
-				3D4E83E12858B4EDFAAFC04D /* Pods-PINRemoteImage-PINRemoteImage-dummy.m in Sources */,
-				184C89F41A98C9A714E30789 /* UIButton+PINRemoteImage.m in Sources */,
-				C214A62ED8CC8C05AB9E245B /* UIImage+DecodedImage.m in Sources */,
-				7696F83D8A4D087DE545964C /* UIImage+WebP.m in Sources */,
-				BFD3B06ABF6AA587A0E93444 /* UIImageView+PINRemoteImage.m in Sources */,
+				A748CD750333F452F76DCBCD /* PINCache.m in Sources */,
+				19154C8D5371B3FFE771492F /* PINDiskCache.m in Sources */,
+				BB3110561B651EF130E658EE /* PINMemoryCache.m in Sources */,
+				67163DD0260900C31DCE6636 /* Pods-PINRemoteImage Tests-PINCache-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		9ECD4AE567C4F53B1862DDCE /* Sources */ = {
+		50C6979908A2C9ABD86C14B5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3E07C1262EBFE285E986F41E /* Pods-PINRemoteImage-libwebp-dummy.m in Sources */,
-				13CF04FD47AF50334A7A56E0 /* alpha.c in Sources */,
-				19A0A48CCEAF093F2647F5F4 /* alpha.c in Sources */,
-				D9B132BFBF470111603C7F11 /* alpha_processing.c in Sources */,
-				5428FC7776D9ABAB986C29BC /* alpha_processing_sse2.c in Sources */,
-				01DEB31C00F5F2188B1AD53F /* analysis.c in Sources */,
-				95B422FF46603B1348AD71A6 /* backward_references.c in Sources */,
-				0EED3E2F2DA00E9B83E4D6F1 /* bit_reader.c in Sources */,
-				EF2F505FB3B719C43E67ED33 /* bit_writer.c in Sources */,
-				821FC51B6181E762EC52CF73 /* buffer.c in Sources */,
-				F5EF8CA94A96F67906961FD2 /* color_cache.c in Sources */,
-				4D6C03C0F7ADA1FB10FDC834 /* config.c in Sources */,
-				3E57203A4E0A7A2F61D36886 /* cost.c in Sources */,
-				150A2F31FA767EC5CB8A40DA /* cpu.c in Sources */,
-				F2D7FF6F71741A80867D8899 /* dec.c in Sources */,
-				EDCF10ACB44DF709C73B6B04 /* dec_clip_tables.c in Sources */,
-				8C8BC77F20886A4C1E0C14E1 /* dec_mips32.c in Sources */,
-				5DEE4E890051384A75C6DE4B /* dec_neon.c in Sources */,
-				EF9765DC380EEA12A2A80433 /* dec_sse2.c in Sources */,
-				826F4C9511142A66627C3B8F /* demux.c in Sources */,
-				F537DFF88515D90E8327E408 /* enc.c in Sources */,
-				EF79A8255DA7C465777EB2C4 /* enc_avx2.c in Sources */,
-				F57AE31AE67F8CC414FA1847 /* enc_mips32.c in Sources */,
-				8AF4F1BA79A1F01F81AFE2F4 /* enc_neon.c in Sources */,
-				7DFE11EBFDD2A6BC380F91B6 /* enc_sse2.c in Sources */,
-				1B7B000CC72C8985C38AD02D /* filter.c in Sources */,
-				4D7783783B01E192F3879400 /* filters.c in Sources */,
-				19F66D39D047D85B62CF20A3 /* frame.c in Sources */,
-				A52A40F0D7CD7EA5D18B7554 /* frame.c in Sources */,
-				DB5A11826E1743091C771612 /* histogram.c in Sources */,
-				B1B05353AFEDFC6B9CF47338 /* huffman.c in Sources */,
-				624C08EB10CF5F1E9E937ED5 /* huffman_encode.c in Sources */,
-				919D3A9BD8FDE016E4AED5DC /* idec.c in Sources */,
-				6A7A59E335E277164ED311AD /* io.c in Sources */,
-				6CDE93264A295F1B1FBD5328 /* iterator.c in Sources */,
-				C512506BEC68ED57F34568D3 /* lossless.c in Sources */,
-				FA4D50F968D90739B85224C1 /* lossless_mips32.c in Sources */,
-				474B4E7AD44D9B42470B2034 /* lossless_neon.c in Sources */,
-				508E38DFBAEE452DC930DCE7 /* lossless_sse2.c in Sources */,
-				8B0A0F6BB25922488DE0E57E /* muxedit.c in Sources */,
-				8CDE0C80D02E992838E48752 /* muxinternal.c in Sources */,
-				120DCB47A34E36B1C0E7F6E2 /* muxread.c in Sources */,
-				CFB65695735CFB8342F9CA01 /* picture.c in Sources */,
-				1C82ACAF8DAAB30087625BD9 /* picture_csp.c in Sources */,
-				5180BB722BFD70B2DFD2A246 /* picture_psnr.c in Sources */,
-				EDF6345D40421A1AEF72B73B /* picture_rescale.c in Sources */,
-				99A317CA01A2B3998D0BD47E /* picture_tools.c in Sources */,
-				DD1B5E639FA933CF253DD99B /* quant.c in Sources */,
-				C8A11CDC61F7A6538D1FF85F /* quant.c in Sources */,
-				1E9539593D4AC73E3F82BD3B /* quant_levels.c in Sources */,
-				7DF5222B4E63EA97070927DA /* quant_levels_dec.c in Sources */,
-				43E62E08F8767B8E3B0664FC /* random.c in Sources */,
-				65166FF32752CD4EB006A8B0 /* rescaler.c in Sources */,
-				59CC9A1AD95F1E57F8BFCE68 /* syntax.c in Sources */,
-				169711B2CF880C8C12B9D0ED /* thread.c in Sources */,
-				C1CAEBBD562F75540A0DA82B /* token.c in Sources */,
-				B0C4E0A149A56AE3A7C327BC /* tree.c in Sources */,
-				0AB25D28BE14AC5837C5C78C /* tree.c in Sources */,
-				0B27C597C4A275EFBBE95A6C /* upsampling.c in Sources */,
-				CACA9F18D260194BF52A8ED4 /* upsampling_neon.c in Sources */,
-				DD2BD3DB123636984125A4B3 /* upsampling_sse2.c in Sources */,
-				CE8DC7C818F1EF96F5BF70CF /* utils.c in Sources */,
-				CE5A37825E2FF07B7347631E /* vp8.c in Sources */,
-				C028FEA1867161B489D11F0A /* vp8l.c in Sources */,
-				B3433A17F6AA69B52078F824 /* vp8l.c in Sources */,
-				641331A32A0C70E6C45BD975 /* webp.c in Sources */,
-				ADAD8BB364E7C45007666977 /* webpenc.c in Sources */,
-				8BFAB7AD6811DBCD287F5BC4 /* yuv.c in Sources */,
-				EAD180400E6D19B2950D3B50 /* yuv_mips32.c in Sources */,
-				827DC066E5639E2361380303 /* yuv_sse2.c in Sources */,
+				CF747EC355F3B03B536A935E /* Pods-PINRemoteImage-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		A08F9719ED91879299FE5298 /* Sources */ = {
+		5778CB3C46CD5AB456632447 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4640BAF00C031BE9BF041C81 /* PINCache.m in Sources */,
-				A7FE24A045E1BD35208EE004 /* PINDiskCache.m in Sources */,
-				9BC34D26F17D31F9C89C02FC /* PINMemoryCache.m in Sources */,
-				445A34F5D4879246592CC458 /* Pods-PINRemoteImage Tests-PINCache-dummy.m in Sources */,
+				03EB20EE7E05EC9EF9BB8982 /* FLAnimatedImage.m in Sources */,
+				5117C55A6C9544AB925FCA2A /* FLAnimatedImageView.m in Sources */,
+				047E46CB60F4788C1A927AE4 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		AF86B0BA5B8FD80DA96626B4 /* Sources */ = {
+		C84AC49BDC745DB340AA56D7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8FAD6BFD67311A1B64DE9340 /* FLAnimatedImage.m in Sources */,
-				86F37BD4DF1F3EFB26130285 /* FLAnimatedImageView.m in Sources */,
-				9432B1A674E47CCE3E8FE788 /* Pods-PINRemoteImage Tests-FLAnimatedImage-dummy.m in Sources */,
+				38CB189C568E2F8F57CC3A0D /* FLAnimatedImage.m in Sources */,
+				3AB9629B85A2E26BCF288437 /* FLAnimatedImageView.m in Sources */,
+				46CF43588B88C5E9F018B222 /* Pods-PINRemoteImage-FLAnimatedImage-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		B7821E1C2DBC66EEDFCD98A0 /* Sources */ = {
+		F477C3FA3B0EFF5E47674C52 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1FF0E8127312AF51FD631F4A /* PINCache.m in Sources */,
-				E9A17BE3E525BE06F079A433 /* PINDiskCache.m in Sources */,
-				0D23241A86754CD27900C39F /* PINMemoryCache.m in Sources */,
-				A6CAAE0E1B7EEF5B82BBAC0E /* Pods-PINRemoteImage-PINCache-dummy.m in Sources */,
+				0094A47556FDC879C6D6356E /* FLAnimatedImageView+PINRemoteImage.m in Sources */,
+				07FB7C0AA5DDF7DDDDB8180C /* NSData+ImageDetectors.m in Sources */,
+				18712DEABB45CDF482FA801E /* PINDataTaskOperation.m in Sources */,
+				95402FF7528436D42D69E38B /* PINProgressiveImage.m in Sources */,
+				B4ACAA9F1007749F9806E015 /* PINRemoteImageCallbacks.m in Sources */,
+				CADC210C9D101453ED12AE22 /* PINRemoteImageCategoryManager.m in Sources */,
+				402297B807232FAAB993D824 /* PINRemoteImageDownloadTask.m in Sources */,
+				1405E5094BB9BDD89FA1CF5C /* PINRemoteImageManager.m in Sources */,
+				2116CB642B3919F226BCA7E2 /* PINRemoteImageManagerResult.m in Sources */,
+				E3B0C202AD4EDB1B78C25F3A /* PINRemoteImageProcessorTask.m in Sources */,
+				519711DB6DB7827EE02E50E0 /* PINRemoteImageTask.m in Sources */,
+				FFAD1D96A346615C01F27092 /* PINURLSessionManager.m in Sources */,
+				E6CBA266FF64CACB89E6D084 /* Pods-PINRemoteImage-PINRemoteImage-dummy.m in Sources */,
+				556EDC6EA4BDD83D7AF95F99 /* UIButton+PINRemoteImage.m in Sources */,
+				0EA32304B4F7C1916B519C4C /* UIImage+DecodedImage.m in Sources */,
+				6078E30DC14129FAA0561D79 /* UIImage+WebP.m in Sources */,
+				DDE7286232CD71975B8D6A31 /* UIImageView+PINRemoteImage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		BE94098258B7313EE31894FA /* Sources */ = {
+		F53D748E2E579F06CD9D9531 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2DCA557DAB88A1B7B682894E /* Pods-PINRemoteImage Tests-dummy.m in Sources */,
+				D12933ACCBA622692D91EC80 /* Pods-PINRemoteImage Tests-dummy.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		DD71D3B78E58FF2B1AE9687C /* Sources */ = {
+		FD50C1DF3E0D1590BCBFC179 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				046F102F36A3D152D5AC1971 /* Pods-PINRemoteImage-dummy.m in Sources */,
+				8E0014B2901205894F74A111 /* FLAnimatedImageView+PINRemoteImage.m in Sources */,
+				2052BE9B64CC04F6A135EC2E /* NSData+ImageDetectors.m in Sources */,
+				D1D58EDAF30BA9075EA9B332 /* PINDataTaskOperation.m in Sources */,
+				F55E2979D60FD4FADB78A0F1 /* PINProgressiveImage.m in Sources */,
+				3CCC4C341A1A67CF77B4C69E /* PINRemoteImageCallbacks.m in Sources */,
+				1E583050473B2D10F6EE2840 /* PINRemoteImageCategoryManager.m in Sources */,
+				5F6A726880585038D28F8F4C /* PINRemoteImageDownloadTask.m in Sources */,
+				2E60682CB5A0A21D625A9E8A /* PINRemoteImageManager.m in Sources */,
+				3CC22E823334E1D3A6CACD18 /* PINRemoteImageManagerResult.m in Sources */,
+				15891EB0433C4442D1B7FA2E /* PINRemoteImageProcessorTask.m in Sources */,
+				E37F2350F376B3689338A609 /* PINRemoteImageTask.m in Sources */,
+				3FC1B89BEF4B0BE4FBFA3A4F /* PINURLSessionManager.m in Sources */,
+				F61EE4D207C7F926AADC5845 /* Pods-PINRemoteImage Tests-PINRemoteImage-dummy.m in Sources */,
+				A90F00E37A5EB92C7E5829F7 /* UIButton+PINRemoteImage.m in Sources */,
+				39AA8CD157E19842839C7A5A /* UIImage+DecodedImage.m in Sources */,
+				EBD374552AAF9593CAB237F2 /* UIImage+WebP.m in Sources */,
+				CAF2A5EEB0A3F3F41DD3B66E /* UIImageView+PINRemoteImage.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		01ABA40276E6ED582397117C /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage Tests-PINCache";
-			target = F5893B7048FAF770D6678D64 /* Pods-PINRemoteImage Tests-PINCache */;
-			targetProxy = 9E014BEDD222D1050FBC30AB /* PBXContainerItemProxy */;
-		};
-		0456C70A339CEDB6876AE88B /* PBXTargetDependency */ = {
+		115F19B3FD68A2D4A0491173 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-PINRemoteImage Tests-FLAnimatedImage";
-			target = 822D6AA9F3EEB56D9A1868C7 /* Pods-PINRemoteImage Tests-FLAnimatedImage */;
-			targetProxy = FDBABB577A085676825DF2EF /* PBXContainerItemProxy */;
+			target = C82F0D26AC43E8178B238108 /* Pods-PINRemoteImage Tests-FLAnimatedImage */;
+			targetProxy = 712249F35521B3EF4E35AD74 /* PBXContainerItemProxy */;
 		};
-		09A0E5DD6198192BCD132C48 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage-libwebp";
-			target = FD5C94A81700C30D9BE32245 /* Pods-PINRemoteImage-libwebp */;
-			targetProxy = C53F9EA083D887EAC0C675FA /* PBXContainerItemProxy */;
-		};
-		1E8FA8D730984ABBE6750582 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage Tests-FLAnimatedImage";
-			target = 822D6AA9F3EEB56D9A1868C7 /* Pods-PINRemoteImage Tests-FLAnimatedImage */;
-			targetProxy = 270FAF9B3CE8E11B858FA530 /* PBXContainerItemProxy */;
-		};
-		27916BE8F9D2300947238600 /* PBXTargetDependency */ = {
+		1C3160C8EA921646EACF5C66 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-PINRemoteImage-FLAnimatedImage";
-			target = 3091AE0AB69637A0D4873AB2 /* Pods-PINRemoteImage-FLAnimatedImage */;
-			targetProxy = 4DB640D8733D5197E4A1D5EE /* PBXContainerItemProxy */;
+			target = ADE1074A6F3EBF9B00A11E22 /* Pods-PINRemoteImage-FLAnimatedImage */;
+			targetProxy = ED27D78494A259DA9052E722 /* PBXContainerItemProxy */;
 		};
-		5376B5ACE40A358E125E6ECB /* PBXTargetDependency */ = {
+		1DF13F402798A780A1596CA5 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage-FLAnimatedImage";
-			target = 3091AE0AB69637A0D4873AB2 /* Pods-PINRemoteImage-FLAnimatedImage */;
-			targetProxy = DDE224E51AC17F3B477DB629 /* PBXContainerItemProxy */;
+			name = "Pods-PINRemoteImage-PINCache";
+			target = F5BD80853C6CC61691FF8C4E /* Pods-PINRemoteImage-PINCache */;
+			targetProxy = 0DFC3DE7B49DAB2BDFED6C79 /* PBXContainerItemProxy */;
 		};
-		580BCF913BD34F693C827590 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage-PINRemoteImage";
-			target = E6C155F0A4EA8DC094A3DF98 /* Pods-PINRemoteImage-PINRemoteImage */;
-			targetProxy = 19118B7BC1BAD5D3E168EC52 /* PBXContainerItemProxy */;
-		};
-		721872E31F9769FCA457482A /* PBXTargetDependency */ = {
+		28DCEB90912B4F8FFA780F41 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-PINRemoteImage Tests-PINCache";
-			target = F5893B7048FAF770D6678D64 /* Pods-PINRemoteImage Tests-PINCache */;
-			targetProxy = FE49B4B3F8E7E2177552F4CB /* PBXContainerItemProxy */;
+			target = 940E8008C17E41E278D7FE97 /* Pods-PINRemoteImage Tests-PINCache */;
+			targetProxy = 86F607CC32C813741ABA5CB8 /* PBXContainerItemProxy */;
 		};
-		7BD1A0A1B8AA49C5FC8A06A9 /* PBXTargetDependency */ = {
+		2D162B68D1B4D8F6BAA9D0AA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-PINRemoteImage-PINCache";
+			target = F5BD80853C6CC61691FF8C4E /* Pods-PINRemoteImage-PINCache */;
+			targetProxy = EB0652CEA74598B03A444E54 /* PBXContainerItemProxy */;
+		};
+		7DCA461E9362EB5D7BCF7893 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "Pods-PINRemoteImage Tests-PINRemoteImage";
-			target = 9C0680BEE34556A8023EB5DB /* Pods-PINRemoteImage Tests-PINRemoteImage */;
-			targetProxy = 99B5DAA78C94EE4EE1070E01 /* PBXContainerItemProxy */;
+			target = 9D5D69DDEABF36FE56E607B6 /* Pods-PINRemoteImage Tests-PINRemoteImage */;
+			targetProxy = 1F8F5CA0C515A349A769B21F /* PBXContainerItemProxy */;
 		};
-		9CD46119887C572C01EA9E9C /* PBXTargetDependency */ = {
+		85500A0B211E12E801ACED38 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage-PINCache";
-			target = F87A88BDC23AD1F92436E1A8 /* Pods-PINRemoteImage-PINCache */;
-			targetProxy = 597D5B479FB32FF01887A250 /* PBXContainerItemProxy */;
+			name = "Pods-PINRemoteImage-FLAnimatedImage";
+			target = ADE1074A6F3EBF9B00A11E22 /* Pods-PINRemoteImage-FLAnimatedImage */;
+			targetProxy = 3BB02AE8F3956A822DA2A57F /* PBXContainerItemProxy */;
 		};
-		B39F85DE3BD404CA8197EA63 /* PBXTargetDependency */ = {
+		A7FA5DDDDEA406B97F32A240 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = "Pods-PINRemoteImage-PINCache";
-			target = F87A88BDC23AD1F92436E1A8 /* Pods-PINRemoteImage-PINCache */;
-			targetProxy = 6936FAE5E07F4A3F56207603 /* PBXContainerItemProxy */;
+			name = "Pods-PINRemoteImage Tests-PINCache";
+			target = 940E8008C17E41E278D7FE97 /* Pods-PINRemoteImage Tests-PINCache */;
+			targetProxy = D1552148CBD05F2B3BD59700 /* PBXContainerItemProxy */;
+		};
+		BF3CB6A7508919A47C5F5029 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-PINRemoteImage Tests-FLAnimatedImage";
+			target = C82F0D26AC43E8178B238108 /* Pods-PINRemoteImage Tests-FLAnimatedImage */;
+			targetProxy = CBFADFDC029524D8D76D885D /* PBXContainerItemProxy */;
+		};
+		C4C839404F8D54DA46F45E12 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-PINRemoteImage-libwebp";
+			target = 2C24A84F297BD8FD6532997F /* Pods-PINRemoteImage-libwebp */;
+			targetProxy = 0685A433F67D1AE4514B6806 /* PBXContainerItemProxy */;
+		};
+		F62EA02C01638BDBFD23FE79 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Pods-PINRemoteImage-PINRemoteImage";
+			target = 0739948874D2178089A48DAB /* Pods-PINRemoteImage-PINRemoteImage */;
+			targetProxy = CB8BEE33FDD53A709779FD4C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		0FB06DB711D625804A69F153 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF61C3873B4B3A2C9EFDBE21 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		11D0113FC6929FF214671AC5 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0C501993B3ECC8147FE9E10 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-libwebp/Pods-PINRemoteImage-libwebp-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		1A5455A44CBFE623156D2F5C /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C2F9F8DF4033F87254BFE90D /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-FLAnimatedImage/Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		1DE5A35025FC7ACAC469D34A /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3285143675C23ECB420F2903 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINCache/Pods-PINRemoteImage Tests-PINCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		2953E99EA7F02F14975D8687 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8241AA46CE5E88509ABCC479 /* Pods-PINRemoteImage.debug.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		2CE408FEAB59BA84B49C614D /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B13E2D603C55C02E09088BBC /* Pods-PINRemoteImage.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		2D0726CBD2576FAFCA824DC9 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = B667E47AE90ADBB16875418E /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINRemoteImage/Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		3441AB811D4F26D2CA88C0EC /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B4938CFE6128496CCA09AAE /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		39062C3206EAB5F00B1346C8 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = C2F9F8DF4033F87254BFE90D /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-FLAnimatedImage/Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		3CDB72EBAD63DB38A694194A /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = YES;
-				ENABLE_NS_ASSERTIONS = NO;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				STRIP_INSTALLED_PRODUCT = NO;
-				SYMROOT = "${SRCROOT}/../build";
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
-		};
-		5D7D1A9D8AE35E88E09ACF5B /* Debug */ = {
+		1028A5E403F83FEAE4BCB55F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -1837,9 +1699,25 @@
 			};
 			name = Debug;
 		};
-		69757BF6FE3E8E2B041D4FE9 /* Debug */ = {
+		5073B45424BA8FF44A9B485B /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3285143675C23ECB420F2903 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */;
+			baseConfigurationReference = C979F6E3D7BDAB2715BBFB51 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-libwebp/Pods-PINRemoteImage-libwebp-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		517621B1E187280858477A02 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1F87CB2EF8EC4EA3200DF097 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINCache/Pods-PINRemoteImage Tests-PINCache-prefix.pch";
@@ -1853,12 +1731,28 @@
 			};
 			name = Debug;
 		};
-		7F0D86642BBBC951A0B2CB64 /* Debug */ = {
+		532B5FFFAEE1ECE44D907228 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = B667E47AE90ADBB16875418E /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */;
+			baseConfigurationReference = D85E879D0A985F460758ABF3 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINRemoteImage/Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		54AF25D1B2E81AB3D9D52A87 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D85E879D0A985F460758ABF3 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				OTHER_LDFLAGS = "";
@@ -1869,41 +1763,9 @@
 			};
 			name = Debug;
 		};
-		B4DB559FF8095AD684125EAF /* Release */ = {
+		5ADAB08E363518BA311A9878 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3F6EF3E8BFFE91E6DBE1FCF9 /* Pods-PINRemoteImage Tests.release.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PODS_ROOT = "$(SRCROOT)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		BFB171D396B7B4FFBDBA31BE /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1B4938CFE6128496CCA09AAE /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
-		C66A0A411F07DA22E197B312 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = E0C501993B3ECC8147FE9E10 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */;
+			baseConfigurationReference = C979F6E3D7BDAB2715BBFB51 /* Pods-PINRemoteImage-libwebp-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-libwebp/Pods-PINRemoteImage-libwebp-prefix.pch";
@@ -1917,25 +1779,9 @@
 			};
 			name = Debug;
 		};
-		CA16829DA970DED317B28384 /* Debug */ = {
+		5C61F8FC5677108194622276 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 518940E1EAB1CF8C819D29A6 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */;
-			buildSettings = {
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "";
-				OTHER_LIBTOOLFLAGS = "";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		E3789D9AC8FC87A3A9E7CDA0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = FF61C3873B4B3A2C9EFDBE21 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */;
+			baseConfigurationReference = 3A38D134C79DA4234655EAE2 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-prefix.pch";
@@ -1949,12 +1795,12 @@
 			};
 			name = Release;
 		};
-		F4C5C97154A7CA162DC271F5 /* Release */ = {
+		68E381B93DCF9EEE2978F583 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 518940E1EAB1CF8C819D29A6 /* Pods-PINRemoteImage-PINCache-Private.xcconfig */;
+			baseConfigurationReference = 0501ADF0577B48BF70AA9AB8 /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINCache/Pods-PINRemoteImage-PINCache-prefix.pch";
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-FLAnimatedImage/Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				OTHER_LDFLAGS = "";
@@ -1965,9 +1811,9 @@
 			};
 			name = Release;
 		};
-		FD76AB005C2CDA30E78FFE28 /* Debug */ = {
+		829B73CD9EE4401DA15B454B /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5B25276ADCAF13177E8879D7 /* Pods-PINRemoteImage Tests.debug.xcconfig */;
+			baseConfigurationReference = F5205CC8732530BFC8C5AC6C /* Pods-PINRemoteImage.debug.xcconfig */;
 			buildSettings = {
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
@@ -1981,100 +1827,294 @@
 			};
 			name = Debug;
 		};
+		86CB31C472BF26D75FD6CBFC /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7057648BB45CA7E897825284 /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINRemoteImage/Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		97343325F7EEECBBBE140F7E /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = D934B71E11DC1BF1BE3AA2C0 /* Pods-PINRemoteImage Tests.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		9C6C100B22317378F21F5DD3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3A38D134C79DA4234655EAE2 /* Pods-PINRemoteImage-PINRemoteImage-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-PINRemoteImage/Pods-PINRemoteImage-PINRemoteImage-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		BD9288F1343903D7BE13A6D9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FD581AECE86AD9191C4B153 /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		C920AB9F69AF50FC69EFB60F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_PREPROCESSOR_DEFINITIONS = "RELEASE=1";
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "${SRCROOT}/../build";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		CD7FC81AD80F61E68D203F04 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1FD581AECE86AD9191C4B153 /* Pods-PINRemoteImage-FLAnimatedImage-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage-FLAnimatedImage/Pods-PINRemoteImage-FLAnimatedImage-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		D3CDFD5B450C8854F5E467D1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8C3EE5B1F1C82C2F15B396AE /* Pods-PINRemoteImage.release.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		DFEE8C670418ADFCD55035F1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1F87CB2EF8EC4EA3200DF097 /* Pods-PINRemoteImage Tests-PINCache-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINCache/Pods-PINRemoteImage Tests-PINCache-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		EF5E999398F834E0CB5C4FE7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 440A712A234F860C66C1F6F7 /* Pods-PINRemoteImage Tests.debug.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PODS_ROOT = "$(SRCROOT)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		F9043513695195F8CF7C61DA /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 0501ADF0577B48BF70AA9AB8 /* Pods-PINRemoteImage Tests-FLAnimatedImage-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-FLAnimatedImage/Pods-PINRemoteImage Tests-FLAnimatedImage-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		FA73C9F2011478B470BE16DD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7057648BB45CA7E897825284 /* Pods-PINRemoteImage Tests-PINRemoteImage-Private.xcconfig */;
+			buildSettings = {
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_PREFIX_HEADER = "Target Support Files/Pods-PINRemoteImage Tests-PINRemoteImage/Pods-PINRemoteImage Tests-PINRemoteImage-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 7.1;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "";
+				OTHER_LIBTOOLFLAGS = "";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		06DB3B8C0FC88028ACA801AF /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINRemoteImage" */ = {
+		581D14EC287103D51B5EB83C /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				0FB06DB711D625804A69F153 /* Debug */,
-				E3789D9AC8FC87A3A9E7CDA0 /* Release */,
+				1028A5E403F83FEAE4BCB55F /* Debug */,
+				C920AB9F69AF50FC69EFB60F /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		32AAFE41438F2B0B7BEA013F /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests" */ = {
+		5DA8D032C2B20B395A2DF610 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				FD76AB005C2CDA30E78FFE28 /* Debug */,
-				B4DB559FF8095AD684125EAF /* Release */,
+				EF5E999398F834E0CB5C4FE7 /* Debug */,
+				97343325F7EEECBBBE140F7E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		3B15CF5C66B260D0C7328CD1 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-libwebp" */ = {
+		6DBB7297281F7BEBE00AC8A1 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINCache" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C66A0A411F07DA22E197B312 /* Debug */,
-				11D0113FC6929FF214671AC5 /* Release */,
+				54AF25D1B2E81AB3D9D52A87 /* Debug */,
+				532B5FFFAEE1ECE44D907228 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		75547B89AF6DD2C86CBBE6E4 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-FLAnimatedImage" */ = {
+		765CB9E84250CC6DFE96ED58 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-libwebp" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				3441AB811D4F26D2CA88C0EC /* Debug */,
-				BFB171D396B7B4FFBDBA31BE /* Release */,
+				5ADAB08E363518BA311A9878 /* Debug */,
+				5073B45424BA8FF44A9B485B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		8191C0C1E6C7B487BB5C7690 /* Build configuration list for PBXProject "Pods" */ = {
+		78BBD5380B17B654FC72304B /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-FLAnimatedImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5D7D1A9D8AE35E88E09ACF5B /* Debug */,
-				3CDB72EBAD63DB38A694194A /* Release */,
+				F9043513695195F8CF7C61DA /* Debug */,
+				68E381B93DCF9EEE2978F583 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9711009A1C86EE5C927B6C7F /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINCache" */ = {
+		A9B09B70693E901D91217F70 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINRemoteImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				69757BF6FE3E8E2B041D4FE9 /* Debug */,
-				1DE5A35025FC7ACAC469D34A /* Release */,
+				9C6C100B22317378F21F5DD3 /* Debug */,
+				5C61F8FC5677108194622276 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		B7EA2295E687812B213E3D2F /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINRemoteImage" */ = {
+		B72860EB4AD5B2CDA814A1C9 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINRemoteImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				7F0D86642BBBC951A0B2CB64 /* Debug */,
-				2D0726CBD2576FAFCA824DC9 /* Release */,
+				FA73C9F2011478B470BE16DD /* Debug */,
+				86CB31C472BF26D75FD6CBFC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		BC019F4DBE5BDE83695BB8C5 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-FLAnimatedImage" */ = {
+		DEE42D991AE0D8C0C421AC04 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage Tests-PINCache" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				1A5455A44CBFE623156D2F5C /* Debug */,
-				39062C3206EAB5F00B1346C8 /* Release */,
+				517621B1E187280858477A02 /* Debug */,
+				DFEE8C670418ADFCD55035F1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		CE90B53799B6BB173134A8DC /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-PINCache" */ = {
+		EA0956AAD29CC7F7AC2BAEE9 /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage-FLAnimatedImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				CA16829DA970DED317B28384 /* Debug */,
-				F4C5C97154A7CA162DC271F5 /* Release */,
+				CD7FC81AD80F61E68D203F04 /* Debug */,
+				BD9288F1343903D7BE13A6D9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		D03E483EC878F703DBE412FB /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage" */ = {
+		EE0FFB1BDD036DB92A01C5BA /* Build configuration list for PBXNativeTarget "Pods-PINRemoteImage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				2953E99EA7F02F14975D8687 /* Debug */,
-				2CE408FEAB59BA84B49C614D /* Release */,
+				829B73CD9EE4401DA15B454B /* Debug */,
+				D3CDFD5B450C8854F5E467D1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 96ACB2D0C4443E8617339972 /* Project object */;
+	rootObject = A3672C3787DE3FDF78D98167 /* Project object */;
 }

--- a/Example/Pods/Target Support Files/Pods-PINRemoteImage Tests/Pods-PINRemoteImage Tests-environment.h
+++ b/Example/Pods/Target Support Files/Pods-PINRemoteImage Tests/Pods-PINRemoteImage Tests-environment.h
@@ -15,12 +15,24 @@
 // PINCache
 #define COCOAPODS_POD_AVAILABLE_PINCache
 #define COCOAPODS_VERSION_MAJOR_PINCache 2
-#define COCOAPODS_VERSION_MINOR_PINCache 0
+#define COCOAPODS_VERSION_MINOR_PINCache 1
 #define COCOAPODS_VERSION_PATCH_PINCache 0
 
 // PINRemoteImage
 #define COCOAPODS_POD_AVAILABLE_PINRemoteImage
 #define COCOAPODS_VERSION_MAJOR_PINRemoteImage 1
-#define COCOAPODS_VERSION_MINOR_PINRemoteImage 0
+#define COCOAPODS_VERSION_MINOR_PINRemoteImage 2
 #define COCOAPODS_VERSION_PATCH_PINRemoteImage 0
+
+// PINRemoteImage/Core
+#define COCOAPODS_POD_AVAILABLE_PINRemoteImage_Core
+#define COCOAPODS_VERSION_MAJOR_PINRemoteImage_Core 1
+#define COCOAPODS_VERSION_MINOR_PINRemoteImage_Core 2
+#define COCOAPODS_VERSION_PATCH_PINRemoteImage_Core 0
+
+// PINRemoteImage/FLAnimatedImage
+#define COCOAPODS_POD_AVAILABLE_PINRemoteImage_FLAnimatedImage
+#define COCOAPODS_VERSION_MAJOR_PINRemoteImage_FLAnimatedImage 1
+#define COCOAPODS_VERSION_MINOR_PINRemoteImage_FLAnimatedImage 2
+#define COCOAPODS_VERSION_PATCH_PINRemoteImage_FLAnimatedImage 0
 

--- a/Example/Pods/Target Support Files/Pods-PINRemoteImage/Pods-PINRemoteImage-environment.h
+++ b/Example/Pods/Target Support Files/Pods-PINRemoteImage/Pods-PINRemoteImage-environment.h
@@ -15,14 +15,26 @@
 // PINCache
 #define COCOAPODS_POD_AVAILABLE_PINCache
 #define COCOAPODS_VERSION_MAJOR_PINCache 2
-#define COCOAPODS_VERSION_MINOR_PINCache 0
+#define COCOAPODS_VERSION_MINOR_PINCache 1
 #define COCOAPODS_VERSION_PATCH_PINCache 0
 
 // PINRemoteImage
 #define COCOAPODS_POD_AVAILABLE_PINRemoteImage
 #define COCOAPODS_VERSION_MAJOR_PINRemoteImage 1
-#define COCOAPODS_VERSION_MINOR_PINRemoteImage 0
+#define COCOAPODS_VERSION_MINOR_PINRemoteImage 2
 #define COCOAPODS_VERSION_PATCH_PINRemoteImage 0
+
+// PINRemoteImage/Core
+#define COCOAPODS_POD_AVAILABLE_PINRemoteImage_Core
+#define COCOAPODS_VERSION_MAJOR_PINRemoteImage_Core 1
+#define COCOAPODS_VERSION_MINOR_PINRemoteImage_Core 2
+#define COCOAPODS_VERSION_PATCH_PINRemoteImage_Core 0
+
+// PINRemoteImage/FLAnimatedImage
+#define COCOAPODS_POD_AVAILABLE_PINRemoteImage_FLAnimatedImage
+#define COCOAPODS_VERSION_MAJOR_PINRemoteImage_FLAnimatedImage 1
+#define COCOAPODS_VERSION_MINOR_PINRemoteImage_FLAnimatedImage 2
+#define COCOAPODS_VERSION_PATCH_PINRemoteImage_FLAnimatedImage 0
 
 // libwebp
 #define COCOAPODS_POD_AVAILABLE_libwebp

--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -14,17 +14,27 @@ Pod::Spec.new do |s|
   s.homepage         = "https://github.com/pinterest/PINRemoteImage"
   s.license          = 'Apache 2.0'
   s.author           = { "Garrett Moon" => "garrett@pinterest.com" }
-  s.source           = { :git => "https://github.com/pinterest/PINRemoteImage.git", :tag => "1.1.2" }
+  s.source           = { :git => "https://github.com/pinterest/PINRemoteImage.git", :tag => "1.2" }
   s.social_media_url = 'https://twitter.com/garrettmoon'
 
   s.platform     = :ios, '6.0'
   s.requires_arc = true
+  
+  # Include optional FLAnimatedImage module
+  s.default_subspec = 'FLAnimatedImage'
+  
+  ### Subspecs
+  s.subspec 'Core' do |cs|
+    cs.source_files = 'Pod/Classes/**/*.{h,m}'
+    cs.exclude_files = 'Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h', 'Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m'
+    cs.public_header_files = 'Pod/Classes/**/*.h'
+    cs.frameworks = 'UIKit', 'ImageIO', 'CoreImage'
+    cs.dependency 'PINCache', '>=2.1'
+  end
 
-  s.source_files = 'Pod/Classes/**/*.{h,m}'
-
-  s.public_header_files = 'Pod/Classes/**/*.h'
-  s.frameworks = 'UIKit', 'ImageIO', 'CoreImage'
-  s.dependency 'FLAnimatedImage', '>= 1.0'
-  s.dependency 'PINCache', '>=2.1'
-
+  s.subspec "FLAnimatedImage" do |fs|
+    fs.dependency 'PINRemoteImage/Core'
+    fs.source_files = 'Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h', 'Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m'
+    fs.dependency 'FLAnimatedImage', '>= 1.0'
+  end
 end

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -8,7 +8,9 @@
 
 #import "PINRemoteImageManager.h"
 
+#if USE_FLANIMATED_IMAGE
 #import <FLAnimatedImage/FLAnimatedImage.h>
+#endif
 #import <PINCache/PINCache.h>
 
 #import "PINRemoteImage.h"
@@ -638,7 +640,9 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
         if ([object isKindOfClass:[UIImage class]]) {
             image = (UIImage *)object;
         } else if (allowAnimated && [object isKindOfClass:[NSData class]] && [(NSData *)object pin_isGIF]) {
+#if USE_FLANIMATED_IMAGE
             animatedImage = [FLAnimatedImage animatedImageWithGIFData:object];
+#endif
         }
     }
     
@@ -691,7 +695,9 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
     } else if ([object isKindOfClass:[NSData class]]) {
         NSData *imageData = (NSData *)object;
         if ([imageData pin_isGIF] && ignoreGIF == NO) {
+#if USE_FLANIMATED_IMAGE
             animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:imageData];
+#endif
         } else {
             BOOL skipDecode = (options & PINRemoteImageManagerDownloadOptionsSkipDecode) != 0;
             image = [UIImage pin_decodedImageWithData:imageData skipDecodeIfPossible:skipDecode];
@@ -745,7 +751,9 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
             
             if (remoteImageError == nil) {
                 if ([data pin_isGIF] && ignoreGIF == NO) {
+#if USE_FLANIMATED_IMAGE
                     animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:data];
+#endif
                     //FLAnimatedImage handles its own caching of frames
                     cacheCost = [data length];
                 } else {
@@ -980,7 +988,9 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
         if ([object isKindOfClass:[UIImage class]]) {
             image = (UIImage *)object;
         } else if ([object isKindOfClass:[NSData class]]) {
+#if USE_FLANIMATED_IMAGE
             animatedImage = [[FLAnimatedImage alloc] initWithAnimatedGIFData:object];
+#endif
         }
     };
     

--- a/Pod/Classes/PINRemoteImageManagerResult.h
+++ b/Pod/Classes/PINRemoteImageManagerResult.h
@@ -7,8 +7,10 @@
 //
 
 #import <UIKit/UIKit.h>
-
+#import "PINRemoteImage.h"
+#if USE_FLANIMATED_IMAGE
 #import <FLAnimatedImage/FLAnimatedImage.h>
+#endif
 
 /** How the image was fetched. */
 typedef NS_ENUM(NSUInteger, PINRemoteImageResultType) {


### PR DESCRIPTION
This merge request addresses multiple issues:

1) This fixes a bug where the `PINRemoteImage.podspec` git tag was not updated, when the pod version was updated to `1.2`. 

This error occurred here: https://github.com/pinterest/PINRemoteImage/commit/dcf1fa695b6bc1e26bd36e512a6d47c129d52958

2) Updates PinCache in the Example/Pods folder to reflect upgrade from this commit: https://github.com/pinterest/PINRemoteImage/commit/c00f8ffc9596c32a1ce96446a181cb090ef001b3

3) Makes FLAnimatedImage optional, but is included as part of the default subspec.