### PR TITLE
Switch to Accelerate for blurring

### DIFF
--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
     cs.source_files = 'Pod/Classes/**/*.{h,m}'
     cs.exclude_files = 'Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.h', 'Pod/Classes/Image Categories/FLAnimatedImageView+PINRemoteImage.m'
     cs.public_header_files = 'Pod/Classes/**/*.h'
-    cs.frameworks = 'UIKit', 'ImageIO', 'CoreImage'
+    cs.frameworks = 'UIKit', 'ImageIO', 'Accelerate'
     cs.dependency 'PINCache', '>=2.1'
   end
 

--- a/Pod/Classes/PINProgressiveImage.h
+++ b/Pod/Classes/PINProgressiveImage.h
@@ -17,7 +17,7 @@
 - (void)updateProgressiveImageWithData:(nonnull NSData *)data expectedNumberOfBytes:(int64_t)expectedNumberOfBytes;
 
 //Returns the latest image based on thresholds, returns nil if no new image is generated
-- (nullable UIImage *)currentImageBlurred:(BOOL)blurred;
+- (UIImage *)currentImageBlurred:(BOOL)blurred maxProgressiveRenderSize:(CGSize)maxBlurSize;
 
 - (nullable NSData *)data;
 

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -68,9 +68,6 @@
             CFRelease(_imageSource);
         }
     [self.lock unlock];
-#if !PIN_APP_EXTENSIONS
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-#endif
 }
 
 #pragma mark - public

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -153,7 +153,7 @@
     [self.lock unlock];
 }
 
-- (UIImage *)currentImageBlurred:(BOOL)blurred
+- (UIImage *)currentImageBlurred:(BOOL)blurred maxProgressiveRenderSize:(CGSize)maxProgressiveRenderSize
 {
     [self.lock lock];
         if (self.imageSource == nil) {
@@ -203,6 +203,11 @@
             NSDictionary *jpegProperties = imageProperties[(NSString *)kCGImagePropertyJFIFDictionary];
             NSNumber *isProgressive = jpegProperties[(NSString *)kCGImagePropertyJFIFIsProgressive];
             self.isProgressiveJPEG = jpegProperties && [isProgressive boolValue];
+        }
+    
+        if (self.size.width > maxProgressiveRenderSize.width || self.size.height > maxProgressiveRenderSize.height) {
+            [self.lock unlock];
+            return nil;
         }
         
         float progress = 0;
@@ -314,12 +319,9 @@
         return nil;
     }
     
-    CGSize maxSize = CGSizeMake(1024, 1024);
     CGSize inputSize = inputImage.size;
     if (inputSize.width < 1 ||
-        inputSize.height < 1 ||
-        maxSize.height < inputSize.height ||
-        maxSize.width < inputSize.width) {
+        inputSize.height < 1) {
         CGImageRelease(inputImageRef);
         return nil;
     }

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -430,9 +430,7 @@
     return outputUIImage;
 }
 
-//| ----------------------------------------------------------------------------
 //  Helper function to handle deferred cleanup of a buffer.
-//
 static void cleanupBuffer(void *userData, void *buf_data)
 {
     free(buf_data);

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -324,8 +324,14 @@
         return nil;
     }
     
-    CGFloat radius = MAX(__FLT_EPSILON__, (inputImage.size.width / 25.0) * MAX(0, 1.0 - progress));
+    CGFloat radius = (inputImage.size.width / 25.0) * MAX(0, 1.0 - progress);
     radius *= inputImage.scale;
+    
+    //we'll round the radius to a whole number below anyway,
+    if (radius < FLT_EPSILON) {
+        CGImageRelease(inputImageRef);
+        return inputImage;
+    }
     
     UIGraphicsBeginImageContextWithOptions(inputSize, YES, inputImage.scale);
     CGContextRef ctx = UIGraphicsGetCurrentContext();
@@ -378,6 +384,7 @@
                 
                 wholeRadius |= 1; // force wholeRadius to be odd so that the three box-blur methodology works.
                 
+                //calculate the size necessary for vImageBoxConvolve_ARGB8888, this does not actually do any operations.
                 NSInteger tempBufferSize = vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, NULL, 0, 0, wholeRadius, wholeRadius, NULL, kvImageGetTempBufferSize | kvImageEdgeExtend);
                 void *tempBuffer = malloc(tempBufferSize);
                 

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -224,6 +224,15 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * _
                              completion:(nullable dispatch_block_t)completion;
 
 /**
+ Sets the maximum size of an image that PINRemoteImage will blur. If the image is too large, blurring is skipped
+ 
+ @param maxProgressiveRenderSize A CGSize which indicates the max size PINRemoteImage will render a progressive image. If an image is larger in either dimension, progressive rendering will be skipped
+ @param completion Completion to be called once maxProgressiveRenderSize is set.
+ */
+- (void)setProgressiveRendersMaxProgressiveRenderSize:(CGSize)maxProgressiveRenderSize
+                              completion:(nullable dispatch_block_t)completion;
+
+/**
  Prefetch an image at the given URL.
  
  @param url NSURL where the image to prefetch resides.


### PR DESCRIPTION
Core Image crashes were still showing up in our stack traces
even after many speculative fixes. Lets see if accelerate does
better.