### PR TITLE
Pass through setUpdateWithProgress: value to prefixed property

### DIFF
--- a/Pod/Classes/Image Categories/UIImageView+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/UIImageView+PINRemoteImage.m
@@ -195,7 +195,7 @@
 
 - (void)setUpdateWithProgress:(BOOL)updateWithProgress
 {
-    [self setUpdateWithProgress:updateWithProgress];
+    self.pin_updateWithProgress = updateWithProgress;
 }
 
 - (void)setPlaceholderWithImage:(UIImage *)image


### PR DESCRIPTION
Fixes the setUpdateWithProgress: method that currently calls itself instead of passing the value through to the prefixed pin_updateWithProgress property. This results into a infinite loop and a crash.