### PR TITLE
Optionally pass full result to category implementor

### DIFF
--- a/Pod/Classes/PINRemoteImageCategoryManager.h
+++ b/Pod/Classes/PINRemoteImageCategoryManager.h
@@ -219,6 +219,11 @@
 
 @optional
 
+/**
+ If you implement this method, it is called instead of pin_updateUIWithImage:animatedImage:
+ */
+- (void)pin_updateUIWithRemoteImageManagerResult:(PINRemoteImageManagerResult *)result;
+
 - (PINRemoteImageManagerDownloadOptions)pin_defaultOptions;
 
 @end

--- a/Pod/Classes/PINRemoteImageCategoryManager.m
+++ b/Pod/Classes/PINRemoteImageCategoryManager.m
@@ -195,7 +195,13 @@
                     return;
                 }
                 if (result.image) {
-                    [view pin_updateUIWithImage:result.image animatedImage:nil];
+                    if ([view respondsToSelector:@selector(pin_updateUIWithRemoteImageManagerResult:)]) {
+                        [view pin_updateUIWithRemoteImageManagerResult:result];
+                    }
+                    else {
+                        [view pin_updateUIWithImage:result.image animatedImage:nil];                        
+                    }
+
                 }
             };
             if ([NSThread isMainThread]) {
@@ -224,7 +230,12 @@
                 return;
             }
             
-            [view pin_updateUIWithImage:result.image animatedImage:result.animatedImage];
+            if ([view respondsToSelector:@selector(pin_updateUIWithRemoteImageManagerResult:)]) {
+                [view pin_updateUIWithRemoteImageManagerResult:result];
+            }
+            else {
+                [view pin_updateUIWithImage:result.image animatedImage:result.animatedImage];
+            }
             
             if (completion) {
                 completion(result);

--- a/Pod/Classes/PINRemoteImageCategoryManager.m
+++ b/Pod/Classes/PINRemoteImageCategoryManager.m
@@ -184,6 +184,8 @@
         options |= PINRemoteImageManagerDownloadOptionsIgnoreGIFs;
     }
     
+    BOOL updateWithFullResult = [view respondsToSelector:@selector(pin_updateUIWithRemoteImageManagerResult:)];
+    
     PINRemoteImageManagerImageCompletion internalProgress = nil;
     if ([self updateWithProgressOnView:view] && processorKey.length <= 0 && processor == nil) {
         internalProgress = ^(PINRemoteImageManagerResult *result)
@@ -195,7 +197,7 @@
                     return;
                 }
                 if (result.image) {
-                    if ([view respondsToSelector:@selector(pin_updateUIWithRemoteImageManagerResult:)]) {
+                    if (updateWithFullResult) {
                         [view pin_updateUIWithRemoteImageManagerResult:result];
                     }
                     else {
@@ -230,7 +232,7 @@
                 return;
             }
             
-            if ([view respondsToSelector:@selector(pin_updateUIWithRemoteImageManagerResult:)]) {
+            if (updateWithFullResult) {
                 [view pin_updateUIWithRemoteImageManagerResult:result];
             }
             else {


### PR DESCRIPTION
An image-rendering object might want more details of the download than just the image when a download is completed and it needs to render the new result, so optionally give it the whole result object.

Example usage: Our image view subclass renders the setting of the new image as an animated fade-in if the image was newly downloaded and took more than a tenth of a second to complete, so that it transitions nicely from the placeholder image.