### PR TITLE
Add optional block to track download progress of image

### DIFF
--- a/Example-Mac/PINRemoteImage/ProgressiveViewController.m
+++ b/Example-Mac/PINRemoteImage/ProgressiveViewController.m
@@ -50,7 +50,7 @@
     NSMutableArray *progress = [[NSMutableArray alloc] init];
     [[PINRemoteImageManager sharedImageManager]
      downloadImageWithURL:progressiveURL
-     options:PINRemoteImageManagerDownloadOptionsNone progress:^(PINRemoteImageManagerResult *result) {
+     options:PINRemoteImageManagerDownloadOptionsNone progressImage:^(PINRemoteImageManagerResult *result) {
          [progress addObject:result.image];
      } completion:^(PINRemoteImageManagerResult *result) {
          [progress addObject:result.image];

--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -683,7 +683,7 @@
     __block UIImage *image;
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
-                                    progress:nil
+                               progressImage:nil
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
@@ -699,7 +699,7 @@
     [self.imageManager setCurrentBytesPerSecond:5];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
-                                    progress:nil
+                               progressImage:nil
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
@@ -711,7 +711,7 @@
     [self.imageManager.cache removeAllObjects];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
-                                    progress:nil
+                               progressImage:nil
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
@@ -725,7 +725,7 @@
     [self.imageManager setCurrentBytesPerSecond:100];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
-                                    progress:nil
+                               progressImage:nil
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
@@ -742,7 +742,7 @@
     [self.imageManager setCurrentBytesPerSecond:7];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Medium], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
-                                    progress:nil
+                               progressImage:nil
                                   completion:^(PINRemoteImageManagerResult *result)
      {
          image = result.image;
@@ -770,7 +770,7 @@
     [self.imageManager setCurrentBytesPerSecond:7];
     [self.imageManager downloadImageWithURLs:@[[self JPEGURL_Small], [self JPEGURL_Large]]
                                      options:PINRemoteImageManagerDownloadOptionsNone
-                                    progress:nil
+                               progressImage:nil
                                   completion:^(PINRemoteImageManagerResult *result)
      {
          image = result.image;

--- a/Example/PINRemoteImage/ProgressiveViewController.m
+++ b/Example/PINRemoteImage/ProgressiveViewController.m
@@ -48,7 +48,7 @@
     NSMutableArray *progress = [[NSMutableArray alloc] init];
     [[PINRemoteImageManager sharedImageManager]
      downloadImageWithURL:progressiveURL
-     options:PINRemoteImageManagerDownloadOptionsNone progress:^(PINRemoteImageManagerResult *result) {
+     options:PINRemoteImageManagerDownloadOptionsNone progressImage:^(PINRemoteImageManagerResult *result) {
          [progress addObject:result.image];
      } completion:^(PINRemoteImageManagerResult *result) {
          [progress addObject:result.image];

--- a/Pod/Classes/PINRemoteImageCallbacks.h
+++ b/Pod/Classes/PINRemoteImageCallbacks.h
@@ -13,7 +13,7 @@
 @interface PINRemoteImageCallbacks : NSObject
 
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion completionBlock;
-@property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion progressBlock;
+@property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion progressImageBlock;
 @property (nonatomic, strong, nullable) PINRemoteImageManagerDownloadProgress downloadProgressBlock;
 @property (nonatomic, assign) CFTimeInterval requestTime;
 

--- a/Pod/Classes/PINRemoteImageCallbacks.h
+++ b/Pod/Classes/PINRemoteImageCallbacks.h
@@ -14,7 +14,7 @@
 
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion completionBlock;
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion progressImageBlock;
-@property (nonatomic, strong, nullable) PINRemoteImageManagerDownloadProgress progressDownloadBlock;
+@property (nonatomic, strong, nullable) PINRemoteImageManagerProgressDownload progressDownloadBlock;
 @property (nonatomic, assign) CFTimeInterval requestTime;
 
 @end

--- a/Pod/Classes/PINRemoteImageCallbacks.h
+++ b/Pod/Classes/PINRemoteImageCallbacks.h
@@ -14,6 +14,7 @@
 
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion completionBlock;
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion progressBlock;
+@property (nonatomic, strong, nullable) PINRemoteImageManagerDownloadProgress downloadProgressBlock;
 @property (nonatomic, assign) CFTimeInterval requestTime;
 
 @end

--- a/Pod/Classes/PINRemoteImageCallbacks.h
+++ b/Pod/Classes/PINRemoteImageCallbacks.h
@@ -14,7 +14,7 @@
 
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion completionBlock;
 @property (nonatomic, strong, nullable) PINRemoteImageManagerImageCompletion progressImageBlock;
-@property (nonatomic, strong, nullable) PINRemoteImageManagerDownloadProgress downloadProgressBlock;
+@property (nonatomic, strong, nullable) PINRemoteImageManagerDownloadProgress progressDownloadBlock;
 @property (nonatomic, assign) CFTimeInterval requestTime;
 
 @end

--- a/Pod/Classes/PINRemoteImageCategoryManager.m
+++ b/Pod/Classes/PINRemoteImageCategoryManager.m
@@ -259,7 +259,7 @@
     if (urls.count > 1) {
         downloadImageOperationUUID = [[PINRemoteImageManager sharedImageManager] downloadImageWithURLs:urls
                                                                                                options:options
-                                                                                              progress:internalProgress
+                                                                                         progressImage:internalProgress
                                                                                             completion:internalCompletion];
     } else if (processorKey.length > 0 && processor) {
         downloadImageOperationUUID = [[PINRemoteImageManager sharedImageManager] downloadImageWithURL:urls[0]
@@ -270,7 +270,7 @@
     } else {
         downloadImageOperationUUID = [[PINRemoteImageManager sharedImageManager] downloadImageWithURL:urls[0]
                                                                                               options:options
-                                                                                             progress:internalProgress
+                                                                                        progressImage:internalProgress
                                                                                            completion:internalCompletion];
     }
     

--- a/Pod/Classes/PINRemoteImageDownloadTask.m
+++ b/Pod/Classes/PINRemoteImageDownloadTask.m
@@ -17,7 +17,7 @@
 {
     __block BOOL hasProgressBlocks = NO;
     [self.callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
-        if (callback.progressBlock) {
+        if (callback.progressImageBlock) {
             hasProgressBlocks = YES;
             *stop = YES;
         }
@@ -28,15 +28,16 @@
 - (void)callProgressWithQueue:(dispatch_queue_t)queue withImage:(PINImage *)image
 {
     [self.callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
-        if (callback.progressBlock != nil) {
+        if (callback.progressImageBlock != nil) {
             PINLog(@"calling progress for UUID: %@ key: %@", UUID, self.key);
             dispatch_async(queue, ^
             {
-                callback.progressBlock([PINRemoteImageManagerResult imageResultWithImage:image
-                                                                          animatedImage:nil
-                                                                          requestLength:CACurrentMediaTime() - callback.requestTime
-                                                                                  error:nil
-                                                                             resultType:PINRemoteImageResultTypeProgress UUID:UUID]);
+                callback.progressImageBlock([PINRemoteImageManagerResult imageResultWithImage:image
+                                                                                animatedImage:nil
+                                                                                requestLength:CACurrentMediaTime() - callback.requestTime
+                                                                                        error:nil
+                                                                                   resultType:PINRemoteImageResultTypeProgress
+                                                                                         UUID:UUID]);
             });
         }
     }];

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -114,6 +114,14 @@ typedef void(^PINRemoteImageManagerAuthenticationChallengeCompletionHandler)(NSU
  */
 typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * __nullable task, NSURLAuthenticationChallenge * __nonnull challenge, PINRemoteImageManagerAuthenticationChallengeCompletionHandler __nullable aHandler);
 
+/**
+ Handler called for many PINRemoteImage tasks providing the progress of the download.
+ 
+ @param completedBytes Amount of bytes that have been downloaded so far.
+ @param totalBytes Total amount of bytes in the image being downloaded.
+ */
+typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, NSInteger totalBytes);
+
 @interface PINRemoteImageManager : NSObject
 
 @property (nonatomic, readonly, nonnull) PINCache * cache;
@@ -303,6 +311,38 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * _
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
+ Download or retrieve from cache the image found at the url. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
+ 
+ @param url NSURL where the image to download resides.
+ @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
+ @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
+ 
+ @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
+ */
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                         downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+
+/**
+ Download or retrieve from cache the image found at the url. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
+ 
+ @param url NSURL where the image to download resides.
+ @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
+ @param progress PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
+ @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
+ 
+ @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
+ */
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                                 progress:(nullable PINRemoteImageManagerImageCompletion)progress
+                         downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+
+/**
  Download or retrieve from cache the image found at the url and process it before calling completion. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
  
  @param url NSURL where the image to download resides.
@@ -317,6 +357,25 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * _
                                   options:(PINRemoteImageManagerDownloadOptions)options
                              processorKey:(nullable NSString *)processorKey
                                 processor:(nullable PINRemoteImageManagerImageProcessor)processor
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+
+/**
+ Download or retrieve from cache the image found at the url and process it before calling completion. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
+ 
+ @param url NSURL where the image to download resides.
+ @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
+ @param processorKey NSString key to uniquely identify processor and process. Will be used for caching processed images.
+ @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param processor PINRemoteImageManagerImageProcessor block which will be called to post-process downloaded image.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
+ 
+ @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
+ */
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                             processorKey:(nullable NSString *)processorKey
+                                processor:(nullable PINRemoteImageManagerImageProcessor)processor
+                         downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -163,7 +163,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
 
 /**
  Set the minimum BPS to download the highest quality image in a set.
- @see downloadImageWithURLs:options:progress:completion:
+ @see downloadImageWithURLs:options:progressImage:completion:
  
  @param highQualityBPSThreshold bytes per second minimum. Defaults to 500000.
  @param completion Completion to be called once highQualityBPSThreshold has been set.
@@ -172,7 +172,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
 
 /**
  Set the maximum BPS to download the lowest quality image in a set.
- @see downloadImageWithURLs:options:progress:completion:
+ @see downloadImageWithURLs:options:progressImage:completion:
 
  @param lowQualityBPSThreshold bytes per second maximum. Defaults to 50000.
  @param completion Completion to be called once lowQualityBPSThreshold has been set.
@@ -182,7 +182,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
 
 /**
  Set whether high quality images should be downloaded when a low quality image is cached if network connectivity has improved.
- @see downloadImageWithURLs:options:progress:completion:
+ @see downloadImageWithURLs:options:progressImage:completion:
  
  @param shouldUpgradeLowQualityImages if YES, low quality images will be 'upgraded'.
  @param completion Completion to be called once shouldUpgradeLowQualityImages has been set.
@@ -300,14 +300,14 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  
  @param url NSURL where the image to download resides.
  @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
- @param progress PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
+ @param progressImage PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
  
  @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
-                                 progress:(nullable PINRemoteImageManagerImageCompletion)progress
+                            progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
@@ -330,7 +330,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  
  @param url NSURL where the image to download resides.
  @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
- @param progress PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
+ @param progressImage PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
  @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
  
@@ -338,7 +338,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
-                                 progress:(nullable PINRemoteImageManagerImageCompletion)progress
+                            progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
                          downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
@@ -385,14 +385,14 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  
  @param urls An array of NSURLs of increasing size.
  @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
- @param progress PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
+ @param progressImage PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
  
  @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
  */
 - (nullable NSUUID *)downloadImageWithURLs:(nonnull NSArray <NSURL *> *)urls
                                    options:(PINRemoteImageManagerDownloadOptions)options
-                                  progress:(nullable PINRemoteImageManagerImageCompletion)progress
+                             progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
                                 completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
@@ -434,9 +434,9 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
 /**
  * @abstract set the progress callback on a download task. You can use this to add progress callbacks or remove them for in flight downloads
  *
- * @param progressCallback a PINRemoteImageManagerImageCompletion block to be called with a progress update
+ * @param progressImageCallback a PINRemoteImageManagerImageCompletion block to be called with a progress update
  * @param UUID NSUUID of the task to set the priority on.
  */
-- (void)setProgressCallback:(nullable PINRemoteImageManagerImageCompletion)progress ofTaskWithUUID:(nonnull NSUUID *)UUID;
+- (void)setProgressImageCallback:(nullable PINRemoteImageManagerImageCompletion)progressImageBlock ofTaskWithUUID:(nonnull NSUUID *)UUID;
 
 @end

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -315,14 +315,14 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  
  @param url NSURL where the image to download resides.
  @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
- @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param progressDownload PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
  
  @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
-                         downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
+                         progressDownload:(nullable PINRemoteImageManagerDownloadProgress)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
@@ -331,7 +331,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  @param url NSURL where the image to download resides.
  @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
  @param progressImage PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
- @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param progressDownload PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
  
  @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
@@ -339,7 +339,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
                             progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
-                         downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
+                         progressDownload:(nullable PINRemoteImageManagerDownloadProgress)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
@@ -365,7 +365,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  @param url NSURL where the image to download resides.
  @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
  @param processorKey NSString key to uniquely identify processor and process. Will be used for caching processed images.
- @param downloadProgress PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param progressDownload PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
  @param processor PINRemoteImageManagerImageProcessor block which will be called to post-process downloaded image.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
  
@@ -375,7 +375,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
                                   options:(PINRemoteImageManagerDownloadOptions)options
                              processorKey:(nullable NSString *)processorKey
                                 processor:(nullable PINRemoteImageManagerImageProcessor)processor
-                         downloadProgress:(nullable PINRemoteImageManagerDownloadProgress)downloadProgress
+                         progressDownload:(nullable PINRemoteImageManagerDownloadProgress)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -120,7 +120,7 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * _
  @param completedBytes Amount of bytes that have been downloaded so far.
  @param totalBytes Total amount of bytes in the image being downloaded.
  */
-typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, NSInteger totalBytes);
+typedef void(^PINRemoteImageManagerProgressDownload)(NSInteger completedBytes, NSInteger totalBytes);
 
 @interface PINRemoteImageManager : NSObject
 
@@ -322,7 +322,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
-                         progressDownload:(nullable PINRemoteImageManagerDownloadProgress)progressDownload
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
@@ -339,7 +339,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
                             progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
-                         progressDownload:(nullable PINRemoteImageManagerDownloadProgress)progressDownload
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
@@ -375,7 +375,7 @@ typedef void(^PINRemoteImageManagerDownloadProgress)(NSInteger completedBytes, N
                                   options:(PINRemoteImageManagerDownloadOptions)options
                              processorKey:(nullable NSString *)processorKey
                                 processor:(nullable PINRemoteImageManagerImageProcessor)processor
-                         progressDownload:(nullable PINRemoteImageManagerDownloadProgress)progressDownload
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -367,13 +367,13 @@ static dispatch_once_t sharedDispatchToken;
 {
     return [self downloadImageWithURL:url
                               options:options
-                             progress:nil
+                        progressImage:nil
                            completion:completion];
 }
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                          options:(PINRemoteImageManagerDownloadOptions)options
-                        progress:(PINRemoteImageManagerImageCompletion)progress
+                   progressImage:(PINRemoteImageManagerImageCompletion)progressImage
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -381,7 +381,7 @@ static dispatch_once_t sharedDispatchToken;
                              priority:PINRemoteImageManagerPriorityMedium
                          processorKey:nil
                             processor:nil
-                             progress:progress
+                        progressImage:progressImage
                      downloadProgress:nil
                            completion:completion
                             inputUUID:nil];
@@ -397,7 +397,7 @@ static dispatch_once_t sharedDispatchToken;
                              priority:PINRemoteImageManagerPriorityMedium
                          processorKey:nil
                             processor:nil
-                             progress:nil
+                        progressImage:nil
                      downloadProgress:downloadProgress
                            completion:completion
                             inputUUID:nil];
@@ -405,7 +405,7 @@ static dispatch_once_t sharedDispatchToken;
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                          options:(PINRemoteImageManagerDownloadOptions)options
-                        progress:(PINRemoteImageManagerImageCompletion)progress
+                   progressImage:(PINRemoteImageManagerImageCompletion)progressImage
                 downloadProgress:(PINRemoteImageManagerDownloadProgress)downloadProgress
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
@@ -414,7 +414,7 @@ static dispatch_once_t sharedDispatchToken;
                              priority:PINRemoteImageManagerPriorityMedium
                          processorKey:nil
                             processor:nil
-                             progress:progress
+                        progressImage:progressImage
                      downloadProgress:downloadProgress
                            completion:completion
                             inputUUID:nil];
@@ -431,7 +431,7 @@ static dispatch_once_t sharedDispatchToken;
                              priority:PINRemoteImageManagerPriorityMedium
                          processorKey:processorKey
                             processor:processor
-                             progress:nil
+                        progressImage:nil
                      downloadProgress:nil
                            completion:completion
                             inputUUID:nil];
@@ -449,7 +449,7 @@ static dispatch_once_t sharedDispatchToken;
                          priority:PINRemoteImageManagerPriorityMedium
                      processorKey:processorKey
                         processor:processor
-                         progress:nil
+                    progressImage:nil
                  downloadProgress:downloadProgress
                        completion:completion
                         inputUUID:nil];
@@ -460,7 +460,7 @@ static dispatch_once_t sharedDispatchToken;
                         priority:(PINRemoteImageManagerPriority)priority
                     processorKey:(NSString *)processorKey
                        processor:(PINRemoteImageManagerImageProcessor)processor
-                        progress:(PINRemoteImageManagerImageCompletion)progress
+                   progressImage:(PINRemoteImageManagerImageCompletion)progressImage
                 downloadProgress:(PINRemoteImageManagerDownloadProgress)downloadProgress
                       completion:(PINRemoteImageManagerImageCompletion)completion
                        inputUUID:(NSUUID *)UUID
@@ -522,7 +522,7 @@ static dispatch_once_t sharedDispatchToken;
                  taskExisted = YES;
                  PINLog(@"Task exists, attaching with key: %@, URL: %@, UUID: %@, task: %@", key, url, UUID, task);
              }
-             [task addCallbacksWithCompletionBlock:completion progressBlock:progress downloadProgressBlock:downloadProgress withUUID:UUID];
+             [task addCallbacksWithCompletionBlock:completion progressImageBlock:progressImage downloadProgressBlock:downloadProgress withUUID:UUID];
              [strongSelf.tasks setObject:task forKey:key];
              
              BlockAssert(taskClass == [task class], @"Task class should be the same!");
@@ -574,7 +574,7 @@ static dispatch_once_t sharedDispatchToken;
                                                             priority:priority
                                                         processorKey:processorKey
                                                            processor:processor
-                                                            progress:(PINRemoteImageManagerImageCompletion)progress
+                                                       progressImage:(PINRemoteImageManagerImageCompletion)progressImage
                                                     downloadProgress:nil
                                                           completion:completion
                                                            inputUUID:UUID];
@@ -594,7 +594,7 @@ static dispatch_once_t sharedDispatchToken;
                                                              options:options
                                                             priority:priority
                                                                  key:key
-                                                            progress:progress
+                                                       progressImage:progressImage
                                                                 UUID:UUID];
                                 }
                             }
@@ -708,7 +708,7 @@ static dispatch_once_t sharedDispatchToken;
                      options:(PINRemoteImageManagerDownloadOptions)options
                     priority:(PINRemoteImageManagerPriority)priority
                          key:(NSString *)key
-                    progress:(PINRemoteImageManagerImageCompletion)progress
+               progressImage:(PINRemoteImageManagerImageCompletion)progressImage
                         UUID:(NSUUID *)UUID
 {
     [self lock];
@@ -996,7 +996,7 @@ static dispatch_once_t sharedDispatchToken;
                       priority:PINRemoteImageManagerPriorityVeryLow
                   processorKey:nil
                      processor:nil
-                      progress:nil
+                 progressImage:nil
               downloadProgress:nil
                     completion:nil
                      inputUUID:nil];
@@ -1064,7 +1064,7 @@ static dispatch_once_t sharedDispatchToken;
     }];
 }
 
-- (void)setProgressCallback:(nullable PINRemoteImageManagerImageCompletion)progress ofTaskWithUUID:(nonnull NSUUID *)UUID
+- (void)setProgressImageCallback:(nullable PINRemoteImageManagerImageCompletion)progressImageBlock ofTaskWithUUID:(nonnull NSUUID *)UUID
 {
     if (UUID == nil) {
         return;
@@ -1081,7 +1081,7 @@ static dispatch_once_t sharedDispatchToken;
                 if ([blockUUID isEqual:UUID]) {
                     if ([task isKindOfClass:[PINRemoteImageDownloadTask class]]) {
                         PINRemoteImageCallbacks *callbacks = task.callbackBlocks[blockUUID];
-                        callbacks.progressBlock = progress;
+                        callbacks.progressImageBlock = progressImageBlock;
                     }
                     break;
                 }
@@ -1297,7 +1297,7 @@ static dispatch_once_t sharedDispatchToken;
 
 - (NSUUID *)downloadImageWithURLs:(NSArray <NSURL *> *)urls
                           options:(PINRemoteImageManagerDownloadOptions)options
-                         progress:(PINRemoteImageManagerImageCompletion)progress
+                    progressImage:(PINRemoteImageManagerImageCompletion)progressImage
                        completion:(PINRemoteImageManagerImageCompletion)completion
 {
     NSUUID *UUID = [NSUUID UUID];
@@ -1308,7 +1308,7 @@ static dispatch_once_t sharedDispatchToken;
                           priority:PINRemoteImageManagerPriorityMedium
                       processorKey:nil
                          processor:nil
-                          progress:progress
+                     progressImage:progressImage
                   downloadProgress:nil
                         completion:completion
                          inputUUID:UUID];
@@ -1379,7 +1379,7 @@ static dispatch_once_t sharedDispatchToken;
                                 priority:PINRemoteImageManagerPriorityMedium
                             processorKey:nil
                                processor:nil
-                                progress:progress
+                           progressImage:progressImage
                         downloadProgress:nil
                               completion:^(PINRemoteImageManagerResult *result) {
                                   typeof(self) strongSelf = weakSelf;

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -389,7 +389,7 @@ static dispatch_once_t sharedDispatchToken;
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                          options:(PINRemoteImageManagerDownloadOptions)options
-                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
+                progressDownload:(PINRemoteImageManagerProgressDownload)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -406,7 +406,7 @@ static dispatch_once_t sharedDispatchToken;
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                          options:(PINRemoteImageManagerDownloadOptions)options
                    progressImage:(PINRemoteImageManagerImageCompletion)progressImage
-                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
+                progressDownload:(PINRemoteImageManagerProgressDownload)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -441,7 +441,7 @@ static dispatch_once_t sharedDispatchToken;
                          options:(PINRemoteImageManagerDownloadOptions)options
                     processorKey:(NSString *)processorKey
                        processor:(PINRemoteImageManagerImageProcessor)processor
-                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
+                progressDownload:(PINRemoteImageManagerProgressDownload)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -461,7 +461,7 @@ static dispatch_once_t sharedDispatchToken;
                     processorKey:(NSString *)processorKey
                        processor:(PINRemoteImageManagerImageProcessor)processor
                    progressImage:(PINRemoteImageManagerImageCompletion)progressImage
-                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
+                progressDownload:(PINRemoteImageManagerProgressDownload)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
                        inputUUID:(NSUUID *)UUID
 {

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -382,14 +382,14 @@ static dispatch_once_t sharedDispatchToken;
                          processorKey:nil
                             processor:nil
                         progressImage:progressImage
-                     downloadProgress:nil
+                     progressDownload:nil
                            completion:completion
                             inputUUID:nil];
 }
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                          options:(PINRemoteImageManagerDownloadOptions)options
-                downloadProgress:(PINRemoteImageManagerDownloadProgress)downloadProgress
+                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -398,7 +398,7 @@ static dispatch_once_t sharedDispatchToken;
                          processorKey:nil
                             processor:nil
                         progressImage:nil
-                     downloadProgress:downloadProgress
+                     progressDownload:progressDownload
                            completion:completion
                             inputUUID:nil];
 }
@@ -406,7 +406,7 @@ static dispatch_once_t sharedDispatchToken;
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                          options:(PINRemoteImageManagerDownloadOptions)options
                    progressImage:(PINRemoteImageManagerImageCompletion)progressImage
-                downloadProgress:(PINRemoteImageManagerDownloadProgress)downloadProgress
+                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -415,7 +415,7 @@ static dispatch_once_t sharedDispatchToken;
                          processorKey:nil
                             processor:nil
                         progressImage:progressImage
-                     downloadProgress:downloadProgress
+                     progressDownload:progressDownload
                            completion:completion
                             inputUUID:nil];
 }
@@ -432,7 +432,7 @@ static dispatch_once_t sharedDispatchToken;
                          processorKey:processorKey
                             processor:processor
                         progressImage:nil
-                     downloadProgress:nil
+                     progressDownload:nil
                            completion:completion
                             inputUUID:nil];
 }
@@ -441,7 +441,7 @@ static dispatch_once_t sharedDispatchToken;
                          options:(PINRemoteImageManagerDownloadOptions)options
                     processorKey:(NSString *)processorKey
                        processor:(PINRemoteImageManagerImageProcessor)processor
-                downloadProgress:(PINRemoteImageManagerDownloadProgress)downloadProgress
+                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
@@ -450,7 +450,7 @@ static dispatch_once_t sharedDispatchToken;
                      processorKey:processorKey
                         processor:processor
                     progressImage:nil
-                 downloadProgress:downloadProgress
+                 progressDownload:progressDownload
                        completion:completion
                         inputUUID:nil];
 }
@@ -461,7 +461,7 @@ static dispatch_once_t sharedDispatchToken;
                     processorKey:(NSString *)processorKey
                        processor:(PINRemoteImageManagerImageProcessor)processor
                    progressImage:(PINRemoteImageManagerImageCompletion)progressImage
-                downloadProgress:(PINRemoteImageManagerDownloadProgress)downloadProgress
+                progressDownload:(PINRemoteImageManagerDownloadProgress)progressDownload
                       completion:(PINRemoteImageManagerImageCompletion)completion
                        inputUUID:(NSUUID *)UUID
 {
@@ -522,7 +522,7 @@ static dispatch_once_t sharedDispatchToken;
                  taskExisted = YES;
                  PINLog(@"Task exists, attaching with key: %@, URL: %@, UUID: %@, task: %@", key, url, UUID, task);
              }
-             [task addCallbacksWithCompletionBlock:completion progressImageBlock:progressImage downloadProgressBlock:downloadProgress withUUID:UUID];
+             [task addCallbacksWithCompletionBlock:completion progressImageBlock:progressImage progressDownloadBlock:progressDownload withUUID:UUID];
              [strongSelf.tasks setObject:task forKey:key];
              
              BlockAssert(taskClass == [task class], @"Task class should be the same!");
@@ -575,7 +575,7 @@ static dispatch_once_t sharedDispatchToken;
                                                         processorKey:processorKey
                                                            processor:processor
                                                        progressImage:(PINRemoteImageManagerImageCompletion)progressImage
-                                                    downloadProgress:nil
+                                                    progressDownload:nil
                                                           completion:completion
                                                            inputUUID:UUID];
                                 }
@@ -997,7 +997,7 @@ static dispatch_once_t sharedDispatchToken;
                   processorKey:nil
                      processor:nil
                  progressImage:nil
-              downloadProgress:nil
+              progressDownload:nil
                     completion:nil
                      inputUUID:nil];
 }
@@ -1309,7 +1309,7 @@ static dispatch_once_t sharedDispatchToken;
                       processorKey:nil
                          processor:nil
                      progressImage:progressImage
-                  downloadProgress:nil
+                  progressDownload:nil
                         completion:completion
                          inputUUID:UUID];
         return UUID;
@@ -1380,7 +1380,7 @@ static dispatch_once_t sharedDispatchToken;
                             processorKey:nil
                                processor:nil
                            progressImage:progressImage
-                        downloadProgress:nil
+                        progressDownload:nil
                               completion:^(PINRemoteImageManagerResult *result) {
                                   typeof(self) strongSelf = weakSelf;
                                   //clean out any lower quality images from the cache

--- a/Pod/Classes/PINRemoteImageTask.h
+++ b/Pod/Classes/PINRemoteImageTask.h
@@ -18,7 +18,10 @@
 @property (nonatomic, copy, nullable) NSString *key;
 #endif
 
-- (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock progressBlock:(nullable PINRemoteImageManagerImageCompletion)progressBlock downloadProgressBlock:(nullable PINRemoteImageManagerDownloadProgress)downloadProgressBlock withUUID:(nonnull NSUUID *)UUID;
+- (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock
+                     progressImageBlock:(nullable PINRemoteImageManagerImageCompletion)progressImageBlock
+                  downloadProgressBlock:(nullable PINRemoteImageManagerDownloadProgress)downloadProgressBlock
+                               withUUID:(nonnull NSUUID *)UUID;
 - (void)removeCallbackWithUUID:(nonnull NSUUID *)UUID;
 - (void)callCompletionsWithQueue:(nonnull dispatch_queue_t)queue remove:(BOOL)remove withImage:(nullable PINImage *)image animatedImage:(nullable FLAnimatedImage *)animatedImage cached:(BOOL)cached error:(nullable NSError *)error;
 //returns YES if no more attached completionBlocks

--- a/Pod/Classes/PINRemoteImageTask.h
+++ b/Pod/Classes/PINRemoteImageTask.h
@@ -18,7 +18,7 @@
 @property (nonatomic, copy, nullable) NSString *key;
 #endif
 
-- (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock progressBlock:(nullable PINRemoteImageManagerImageCompletion)progressBlock withUUID:(nonnull NSUUID *)UUID;
+- (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock progressBlock:(nullable PINRemoteImageManagerImageCompletion)progressBlock downloadProgressBlock:(nullable PINRemoteImageManagerDownloadProgress)downloadProgressBlock withUUID:(nonnull NSUUID *)UUID;
 - (void)removeCallbackWithUUID:(nonnull NSUUID *)UUID;
 - (void)callCompletionsWithQueue:(nonnull dispatch_queue_t)queue remove:(BOOL)remove withImage:(nullable PINImage *)image animatedImage:(nullable FLAnimatedImage *)animatedImage cached:(BOOL)cached error:(nullable NSError *)error;
 //returns YES if no more attached completionBlocks

--- a/Pod/Classes/PINRemoteImageTask.h
+++ b/Pod/Classes/PINRemoteImageTask.h
@@ -20,7 +20,7 @@
 
 - (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock
                      progressImageBlock:(nullable PINRemoteImageManagerImageCompletion)progressImageBlock
-                  downloadProgressBlock:(nullable PINRemoteImageManagerDownloadProgress)downloadProgressBlock
+                  progressDownloadBlock:(nullable PINRemoteImageManagerDownloadProgress)progressDownloadBlock
                                withUUID:(nonnull NSUUID *)UUID;
 - (void)removeCallbackWithUUID:(nonnull NSUUID *)UUID;
 - (void)callCompletionsWithQueue:(nonnull dispatch_queue_t)queue remove:(BOOL)remove withImage:(nullable PINImage *)image animatedImage:(nullable FLAnimatedImage *)animatedImage cached:(BOOL)cached error:(nullable NSError *)error;

--- a/Pod/Classes/PINRemoteImageTask.h
+++ b/Pod/Classes/PINRemoteImageTask.h
@@ -20,7 +20,7 @@
 
 - (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock
                      progressImageBlock:(nullable PINRemoteImageManagerImageCompletion)progressImageBlock
-                  progressDownloadBlock:(nullable PINRemoteImageManagerDownloadProgress)progressDownloadBlock
+                  progressDownloadBlock:(nullable PINRemoteImageManagerProgressDownload)progressDownloadBlock
                                withUUID:(nonnull NSUUID *)UUID;
 - (void)removeCallbackWithUUID:(nonnull NSUUID *)UUID;
 - (void)callCompletionsWithQueue:(nonnull dispatch_queue_t)queue remove:(BOOL)remove withImage:(nullable PINImage *)image animatedImage:(nullable FLAnimatedImage *)animatedImage cached:(BOOL)cached error:(nullable NSError *)error;

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -27,7 +27,7 @@
 
 - (void)addCallbacksWithCompletionBlock:(PINRemoteImageManagerImageCompletion)completionBlock
                      progressImageBlock:(PINRemoteImageManagerImageCompletion)progressImageBlock
-                  progressDownloadBlock:(PINRemoteImageManagerDownloadProgress)progressDownloadBlock
+                  progressDownloadBlock:(PINRemoteImageManagerProgressDownload)progressDownloadBlock
                                withUUID:(NSUUID *)UUID
 {
     PINRemoteImageCallbacks *completion = [[PINRemoteImageCallbacks alloc] init];

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -27,13 +27,13 @@
 
 - (void)addCallbacksWithCompletionBlock:(PINRemoteImageManagerImageCompletion)completionBlock
                      progressImageBlock:(PINRemoteImageManagerImageCompletion)progressImageBlock
-                  downloadProgressBlock:(PINRemoteImageManagerDownloadProgress)downloadProgressBlock
+                  progressDownloadBlock:(PINRemoteImageManagerDownloadProgress)progressDownloadBlock
                                withUUID:(NSUUID *)UUID
 {
     PINRemoteImageCallbacks *completion = [[PINRemoteImageCallbacks alloc] init];
     completion.completionBlock = completionBlock;
     completion.progressImageBlock = progressImageBlock;
-    completion.downloadProgressBlock = downloadProgressBlock;
+    completion.progressDownloadBlock = progressDownloadBlock;
     
     [self.callbackBlocks setObject:completion forKey:UUID];
 }

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -25,11 +25,12 @@
     return [NSString stringWithFormat:@"<%@: %p> completionBlocks: %lu", NSStringFromClass([self class]), self, (unsigned long)self.callbackBlocks.count];
 }
 
-- (void)addCallbacksWithCompletionBlock:(PINRemoteImageManagerImageCompletion)completionBlock progressBlock:(PINRemoteImageManagerImageCompletion)progressBlock withUUID:(NSUUID *)UUID
+- (void)addCallbacksWithCompletionBlock:(PINRemoteImageManagerImageCompletion)completionBlock progressBlock:(PINRemoteImageManagerImageCompletion)progressBlock downloadProgressBlock:(PINRemoteImageManagerDownloadProgress)downloadProgressBlock withUUID:(NSUUID *)UUID
 {
     PINRemoteImageCallbacks *completion = [[PINRemoteImageCallbacks alloc] init];
     completion.completionBlock = completionBlock;
     completion.progressBlock = progressBlock;
+    completion.downloadProgressBlock = downloadProgressBlock;
     
     [self.callbackBlocks setObject:completion forKey:UUID];
 }

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -25,11 +25,14 @@
     return [NSString stringWithFormat:@"<%@: %p> completionBlocks: %lu", NSStringFromClass([self class]), self, (unsigned long)self.callbackBlocks.count];
 }
 
-- (void)addCallbacksWithCompletionBlock:(PINRemoteImageManagerImageCompletion)completionBlock progressBlock:(PINRemoteImageManagerImageCompletion)progressBlock downloadProgressBlock:(PINRemoteImageManagerDownloadProgress)downloadProgressBlock withUUID:(NSUUID *)UUID
+- (void)addCallbacksWithCompletionBlock:(PINRemoteImageManagerImageCompletion)completionBlock
+                     progressImageBlock:(PINRemoteImageManagerImageCompletion)progressImageBlock
+                  downloadProgressBlock:(PINRemoteImageManagerDownloadProgress)downloadProgressBlock
+                               withUUID:(NSUUID *)UUID
 {
     PINRemoteImageCallbacks *completion = [[PINRemoteImageCallbacks alloc] init];
     completion.completionBlock = completionBlock;
-    completion.progressBlock = progressBlock;
+    completion.progressImageBlock = progressImageBlock;
     completion.downloadProgressBlock = downloadProgressBlock;
     
     [self.callbackBlocks setObject:completion forKey:UUID];


### PR DESCRIPTION
To get issue #70 going again I moved code from #110 over to a new pull request as well as updated it to the latest changes like nullability, OS X support etc.

Basically what it does is it adds an additional optional block to PINRemoteImageManager to allow users to track progress of image downloads in bytes.

@garrettmoon I didn't rename the progress parameter to progressImage yet as this would change the API. Don't know if it's already to late for 2.0 where maybe it would make sense to make API breaking changes ...

- [x] Add download progress image named: progressImage
- [x] Renamed progress to progressDownload
- [x] Call PINRemoteImageDownloadTask callback blocks outside the PINRemoteImageManager lock 