### PR TITLE
Fix crash in PINProgressiveImage

### DIFF
--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -356,11 +356,15 @@
                                forKey:kCIInputRadiusKey];
         
         CIImage *outputImage = [self.gaussianFilter outputImage];
-        CGImageRef outputImageRef = [self.processingContext createCGImage:outputImage fromRect:CGRectMake(0, 0, inputImage.size.width, inputImage.size.height)];
-        
-        //"decoding" the image here copies it to CPU memory?
-        outputUIImage = [UIImage pin_decodedImageWithCGImageRef:outputImageRef];
-        CGImageRelease(outputImageRef);
+        if (outputImage) {
+            CGImageRef outputImageRef = [self.processingContext createCGImage:outputImage fromRect:CGRectMake(0, 0, inputImage.size.width, inputImage.size.height)];
+            
+            if (outputImageRef) {
+                //"decoding" the image here copies it to CPU memory?
+                outputUIImage = [UIImage pin_decodedImageWithCGImageRef:outputImageRef];
+                CGImageRelease(outputImageRef);
+            }
+        }
     }
     
     if (outputUIImage == nil) {


### PR DESCRIPTION
[CIFilter outputImage] can return nil, [CIContext createCGImage:fromRect:] requires a non-nil CIImage as input.