### PR TITLE
Add nullability specifier to PINURLSessionManager delegate

### DIFF
--- a/Pod/Classes/PINURLSessionManager.h
+++ b/Pod/Classes/PINURLSessionManager.h
@@ -28,6 +28,6 @@
 
 - (void)invalidateSessionAndCancelTasks;
 
-@property (atomic, weak) id <PINURLSessionManagerDelegate> delegate;
+@property (atomic, weak, nullable) id <PINURLSessionManagerDelegate> delegate;
 
 @end


### PR DESCRIPTION
Hey,

I realised the delegate property was missing nullability specifiers, which can lead to compile-time errors on some configurations.

Cheers