### PR TITLE
Modify estimatedRemainingTimeThreshhold Behavior to Match Documentation

### DIFF
--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -165,7 +165,7 @@
             return nil;
         }
         
-        if (_estimatedRemainingTimeThreshold < 0 || self.estimatedRemainingTime < _estimatedRemainingTimeThreshold) {
+        if (_estimatedRemainingTimeThreshold > 0 && self.estimatedRemainingTime < _estimatedRemainingTimeThreshold) {
             [self.lock unlock];
             return nil;
         }

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -220,7 +220,7 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 /**
  Set the estimated time remaining to download threshold at which to generate progressive images. Progressive images previews will only be generated if the estimated remaining time on a download is greater than estimatedTimeRemainingThreshold. If estimatedTimeRemainingThreshold is less than or equal to zero, this check is skipped.
  
- @param estimatedRemainingTimeThreshold The estimated remaining time threshold used to decide to skip progressive rendering. Defaults to 0.
+ @param estimatedRemainingTimeThreshold The estimated remaining time threshold used to decide to skip progressive rendering. Defaults to 0.1.
  @param completion Completion to be called once estimatedTimeRemainingTimeThreshold is set.
  */
 - (void)setEstimatedRemainingTimeThresholdForProgressiveDownloads:(NSTimeInterval)estimatedRemainingTimeThreshold

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -218,9 +218,9 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
                                completion:(nullable dispatch_block_t)completion;
 
 /**
- Set the estimated time remaining to download threshold at which to generate progressive images. Progressive images previews will only be generated if the estimated remaining time on a download is greater than estimatedTimeRemainingThreshold. If estimatedTimeRemainingThreshold is less than zero, this check is skipped.
+ Set the estimated time remaining to download threshold at which to generate progressive images. Progressive images previews will only be generated if the estimated remaining time on a download is greater than estimatedTimeRemainingThreshold. If estimatedTimeRemainingThreshold is less than or equal to zero, this check is skipped.
  
- @param estimatedRemainingTimeThreshold The estimated remaining time threshold used to decide to skip progressive rendering. Defaults to 0.1.
+ @param estimatedRemainingTimeThreshold The estimated remaining time threshold used to decide to skip progressive rendering. Defaults to 0.
  @param completion Completion to be called once estimatedTimeRemainingTimeThreshold is set.
  */
 - (void)setEstimatedRemainingTimeThresholdForProgressiveDownloads:(NSTimeInterval)estimatedRemainingTimeThreshold

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -245,7 +245,7 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
                              completion:(nullable dispatch_block_t)completion;
 
 /**
- Sets the maximum size of an image that PINRemoteImage will blur. If the image is too large, blurring is skipped
+ Sets the maximum size of an image that PINRemoteImage will render progessively. If the image is too large, progressive rendering is skipped.
  
  @param maxProgressiveRenderSize A CGSize which indicates the max size PINRemoteImage will render a progressive image. If an image is larger in either dimension, progressive rendering will be skipped
  @param completion Completion to be called once maxProgressiveRenderSize is set.

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -196,7 +196,7 @@ static dispatch_once_t sharedDispatchToken;
         self.sessionManager = [[PINURLSessionManager alloc] initWithSessionConfiguration:configuration];
         self.sessionManager.delegate = self;
         
-        self.estimatedRemainingTimeThreshold = 0.0;
+        self.estimatedRemainingTimeThreshold = 0.1;
         self.timeout = PINRemoteImageManagerDefaultTimeout;
         
         _highQualityBPSThreshold = 500000;


### PR DESCRIPTION
- The documentation says the default is 0.1 but it actually defaults to 0. Updated the documentation.
- The documentation says if you set time <= 0 the check is skipped, but actually if you set time < 0 progressive images will never be rendered. Updated the behavior.
- The documentation says maxProgressiveRenderSize only affects which images are blurred, but it actually affects which images are progressively rendered at all. Updated the documentation.