### PR TITLE
Fix a race condition in PINURLSessionManager

### DIFF
--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -26,6 +26,7 @@
         self.sessionManagerLock = [[NSLock alloc] init];
         self.sessionManagerLock.name = @"PINURLSessionManager";
         self.operationQueue = [[NSOperationQueue alloc] init];
+        self.operationQueue.name = @"PINURLSessionManager Operation Queue";
         
         //queue must be serial to ensure proper ordering
         [self.operationQueue setMaxConcurrentOperationCount:1];


### PR DESCRIPTION
The callback queue cannot be concurrent because there's no way to guarantee the
operations happen FIFO.

Also fixed an issue where authentication wouldn't happen if the PINURLSessionManager
delegate didn't respond to didReceiveChallenge: