### PR TITLE
So, uh,

### DIFF
--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -336,6 +336,10 @@
 //Must be called within lock
 - (UIImage *)postProcessImage:(UIImage *)inputImage withProgress:(float)progress
 {
+    if (inputImage == nil) {
+        return nil;
+    }
+    
     if (self.processingContext == nil) {
         self.processingContext = [CIContext contextWithOptions:@{kCIContextUseSoftwareRenderer : @(self.inBackground), kCIContextPriorityRequestLow: @YES}];
     }


### PR DESCRIPTION
+ (UIImage * _Nonnull)imageWithCGImage:(CGImageRef _Nonnull)cgImage

says it returns a non-nil value but documentation says:

Return Value
A new image object for the specified Quartz image, or nil if the method could not initialize the image from the specified image reference.

So we're guarding against a nil inputImage