### PR TITLE
Placeholder image is set even if url is nil

### DIFF
--- a/Pod/Classes/PINRemoteImageCategoryManager.m
+++ b/Pod/Classes/PINRemoteImageCategoryManager.m
@@ -164,13 +164,16 @@
     }
     
     [self cancelImageDownloadOnView:view];
-    if (urls == nil || urls.count == 0) {
-        [view pin_clearImages];
-        return;
-    }
-    
+  
     if (placeholderImage) {
         [view pin_setPlaceholderWithImage:placeholderImage];
+    }
+    
+    if (urls == nil || urls.count == 0) {
+        if (!placeholderImage) {
+            [view pin_clearImages];
+        }
+        return;
     }
     
     PINRemoteImageManagerDownloadOptions options;


### PR DESCRIPTION
Allow a PinRemoteImageCategory to set a placeholder image even if the provided url does not exist. Fixes #80 
