### PR TITLE
FIX: OS X + Carthage

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "pinterest/PINCache" "2.2.1"
+github "pinterest/PINCache" "2.2.2"

--- a/PINRemoteImage/PINRemoteImage/PINRemoteImage-Prefix.pch
+++ b/PINRemoteImage/PINRemoteImage/PINRemoteImage-Prefix.pch
@@ -7,3 +7,4 @@
 //
 
 #import <Availability.h>
+#import "PINRemoteImageMacros.h"

--- a/Pod/Classes/Categories/PINImage+DecodedImage.h
+++ b/Pod/Classes/Categories/PINImage+DecodedImage.h
@@ -6,11 +6,12 @@
 //
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
+
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageMacros.h"

--- a/Pod/Classes/Categories/PINImage+DecodedImage.h
+++ b/Pod/Classes/Categories/PINImage+DecodedImage.h
@@ -7,15 +7,15 @@
 //
 
 @import Foundation;
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 
 #import "PINRemoteImageMacros.h"
 
-#if !(TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if !PIN_TARGET_IOS
 @interface NSImage (PINiOSMapping)
 
 @property(nonatomic, readonly, nullable) CGImageRef CGImage;
@@ -35,7 +35,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image);
 + (nullable PINImage *)pin_decodedImageWithData:(nonnull NSData *)data;
 + (nullable PINImage *)pin_decodedImageWithData:(nonnull NSData *)data skipDecodeIfPossible:(BOOL)skipDecodeIfPossible;
 + (nullable PINImage *)pin_decodedImageWithCGImageRef:(nonnull CGImageRef)imageRef;
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 + (nullable PINImage *)pin_decodedImageWithCGImageRef:(nonnull CGImageRef)imageRef orientation:(UIImageOrientation) orientation;
 #endif
 

--- a/Pod/Classes/Categories/PINImage+DecodedImage.h
+++ b/Pod/Classes/Categories/PINImage+DecodedImage.h
@@ -6,15 +6,16 @@
 //
 //
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+@import Foundation;
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageMacros.h"
 
-#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if !(TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
 @interface NSImage (PINiOSMapping)
 
 @property(nonatomic, readonly, nullable) CGImageRef CGImage;
@@ -34,7 +35,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image);
 + (nullable PINImage *)pin_decodedImageWithData:(nonnull NSData *)data;
 + (nullable PINImage *)pin_decodedImageWithData:(nonnull NSData *)data skipDecodeIfPossible:(BOOL)skipDecodeIfPossible;
 + (nullable PINImage *)pin_decodedImageWithCGImageRef:(nonnull CGImageRef)imageRef;
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
 + (nullable PINImage *)pin_decodedImageWithCGImageRef:(nonnull CGImageRef)imageRef orientation:(UIImageOrientation) orientation;
 #endif
 

--- a/Pod/Classes/Categories/PINImage+DecodedImage.m
+++ b/Pod/Classes/Categories/PINImage+DecodedImage.m
@@ -16,7 +16,7 @@
 
 #import "NSData+ImageDetectors.h"
 
-#if !(TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
+#if !PIN_TARGET_IOS
 @implementation NSImage (PINiOSMapping)
 
 - (CGImageRef)CGImage
@@ -46,9 +46,9 @@
 
 NSData * __nullable PINImageJPEGRepresentation(PINImage * __nonnull image, CGFloat compressionQuality)
 {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     return UIImageJPEGRepresentation(image, compressionQuality);
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:[image TIFFRepresentation]];
     NSDictionary *imageProperties = @{NSImageCompressionFactor : @(compressionQuality)};
     return [imageRep representationUsingType:NSJPEGFileType properties:imageProperties];
@@ -56,9 +56,9 @@ NSData * __nullable PINImageJPEGRepresentation(PINImage * __nonnull image, CGFlo
 }
 
 NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     return UIImagePNGRepresentation(image);
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:[image TIFFRepresentation]];
     NSDictionary *imageProperties = @{NSImageCompressionFactor : @1};
     return [imageRep representationUsingType:NSPNGFileType properties:imageProperties];
@@ -95,14 +95,14 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
     if (imageSourceRef) {
         CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSourceRef, 0, (CFDictionaryRef)@{(NSString *)kCGImageSourceShouldCache : (NSNumber *)kCFBooleanFalse});
         if (imageRef) {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
             UIImageOrientation orientation = pin_UIImageOrienationFromImageSource(imageSourceRef);
             if (skipDecodeIfPossible) {
                 decodedImage = [PINImage imageWithCGImage:imageRef scale:1.0 orientation:orientation];
             } else {
                 decodedImage = [self pin_decodedImageWithCGImageRef:imageRef orientation:orientation];
             }
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
             if (skipDecodeIfPossible) {
                 CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
                 decodedImage = [[NSImage alloc] initWithCGImage:imageRef size:imageSize];
@@ -121,7 +121,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 
 + (PINImage *)pin_decodedImageWithCGImageRef:(CGImageRef)imageRef
 {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     return [self pin_decodedImageWithCGImageRef:imageRef orientation:UIImageOrientationUp];
 }
 
@@ -154,18 +154,18 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
         
         CGImageRef newImage = CGBitmapContextCreateImage(ctx);
         
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
         decodedImage = [UIImage imageWithCGImage:newImage scale:1.0 orientation:orientation];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
         decodedImage = [[NSImage alloc] initWithCGImage:newImage size:imageSize];
 #endif
         CGImageRelease(newImage);
         CGContextRelease(ctx);
         
     } else {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
         decodedImage = [UIImage imageWithCGImage:imageRef scale:1.0 orientation:orientation];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
         decodedImage = [[NSImage alloc] initWithCGImage:imageRef size:imageSize];
 #endif
     }
@@ -173,7 +173,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
     return decodedImage;
 }
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 UIImageOrientation pin_UIImageOrienationFromImageSource(CGImageSourceRef imageSourceRef) {
     UIImageOrientation orientation = UIImageOrientationUp;
     

--- a/Pod/Classes/Categories/PINImage+DecodedImage.m
+++ b/Pod/Classes/Categories/PINImage+DecodedImage.m
@@ -16,7 +16,7 @@
 
 #import "NSData+ImageDetectors.h"
 
-#ifdef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if !(TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR)
 @implementation NSImage (PINiOSMapping)
 
 - (CGImageRef)CGImage
@@ -46,9 +46,9 @@
 
 NSData * __nullable PINImageJPEGRepresentation(PINImage * __nonnull image, CGFloat compressionQuality)
 {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     return UIImageJPEGRepresentation(image, compressionQuality);
-#else
+#elif TARGET_OS_MAC
     NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:[image TIFFRepresentation]];
     NSDictionary *imageProperties = @{NSImageCompressionFactor : @(compressionQuality)};
     return [imageRep representationUsingType:NSJPEGFileType properties:imageProperties];
@@ -56,9 +56,9 @@ NSData * __nullable PINImageJPEGRepresentation(PINImage * __nonnull image, CGFlo
 }
 
 NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     return UIImagePNGRepresentation(image);
-#else
+#elif TARGET_OS_MAC
     NSBitmapImageRep *imageRep = [NSBitmapImageRep imageRepWithData:[image TIFFRepresentation]];
     NSDictionary *imageProperties = @{NSImageCompressionFactor : @1};
     return [imageRep representationUsingType:NSPNGFileType properties:imageProperties];
@@ -95,14 +95,14 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
     if (imageSourceRef) {
         CGImageRef imageRef = CGImageSourceCreateImageAtIndex(imageSourceRef, 0, (CFDictionaryRef)@{(NSString *)kCGImageSourceShouldCache : (NSNumber *)kCFBooleanFalse});
         if (imageRef) {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
             UIImageOrientation orientation = pin_UIImageOrienationFromImageSource(imageSourceRef);
             if (skipDecodeIfPossible) {
                 decodedImage = [PINImage imageWithCGImage:imageRef scale:1.0 orientation:orientation];
             } else {
                 decodedImage = [self pin_decodedImageWithCGImageRef:imageRef orientation:orientation];
             }
-#else
+#elif TARGET_OS_MAC
             if (skipDecodeIfPossible) {
                 CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
                 decodedImage = [[NSImage alloc] initWithCGImage:imageRef size:imageSize];
@@ -121,7 +121,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 
 + (PINImage *)pin_decodedImageWithCGImageRef:(CGImageRef)imageRef
 {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     return [self pin_decodedImageWithCGImageRef:imageRef orientation:UIImageOrientationUp];
 }
 
@@ -154,18 +154,18 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
         
         CGImageRef newImage = CGBitmapContextCreateImage(ctx);
         
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         decodedImage = [UIImage imageWithCGImage:newImage scale:1.0 orientation:orientation];
-#else
+#elif TARGET_OS_MAC
         decodedImage = [[NSImage alloc] initWithCGImage:newImage size:imageSize];
 #endif
         CGImageRelease(newImage);
         CGContextRelease(ctx);
         
     } else {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         decodedImage = [UIImage imageWithCGImage:imageRef scale:1.0 orientation:orientation];
-#else
+#elif TARGET_OS_MAC
         decodedImage = [[NSImage alloc] initWithCGImage:imageRef size:imageSize];
 #endif
     }
@@ -173,7 +173,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
     return decodedImage;
 }
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
 UIImageOrientation pin_UIImageOrienationFromImageSource(CGImageSourceRef imageSourceRef) {
     UIImageOrientation orientation = UIImageOrientationUp;
     

--- a/Pod/Classes/Categories/PINImage+WebP.h
+++ b/Pod/Classes/Categories/PINImage+WebP.h
@@ -8,9 +8,9 @@
 
 #ifdef PIN_WEBP
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/Categories/PINImage+WebP.h
+++ b/Pod/Classes/Categories/PINImage+WebP.h
@@ -8,10 +8,10 @@
 
 #ifdef PIN_WEBP
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageMacros.h"

--- a/Pod/Classes/Categories/PINImage+WebP.h
+++ b/Pod/Classes/Categories/PINImage+WebP.h
@@ -9,9 +9,9 @@
 #ifdef PIN_WEBP
 
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageMacros.h"

--- a/Pod/Classes/Categories/PINImage+WebP.m
+++ b/Pod/Classes/Categories/PINImage+WebP.m
@@ -65,9 +65,9 @@ static void releaseData(void *info, const void *data, size_t size)
                                                 renderingIntent);
             
             PINImage *image = nil;
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
             image = [UIImage imageWithCGImage:imageRef];
-#else
+#elif TARGET_OS_MAC
             image = [[self alloc] initWithCGImage:imageRef size:CGSizeZero];
 #endif
             

--- a/Pod/Classes/Categories/PINImage+WebP.m
+++ b/Pod/Classes/Categories/PINImage+WebP.m
@@ -65,9 +65,9 @@ static void releaseData(void *info, const void *data, size_t size)
                                                 renderingIntent);
             
             PINImage *image = nil;
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
             image = [UIImage imageWithCGImage:imageRef];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
             image = [[self alloc] initWithCGImage:imageRef size:CGSizeZero];
 #endif
             

--- a/Pod/Classes/Image Categories/PINButton+PINRemoteImage.h
+++ b/Pod/Classes/Image Categories/PINButton+PINRemoteImage.h
@@ -6,10 +6,10 @@
 //
 //
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageManager.h"

--- a/Pod/Classes/Image Categories/PINButton+PINRemoteImage.h
+++ b/Pod/Classes/Image Categories/PINButton+PINRemoteImage.h
@@ -7,9 +7,9 @@
 //
 
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>
 #endif
 
 #import "PINRemoteImageManager.h"

--- a/Pod/Classes/Image Categories/PINButton+PINRemoteImage.h
+++ b/Pod/Classes/Image Categories/PINButton+PINRemoteImage.h
@@ -6,9 +6,9 @@
 //
 //
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/Image Categories/PINButton+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/PINButton+PINRemoteImage.m
@@ -92,9 +92,9 @@
 
 - (void)pin_setPlaceholderWithImage:(PINImage *)image
 {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     [self setImage:image forState:UIControlStateNormal];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     [self setImage:image];
 #endif
 }
@@ -102,10 +102,10 @@
 - (void)pin_updateUIWithImage:(PINImage *)image animatedImage:(FLAnimatedImage *)animatedImage
 {
     if (image) {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
         [self setImage:image forState:UIControlStateNormal];
         [self setNeedsLayout];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
         [self setImage:image];
         [self setNeedsLayout:YES];
 #endif
@@ -114,10 +114,10 @@
 
 - (void)pin_clearImages
 {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     [self setImage:nil forState:UIControlStateNormal];
     [self setNeedsLayout];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     [self setImage:nil];
     [self setNeedsLayout:YES];
 #endif

--- a/Pod/Classes/Image Categories/PINButton+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/PINButton+PINRemoteImage.m
@@ -92,9 +92,9 @@
 
 - (void)pin_setPlaceholderWithImage:(PINImage *)image
 {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     [self setImage:image forState:UIControlStateNormal];
-#else
+#elif TARGET_OS_MAC
     [self setImage:image];
 #endif
 }
@@ -102,10 +102,10 @@
 - (void)pin_updateUIWithImage:(PINImage *)image animatedImage:(FLAnimatedImage *)animatedImage
 {
     if (image) {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         [self setImage:image forState:UIControlStateNormal];
         [self setNeedsLayout];
-#else
+#elif TARGET_OS_MAC
         [self setImage:image];
         [self setNeedsLayout:YES];
 #endif
@@ -114,10 +114,10 @@
 
 - (void)pin_clearImages
 {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     [self setImage:nil forState:UIControlStateNormal];
     [self setNeedsLayout];
-#else
+#elif TARGET_OS_MAC
     [self setImage:nil];
     [self setNeedsLayout:YES];
 #endif

--- a/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.h
+++ b/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.h
@@ -6,10 +6,10 @@
 //
 //
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageManager.h"

--- a/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.h
+++ b/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.h
@@ -7,9 +7,9 @@
 //
 
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageManager.h"

--- a/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.h
+++ b/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.h
@@ -6,9 +6,9 @@
 //
 //
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.m
@@ -100,9 +100,9 @@
     if (image) {
         self.image = image;
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
         [self setNeedsLayout];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
         [self setNeedsLayout:YES];
 #endif
     }
@@ -112,9 +112,9 @@
 {
     self.image = nil;
     
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     [self setNeedsLayout];
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     [self setNeedsLayout:YES];
 #endif
 }

--- a/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.m
+++ b/Pod/Classes/Image Categories/PINImageView+PINRemoteImage.m
@@ -100,9 +100,9 @@
     if (image) {
         self.image = image;
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         [self setNeedsLayout];
-#else
+#elif TARGET_OS_MAC
         [self setNeedsLayout:YES];
 #endif
     }
@@ -112,9 +112,9 @@
 {
     self.image = nil;
     
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     [self setNeedsLayout];
-#else
+#elif TARGET_OS_MAC
     [self setNeedsLayout:YES];
 #endif
 }

--- a/Pod/Classes/PINProgressiveImage.h
+++ b/Pod/Classes/PINProgressiveImage.h
@@ -6,12 +6,12 @@
 //
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageMacros.h"

--- a/Pod/Classes/PINProgressiveImage.h
+++ b/Pod/Classes/PINProgressiveImage.h
@@ -8,9 +8,9 @@
 
 @import Foundation;
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/PINProgressiveImage.h
+++ b/Pod/Classes/PINProgressiveImage.h
@@ -6,10 +6,12 @@
 //
 //
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+@import Foundation;
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageMacros.h"

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -326,9 +326,9 @@
         return nil;
     }
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     CGFloat imageScale = inputImage.scale;
-#else
+#elif TARGET_OS_MAC
     // TODO: What scale factor should be used here?
     CGFloat imageScale = [[NSScreen mainScreen] backingScaleFactor];
 #endif
@@ -343,15 +343,15 @@
     }
     
     CGContextRef ctx;
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     UIGraphicsBeginImageContextWithOptions(inputSize, YES, imageScale);
     ctx = UIGraphicsGetCurrentContext();
-#else
+#elif TARGET_OS_MAC
     ctx = CGBitmapContextCreate(0, inputSize.width, inputSize.height, 8, 0, [NSColorSpace genericRGBColorSpace].CGColorSpace, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
 #endif
     
     if (ctx) {
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
         CGContextScaleCTM(ctx, 1.0, -1.0);
         CGContextTranslateCTM(ctx, 0, -inputSize.height);
 #endif
@@ -431,9 +431,9 @@
                     
                     // Cleanup
                     free(outputBuffer->data);
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
                     outputImage = UIGraphicsGetImageFromCurrentImageContext();
-#else
+#elif TARGET_OS_MAC
                     CGImageRef outputImageRef = CGBitmapContextCreateImage(ctx);
                     outputImage = [[NSImage alloc] initWithCGImage:outputImageRef size:inputSize];
                     CFRelease(outputImageRef);
@@ -453,7 +453,7 @@
         }
     }
     
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
     UIGraphicsEndImageContext();
 #endif
 

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -326,9 +326,9 @@
         return nil;
     }
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     CGFloat imageScale = inputImage.scale;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     // TODO: What scale factor should be used here?
     CGFloat imageScale = [[NSScreen mainScreen] backingScaleFactor];
 #endif
@@ -343,15 +343,15 @@
     }
     
     CGContextRef ctx;
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     UIGraphicsBeginImageContextWithOptions(inputSize, YES, imageScale);
     ctx = UIGraphicsGetCurrentContext();
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
     ctx = CGBitmapContextCreate(0, inputSize.width, inputSize.height, 8, 0, [NSColorSpace genericRGBColorSpace].CGColorSpace, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
 #endif
     
     if (ctx) {
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
         CGContextScaleCTM(ctx, 1.0, -1.0);
         CGContextTranslateCTM(ctx, 0, -inputSize.height);
 #endif
@@ -431,9 +431,9 @@
                     
                     // Cleanup
                     free(outputBuffer->data);
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
                     outputImage = UIGraphicsGetImageFromCurrentImageContext();
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
                     CGImageRef outputImageRef = CGBitmapContextCreateImage(ctx);
                     outputImage = [[NSImage alloc] initWithCGImage:outputImageRef size:inputSize];
                     CFRelease(outputImageRef);
@@ -453,7 +453,7 @@
         }
     }
     
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
     UIGraphicsEndImageContext();
 #endif
 

--- a/Pod/Classes/PINRemoteImageCategoryManager.h
+++ b/Pod/Classes/PINRemoteImageCategoryManager.h
@@ -6,10 +6,10 @@
 //
 //
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageManager.h"

--- a/Pod/Classes/PINRemoteImageCategoryManager.h
+++ b/Pod/Classes/PINRemoteImageCategoryManager.h
@@ -7,9 +7,9 @@
 //
 
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageManager.h"

--- a/Pod/Classes/PINRemoteImageCategoryManager.h
+++ b/Pod/Classes/PINRemoteImageCategoryManager.h
@@ -6,9 +6,9 @@
 //
 //
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/PINRemoteImageMacros.h
+++ b/Pod/Classes/PINRemoteImageMacros.h
@@ -8,6 +8,9 @@
 #ifndef PINRemoteImageMacros_h
 #define PINRemoteImageMacros_h
 
+#define PIN_TARGET_IOS (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#define PIN_TARGET_MAC (TARGET_OS_MAC)
+
 #define PINRemoteImageLogging                0
 #if PINRemoteImageLogging
 #define PINLog(args...) NSLog(args)
@@ -22,11 +25,11 @@
 #define FLAnimatedImage NSObject
 #endif
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 #define PINImage     UIImage
 #define PINImageView UIImageView
 #define PINButton    UIButton
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 #define PINImage     NSImage
 #define PINImageView NSImageView
 #define PINButton    NSButton

--- a/Pod/Classes/PINRemoteImageMacros.h
+++ b/Pod/Classes/PINRemoteImageMacros.h
@@ -3,6 +3,8 @@
 //  PINRemoteImage
 //
 
+#import <TargetConditionals.h>
+
 #ifndef PINRemoteImageMacros_h
 #define PINRemoteImageMacros_h
 

--- a/Pod/Classes/PINRemoteImageMacros.h
+++ b/Pod/Classes/PINRemoteImageMacros.h
@@ -20,11 +20,11 @@
 #define FLAnimatedImage NSObject
 #endif
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
 #define PINImage     UIImage
 #define PINImageView UIImageView
 #define PINButton    UIButton
-#else
+#elif TARGET_OS_MAC
 #define PINImage     NSImage
 #define PINImageView NSImageView
 #define PINButton    NSButton

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -7,9 +7,9 @@
 //
 
 @import Foundation;
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -6,11 +6,12 @@
 //
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
+
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageManagerResult.h"

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -6,11 +6,11 @@
 //
 //
 
-#import <Foundation/Foundation.h>
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+@import Foundation;
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageManagerResult.h"

--- a/Pod/Classes/PINRemoteImageManagerResult.h
+++ b/Pod/Classes/PINRemoteImageManagerResult.h
@@ -6,12 +6,12 @@
 //
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 #if PIN_TARGET_IOS
-@import UIKit;
+#import <UIKit/UIKit.h>
 #elif PIN_TARGET_MAC
-@import Cocoa;
+#import <Cocoa/Cocoa.h>;
 #endif
 
 #import "PINRemoteImageMacros.h"

--- a/Pod/Classes/PINRemoteImageManagerResult.h
+++ b/Pod/Classes/PINRemoteImageManagerResult.h
@@ -8,9 +8,9 @@
 
 @import Foundation;
 
-#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+#if PIN_TARGET_IOS
 @import UIKit;
-#elif TARGET_OS_MAC
+#elif PIN_TARGET_MAC
 @import Cocoa;
 #endif
 

--- a/Pod/Classes/PINRemoteImageManagerResult.h
+++ b/Pod/Classes/PINRemoteImageManagerResult.h
@@ -6,10 +6,12 @@
 //
 //
 
-#ifdef __IPHONE_OS_VERSION_MIN_REQUIRED
-#import <UIKit/UIKit.h>
-#else
-#import <Cocoa/Cocoa.h>
+@import Foundation;
+
+#if (TARGET_OS_IPHONE || TARGET_IPHONE_SIMULATOR || TARGET_OS_TV)
+@import UIKit;
+#elif TARGET_OS_MAC
+@import Cocoa;
 #endif
 
 #import "PINRemoteImageMacros.h"


### PR DESCRIPTION
This does two things

1. Make the target checks more explicit for tvOS & iOS vs OS X. 
2. Include the `TargetConditionals.h` file so that the `PINImage` macros play nicely when including a framework. 