### PR TITLE
Use a hashed key when the URL is too long

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1417,7 +1417,7 @@ static dispatch_once_t sharedDispatchToken;
         for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
             [hexString appendFormat:@"%02lx", (unsigned long)digest[i]];
         }
-        cacheKey = hexString.copy;
+        cacheKey = [hexString copy];
     }
 
     return cacheKey;


### PR DESCRIPTION
The filesystem doesn't support names longer than 255 chars, when that happens the file is not saved, rendering the disk cache useless.
 
This fixes that by creating a hashed key in those cases.