### PR TITLE
Fixes a crash in task callbacks

### DIFF
--- a/Pod/Classes/PINRemoteImageDownloadTask.h
+++ b/Pod/Classes/PINRemoteImageDownloadTask.h
@@ -18,6 +18,7 @@
 @property (nonatomic, assign) BOOL hasProgressBlocks;
 @property (nonatomic, strong, nullable) PINProgressiveImage *progressImage;
 
-- (void)callProgressWithQueue:(nonnull dispatch_queue_t)queue withImage:(nonnull PINImage *)image;
+- (void)callProgressDownloadWithQueue:(nonnull dispatch_queue_t)queue completedBytes:(int64_t)completedBytes totalBytes:(int64_t)totalBytes;
+- (void)callProgressImageWithQueue:(nonnull dispatch_queue_t)queue withImage:(nonnull PINImage *)image;
 
 @end

--- a/Pod/Classes/PINRemoteImageDownloadTask.m
+++ b/Pod/Classes/PINRemoteImageDownloadTask.m
@@ -59,11 +59,12 @@
         if (callback.progressImageBlock != nil) {
             PINLog(@"calling progress for UUID: %@ key: %@", UUID, self.key);
             PINRemoteImageManagerImageCompletion progressImageBlock = callback.progressImageBlock;
+            CFTimeInterval requestTime = callback.requestTime;
             dispatch_async(queue, ^
             {
                 progressImageBlock([PINRemoteImageManagerResult imageResultWithImage:image
                                                                        animatedImage:nil
-                                                                       requestLength:CACurrentMediaTime() - callback.requestTime
+                                                                       requestLength:CACurrentMediaTime() - requestTime
                                                                                error:nil
                                                                           resultType:PINRemoteImageResultTypeProgress
                                                                                 UUID:UUID]);

--- a/Pod/Classes/PINRemoteImageDownloadTask.m
+++ b/Pod/Classes/PINRemoteImageDownloadTask.m
@@ -45,6 +45,8 @@
         if (callback.progressDownloadBlock != nil) {
             PINLog(@"calling progress for UUID: %@ key: %@", UUID, self.key);
             PINRemoteImageManagerProgressDownload progressDownloadBlock = callback.progressDownloadBlock;
+            //The code run asynchronously below is *not* guaranteed to be run in the manager's lock!
+            //All access to the callbacks and self should be done outside the block below!
             dispatch_async(queue, ^
             {
                 progressDownloadBlock(completedBytes, totalBytes);
@@ -60,6 +62,8 @@
             PINLog(@"calling progress for UUID: %@ key: %@", UUID, self.key);
             PINRemoteImageManagerImageCompletion progressImageBlock = callback.progressImageBlock;
             CFTimeInterval requestTime = callback.requestTime;
+            //The code run asynchronously below is *not* guaranteed to be run in the manager's lock!
+            //All access to the callbacks and self should be done outside the block below!
             dispatch_async(queue, ^
             {
                 progressImageBlock([PINRemoteImageManagerResult imageResultWithImage:image

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -120,7 +120,7 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * _
  @param completedBytes Amount of bytes that have been downloaded so far.
  @param totalBytes Total amount of bytes in the image being downloaded.
  */
-typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int64_t    totalBytes);
+typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int64_t totalBytes);
 
 @interface PINRemoteImageManager : NSObject
 

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -57,6 +57,9 @@
             PINLog(@"calling completion for UUID: %@ key: %@", UUID, strongSelf.key);
             PINRemoteImageManagerImageCompletion completionBlock = callback.completionBlock;
             CFTimeInterval requestTime = callback.requestTime;
+            
+            //The code run asynchronously below is *not* guaranteed to be run in the manager's lock!
+            //All access to the callbacks and self should be done outside the block below!
             dispatch_async(queue, ^
             {
                 PINRemoteImageResultType result;

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -56,6 +56,7 @@
         if (callback.completionBlock != nil) {
             PINLog(@"calling completion for UUID: %@ key: %@", UUID, strongSelf.key);
             PINRemoteImageManagerImageCompletion completionBlock = callback.completionBlock;
+            CFTimeInterval requestTime = callback.requestTime;
             dispatch_async(queue, ^
             {
                 PINRemoteImageResultType result;
@@ -66,7 +67,7 @@
                 }
                 completionBlock([PINRemoteImageManagerResult imageResultWithImage:image
                                                                     animatedImage:animatedImage
-                                                                    requestLength:CACurrentMediaTime() - callback.requestTime
+                                                                    requestLength:CACurrentMediaTime() - requestTime
                                                                             error:error
                                                                        resultType:result
                                                                              UUID:UUID]);

--- a/Pod/Classes/PINRemoteImageTask.m
+++ b/Pod/Classes/PINRemoteImageTask.m
@@ -55,6 +55,7 @@
         typeof(self) strongSelf = weakSelf;
         if (callback.completionBlock != nil) {
             PINLog(@"calling completion for UUID: %@ key: %@", UUID, strongSelf.key);
+            PINRemoteImageManagerImageCompletion completionBlock = callback.completionBlock;
             dispatch_async(queue, ^
             {
                 PINRemoteImageResultType result;
@@ -63,12 +64,12 @@
                 } else {
                     result = PINRemoteImageResultTypeNone;
                 }
-                callback.completionBlock([PINRemoteImageManagerResult imageResultWithImage:image
-                                                                            animatedImage:animatedImage
-                                                                            requestLength:CACurrentMediaTime() - callback.requestTime
-                                                                                    error:error
-                                                                               resultType:result
-                                                                                     UUID:UUID]);
+                completionBlock([PINRemoteImageManagerResult imageResultWithImage:image
+                                                                    animatedImage:animatedImage
+                                                                    requestLength:CACurrentMediaTime() - callback.requestTime
+                                                                            error:error
+                                                                       resultType:result
+                                                                             UUID:UUID]);
             });
         }
         if (remove) {


### PR DESCRIPTION
While all methods on tasks are called within the manager's lock,
dispatching to another queue obviously means the manager may not
be locked anymore.

I also moved calling progress download callbacks to the download
task so it's similar to progress image.

Hopefully these issues have been fixed, but it leads me to believe
a better architecture would be to make the tasks immutable by the
manager and have the tasks manage a lock on themselves. I'll need
to think about that more.