### PR TITLE
Fix for local image URLs throwing an error.

### DIFF
--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PINRemoteImage"
-  s.version          = "1.2.2"
+  s.version          = "1.2.3"
   s.summary          = "A thread safe, performant, feature rich image fetcher"
   s.homepage         = "https://github.com/pinterest/PINRemoteImage"
   s.license          = 'Apache 2.0'

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -102,7 +102,7 @@
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
-    if (!error && [task isKindOfClass:[NSHTTPURLResponse class]] && [(NSHTTPURLResponse *)task.response statusCode] == 404) {
+    if (!error && [task.response isKindOfClass:[NSHTTPURLResponse class]] && [(NSHTTPURLResponse *)task.response statusCode] == 404) {
         error = [NSError errorWithDomain:NSURLErrorDomain
                                     code:NSURLErrorRedirectToNonExistentLocation
                                 userInfo:@{NSLocalizedDescriptionKey : @"The requested URL was not found on this server."}];

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -102,7 +102,7 @@
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
-    if (!error && [task.response respondsToSelector:@selector(statusCode)] && [task.response statusCode] == 400) {
+    if (!error && [task isKindOfClass:[NSHTTPURLResponse class]] && [(NSHTTPURLResponse *)task.response statusCode] == 404) {
         error = [NSError errorWithDomain:NSURLErrorDomain
                                     code:NSURLErrorRedirectToNonExistentLocation
                                 userInfo:@{NSLocalizedDescriptionKey : @"The requested URL was not found on this server."}];

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -102,7 +102,8 @@
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
-    if ([(NSHTTPURLResponse *)task.response statusCode] == 404 && !error) {
+    NSHTTPURLResponse *response = (NSHTTPURLResponse *)task.response;
+    if ([response respondsToSelector:@selector(statusCode)] && [response statusCode] == 404 && !error) {
         error = [NSError errorWithDomain:NSURLErrorDomain
                                     code:NSURLErrorRedirectToNonExistentLocation
                                 userInfo:@{NSLocalizedDescriptionKey : @"The requested URL was not found on this server."}];

--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -102,8 +102,7 @@
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
-    NSHTTPURLResponse *response = (NSHTTPURLResponse *)task.response;
-    if ([response respondsToSelector:@selector(statusCode)] && [response statusCode] == 404 && !error) {
+    if (!error && [task.response respondsToSelector:@selector(statusCode)] && [task.response statusCode] == 400) {
         error = [NSError errorWithDomain:NSURLErrorDomain
                                     code:NSURLErrorRedirectToNonExistentLocation
                                 userInfo:@{NSLocalizedDescriptionKey : @"The requested URL was not found on this server."}];


### PR DESCRIPTION
Loading a local image URL would throw an error because it is just a `NSURLResponse` instead of an `NSHTTPURLResponse` and thus calling `statusCode` would throw an unrecognized selector error.

A regression from b7f1856d36.