### PR TITLE
Guard against nil url in category methods

### DIFF
--- a/Pod/Classes/Image Categories/UIButton+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/UIButton+PINRemoteImage.m
@@ -47,7 +47,7 @@
 
 - (void)pin_setImageFromURL:(NSURL *)url placeholderImage:(UIImage *)placeholderImage processorKey:(NSString *)processorKey processor:(PINRemoteImageManagerImageProcessor)processor completion:(PINRemoteImageManagerImageCompletion)completion
 {
-    [PINRemoteImageCategoryManager setImageOnView:self fromURLs:@[url] placeholderImage:placeholderImage processorKey:processorKey processor:processor completion:completion];
+    [PINRemoteImageCategoryManager setImageOnView:self fromURLs:url?@[url]:nil placeholderImage:placeholderImage processorKey:processorKey processor:processor completion:completion];
 }
 
 - (void)pin_setImageFromURLs:(NSArray *)urls

--- a/Pod/Classes/Image Categories/UIImageView+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/UIImageView+PINRemoteImage.m
@@ -47,7 +47,7 @@
 
 - (void)pin_setImageFromURL:(NSURL *)url placeholderImage:(UIImage *)placeholderImage processorKey:(NSString *)processorKey processor:(PINRemoteImageManagerImageProcessor)processor completion:(PINRemoteImageManagerImageCompletion)completion
 {
-    [PINRemoteImageCategoryManager setImageOnView:self fromURLs:@[url] placeholderImage:placeholderImage processorKey:processorKey processor:processor completion:completion];
+    [PINRemoteImageCategoryManager setImageOnView:self fromURLs:url?@[url]:nil placeholderImage:placeholderImage processorKey:processorKey processor:processor completion:completion];
 }
 
 - (void)pin_setImageFromURLs:(NSArray *)urls


### PR DESCRIPTION
The other methods on PINRemoteImageCategoryManager all do this already, but there is one method on both UIImageView and UIButton that doesn't check for nil url before wrapping it in an array.