### PR TITLE
Return image result type of 'None' if no image is downloaded

### DIFF
--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -54,11 +54,17 @@
             PINLog(@"calling completion for UUID: %@ key: %@", UUID, strongSelf.key);
             dispatch_async(queue, ^
             {
+                PINRemoteImageResultType result;
+                if (image || animatedImage) {
+                    result = cached ? PINRemoteImageResultTypeCache : PINRemoteImageResultTypeDownload;
+                } else {
+                    result = PINRemoteImageResultTypeNone;
+                }
                 callback.completionBlock([PINRemoteImageManagerResult imageResultWithImage:image
                                                                             animatedImage:animatedImage
                                                                             requestLength:CACurrentMediaTime() - callback.requestTime
                                                                                     error:error
-                                                                               resultType:cached?PINRemoteImageResultTypeCache:PINRemoteImageResultTypeDownload
+                                                                               resultType:result
                                                                                      UUID:UUID]);
             });
         }


### PR DESCRIPTION
Previously the `resultType` being returned was `PINRemoteImageResultTypeDownload` even when the download failed. Now, we check to see if the `image` has been set and if it not then we return `PINRemoteImageResultTypeNone`.

This fixes #68.