### PR TITLE
Remove decode for CI progressive images

### DIFF
--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -353,6 +353,7 @@
                                     options:PINRemoteImageManagerDownloadOptionsNone
                                  completion:^(PINRemoteImageManagerResult *result)
     {
+        XCTAssert(result.error == nil, @"error is non-nil: %@", result.error);
         outImage = result.image;
         outAnimatedImage = result.animatedImage;
         dispatch_semaphore_signal(semaphore);

--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -152,7 +152,7 @@
         outAnimatedImage = result.animatedImage;
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert(outAnimatedImage && [outAnimatedImage isKindOfClass:[FLAnimatedImage class]], @"Failed downloading animatedImage or animatedImage is not an FLAnimatedImage.");
     XCTAssert(outImage == nil, @"Image is not nil.");
 }
@@ -185,7 +185,7 @@
      {
          dispatch_semaphore_signal(semaphore);
      }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     NSDictionary *headers = [[NSJSONSerialization JSONObjectWithData:self.data options:NSJSONReadingMutableContainers error:nil] valueForKey:@"headers"];
     XCTAssert([headers[@"X-Custom-Header"] isEqualToString:@"Custom Header Value"]);
 }
@@ -203,7 +203,7 @@
         outAnimatedImage = result.animatedImage;
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
     XCTAssert(outAnimatedImage == nil, @"Animated image is not nil.");
 }
@@ -221,7 +221,7 @@
         outAnimatedImage = result.animatedImage;
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
     XCTAssert(outAnimatedImage == nil, @"Animated image is not nil.");
@@ -238,7 +238,7 @@
          outError = result.error;
          dispatch_semaphore_signal(semaphore);
      }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
     XCTAssert(outError.code == NSURLErrorUnsupportedURL);
     XCTAssert([outError.localizedDescription isEqualToString:@"unsupported URL"]);
@@ -255,7 +255,7 @@
          outError = result.error;
          dispatch_semaphore_signal(semaphore);
      }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
     XCTAssert(outError.code == NSURLErrorUnsupportedURL);
     // iOS8 (and presumably 10.10) returns NSURLErrorUnsupportedURL which means the HTTP NSURLProtocol does not accept it
@@ -274,7 +274,7 @@
          outError = result.error;
          dispatch_semaphore_signal(semaphore);
      }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert([outError.domain isEqualToString:NSURLErrorDomain]);
     XCTAssert(outError.code == NSURLErrorRedirectToNonExistentLocation);
     XCTAssert([outError.localizedDescription isEqualToString:@"The requested URL was not found on this server."]);
@@ -357,7 +357,7 @@
         outAnimatedImage = result.animatedImage;
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
     
     CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(outImage.CGImage);
@@ -379,7 +379,7 @@
         outAnimatedImage = result.animatedImage;
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
     
     CGImageAlphaInfo alphaInfo = CGImageGetAlphaInfo(outImage.CGImage);
@@ -399,7 +399,7 @@
         dispatch_semaphore_signal(semaphore);
     }];
     [self.imageManager cancelTaskWithUUID:downloadUUID];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) != 0, @"Semaphore should time out.");
     XCTAssert(self.imageManager.totalDownloads == 0, @"image downloaded too many times");
 }
 
@@ -408,9 +408,8 @@
     id object = [[self.imageManager cache] objectForKey:[self.imageManager cacheKeyForURL:[self JPEGURL] processorKey:nil]];
     XCTAssert(object == nil, @"image should not be in cache");
     
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     [self.imageManager prefetchImageWithURL:[self JPEGURL]];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    sleep([self timeoutTimeInterval]);
     
     object = [[self.imageManager cache] objectForKey:[self.imageManager cacheKeyForURL:[self JPEGURL] processorKey:nil]];
     XCTAssert(object, @"image was not prefetched or was not stored in cache");
@@ -454,7 +453,7 @@
         dispatch_semaphore_signal(semaphore);
     }];
     
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     // callback can occur *before* image is stored in cache this is an optimization to avoid waiting on the cache to write.
     // So, wait until it's actually in the cache.
     [self waitForImageWithURLToBeCached:[self JPEGURL]];
@@ -513,7 +512,7 @@
         dispatch_semaphore_signal(semaphore);
     }];
     
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     XCTAssert([image isKindOfClass:[UIImage class]], @"image should be UIImage");
 }
 
@@ -592,7 +591,7 @@
      }];
 
     [self.imageManager cancelTaskWithUUID:processUUID];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) != 0, @"Semaphore should time out.");
     XCTAssert(self.imageManager.totalDownloads == 0, @"image should not have been downloaded either.");
 }
 
@@ -657,17 +656,17 @@
     [self.imageManager setHighQualityBPSThreshold:10 completion:^{
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self.imageManager setLowQualityBPSThreshold:5 completion:^{
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self.imageManager setShouldUpgradeLowQualityImages:NO completion:^{
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     __block UIImage *image;
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
@@ -678,7 +677,7 @@
         XCTAssert(image.size.width == 750, @"Large image should be downloaded");
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     // callback can occur *before* image is stored in cache this is an optimization to avoid waiting on the cache to write.
     // So, wait until it's actually in the cache.
@@ -694,7 +693,7 @@
         XCTAssert(image.size.width == 750, @"Large image should be found in cache");
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self.imageManager.cache removeAllObjects];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
@@ -706,7 +705,7 @@
         XCTAssert(image.size.width == 345, @"Small image should be downloaded at low bps");
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self waitForImageWithURLToBeCached:[self JPEGURL_Small]];
     
@@ -720,12 +719,12 @@
         XCTAssert(image.size.width == 345, @"Small image should be found in cache");
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self.imageManager setShouldUpgradeLowQualityImages:YES completion:^{
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self.imageManager setCurrentBytesPerSecond:7];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
@@ -737,7 +736,7 @@
          XCTAssert(image.size.width == 600, @"Medium image should be now downloaded");
          dispatch_semaphore_signal(semaphore);
      }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     //small image should have been removed from cache
     NSString *key = [self.imageManager cacheKeyForURL:[self JPEGURL_Small] processorKey:nil];
@@ -753,7 +752,7 @@
     [self.imageManager setShouldUpgradeLowQualityImages:NO completion:^{
         dispatch_semaphore_signal(semaphore);
     }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
     
     [self.imageManager setCurrentBytesPerSecond:7];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Large]]
@@ -765,7 +764,7 @@
          XCTAssert(image.size.width == 345, @"Small image should be now downloaded");
          dispatch_semaphore_signal(semaphore);
      }];
-    dispatch_semaphore_wait(semaphore, [self timeout]);
+    XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
 }
 
 - (void)testAuthentication {
@@ -783,7 +782,7 @@
 									options:PINRemoteImageManagerDownloadOptionsNone
 								 completion:nil];
 	
-	dispatch_semaphore_wait(semaphore, [self timeout]);
+	XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
 	
 	XCTAssert(didCallAuthenticationChallenge, @"Did not call authenticationchallenge.");
 }

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -364,6 +364,7 @@ static CIContext *CPUProcessingContext = nil;
         maxInput.width < inputSize.width ||
         maxOutput.height < inputSize.height ||
         maxOutput.width < inputSize.width) {
+        CGImageRelease(inputImageRef);
         return nil;
     }
     

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -380,8 +380,7 @@ static CIContext *CPUProcessingContext = nil;
             CGImageRef outputImageRef = [processingContext createCGImage:outputImage fromRect:CGRectMake(0, 0, inputImage.size.width, inputImage.size.height)];
             
             if (outputImageRef) {
-                //"decoding" the image here copies it to CPU memory?
-                outputUIImage = [UIImage pin_decodedImageWithCGImageRef:outputImageRef];
+                outputUIImage = [UIImage imageWithCGImage:outputImageRef];
                 CGImageRelease(outputImageRef);
             }
         }


### PR DESCRIPTION
Previously, I'd speculatively decoded images returned from the progressive CIContext
because I'd read that doing so would move the memory from the GPU to the CPU, hopefully
making drawing faster.

I decided to test this hypothesis and by drawing the un-'decoded' image and the image
directly returned from CIContext. Here are some results:

When decoded is drawn before regular
[22486:30240049] decoded - 'regular': 0.000263
[22486:30240097] decoded - 'regular': 0.000242
[22486:30240306] decoded - 'regular': 0.000092
[22486:30240068] decoded - 'regular': 0.000384
[22486:30240096] decoded - 'regular': 0.000111
[22486:30240074] decoded - 'regular': 0.000089
[22486:30240046] decoded - 'regular': 0.000273
[22486:30240351] decoded - 'regular': 0.000250
[22486:30240307] decoded - 'regular': 0.000313
[22486:30240308] decoded - 'regular': 0.000684
[22486:30240307] decoded - 'regular': 0.000485
[22486:30240069] decoded - 'regular': 0.002414
[22486:30240052] decoded - 'regular': 0.000397
[22486:30240049] decoded - 'regular': 0.000293
[22486:30240351] decoded - 'regular': 0.000145

When regular is drawn before decoded
[22610:30246046] decoded - 'regular': 0.000056
[22610:30246030] decoded - 'regular': 0.000473
[22610:30246029] decoded - 'regular': 0.000138
[22610:30246053] decoded - 'regular': 0.000387
[22610:30246030] decoded - 'regular': -0.000006
[22610:30246026] decoded - 'regular': 0.000714
[22610:30246034] decoded - 'regular': 0.000097
[22610:30246621] decoded - 'regular': 0.000039
[22610:30246024] decoded - 'regular': 0.000121
[22610:30246662] decoded - 'regular': -0.000090
[22610:30246030] decoded - 'regular': -0.000057
[22610:30246619] decoded - 'regular': 0.000443
[22610:30246033] decoded - 'regular': 0.001297
[22610:30246623] decoded - 'regular': -0.000020
[22610:30246057] decoded - 'regular': 0.001249
[22610:30246660] decoded - 'regular': 0.000208
[22610:30246659] decoded - 'regular': 0.000048
[22610:30246709] decoded - 'regular': -0.000327
[22610:30246027] decoded - 'regular': 0.000953
[22610:30246025] decoded - 'regular': 0.001228
[22610:30246659] decoded - 'regular': 0.001141

Decoding the image makes little difference and that the difference shows that
the 'decoded' image actually takes longer to draw.

So, we'll save memory and processing time by returning the CGImage from the
context directly as opposed to attempting to decode it.