### PR TITLE
[PINProgressiveImage] Use CoreImage Rather than vImage for Blurring

### DIFF
--- a/Example/PINRemoteImage Tests/PINProgressiveImage+Accelerate.h
+++ b/Example/PINRemoteImage Tests/PINProgressiveImage+Accelerate.h
@@ -1,0 +1,21 @@
+//
+//  PINProgressiveImage+Accelerate.h
+//  PINRemoteImage
+//
+//  Created by Adlai Holler on 5/23/16.
+//  Copyright © 2016 Garrett Moon. All rights reserved.
+//
+
+#import "PINRemoteImageMacros.h"
+#import <PINRemoteImage/PINProgressiveImage.h>
+
+/**
+ An implementation of gaussian blur using accelerate rather than CoreImage, 
+ provided here so we can do performance testing without adding Accelerate into the
+ public framework.
+ */
+@interface PINProgressiveImage (Accelerate)
+
++ (PINImage *)postProcessImageUsingAccelerate:(PINImage *)inputImage withProgress:(float)progress;
+
+@end

--- a/Example/PINRemoteImage Tests/PINProgressiveImage+Accelerate.m
+++ b/Example/PINRemoteImage Tests/PINProgressiveImage+Accelerate.m
@@ -1,0 +1,176 @@
+//
+//  PINProgressiveImage+Accelerate.m
+//  PINRemoteImage
+//
+//  Created by Adlai Holler on 5/23/16.
+//  Copyright © 2016 Garrett Moon. All rights reserved.
+//
+
+#import "PINProgressiveImage+Accelerate.h"
+#import <ImageIO/ImageIO.h>
+#import <Accelerate/Accelerate.h>
+
+#import "PINRemoteImage.h"
+#import "PINImage+DecodedImage.h"
+
+@implementation PINProgressiveImage (Accelerate)
+
+//Heavily cribbed from https://developer.apple.com/library/ios/samplecode/UIImageEffects/Listings/UIImageEffects_UIImageEffects_m.html#//apple_ref/doc/uid/DTS40013396-UIImageEffects_UIImageEffects_m-DontLinkElementID_9
++ (PINImage *)postProcessImageUsingAccelerate:(PINImage *)inputImage withProgress:(float)progress
+{
+    PINImage *outputImage = nil;
+    CGImageRef inputImageRef = CGImageRetain(inputImage.CGImage);
+    if (inputImageRef == nil) {
+        return nil;
+    }
+
+    CGSize inputSize = inputImage.size;
+    if (inputSize.width < 1 ||
+        inputSize.height < 1) {
+        CGImageRelease(inputImageRef);
+        return nil;
+    }
+
+#if PIN_TARGET_IOS
+    CGFloat imageScale = inputImage.scale;
+#elif PIN_TARGET_MAC
+    // TODO: What scale factor should be used here?
+    CGFloat imageScale = [[NSScreen mainScreen] backingScaleFactor];
+#endif
+
+    CGFloat radius = (inputImage.size.width / 25.0) * MAX(0, 1.0 - progress);
+    radius *= imageScale;
+
+    //we'll round the radius to a whole number below anyway,
+    if (radius < FLT_EPSILON) {
+        CGImageRelease(inputImageRef);
+        return inputImage;
+    }
+
+    CGContextRef ctx;
+#if PIN_TARGET_IOS
+    UIGraphicsBeginImageContextWithOptions(inputSize, YES, imageScale);
+    ctx = UIGraphicsGetCurrentContext();
+#elif PIN_TARGET_MAC
+    ctx = CGBitmapContextCreate(0, inputSize.width, inputSize.height, 8, 0, [NSColorSpace genericRGBColorSpace].CGColorSpace, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
+#endif
+
+    if (ctx) {
+#if PIN_TARGET_IOS
+        CGContextScaleCTM(ctx, 1.0, -1.0);
+        CGContextTranslateCTM(ctx, 0, -inputSize.height);
+#endif
+
+        vImage_Buffer effectInBuffer;
+        vImage_Buffer scratchBuffer;
+
+        vImage_Buffer *inputBuffer;
+        vImage_Buffer *outputBuffer;
+
+        vImage_CGImageFormat format = {
+            .bitsPerComponent = 8,
+            .bitsPerPixel = 32,
+            .colorSpace = NULL,
+            // (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little)
+            // requests a BGRA buffer.
+            .bitmapInfo = kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little,
+            .version = 0,
+            .decode = NULL,
+            .renderingIntent = kCGRenderingIntentDefault
+        };
+
+        vImage_Error e = vImageBuffer_InitWithCGImage(&effectInBuffer, &format, NULL, inputImage.CGImage, kvImagePrintDiagnosticsToConsole);
+        if (e == kvImageNoError)
+        {
+            e = vImageBuffer_Init(&scratchBuffer, effectInBuffer.height, effectInBuffer.width, format.bitsPerPixel, kvImageNoFlags);
+            if (e == kvImageNoError) {
+                inputBuffer = &effectInBuffer;
+                outputBuffer = &scratchBuffer;
+
+                // A description of how to compute the box kernel width from the Gaussian
+                // radius (aka standard deviation) appears in the SVG spec:
+                // http://www.w3.org/TR/SVG/filters.html#feGaussianBlurElement
+                //
+                // For larger values of 's' (s >= 2.0), an approximation can be used: Three
+                // successive box-blurs build a piece-wise quadratic convolution kernel, which
+                // approximates the Gaussian kernel to within roughly 3%.
+                //
+                // let d = floor(s * 3*sqrt(2*pi)/4 + 0.5)
+                //
+                // ... if d is odd, use three box-blurs of size 'd', centered on the output pixel.
+                //
+                if (radius - 2. < __FLT_EPSILON__)
+                    radius = 2.;
+                uint32_t wholeRadius = floor((radius * 3. * sqrt(2 * M_PI) / 4 + 0.5) / 2);
+
+                wholeRadius |= 1; // force wholeRadius to be odd so that the three box-blur methodology works.
+
+                //calculate the size necessary for vImageBoxConvolve_ARGB8888, this does not actually do any operations.
+                NSInteger tempBufferSize = vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, NULL, 0, 0, wholeRadius, wholeRadius, NULL, kvImageGetTempBufferSize | kvImageEdgeExtend);
+                void *tempBuffer = malloc(tempBufferSize);
+
+                if (tempBuffer) {
+                    //errors can be ignored because we've passed in allocated memory
+                    vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, tempBuffer, 0, 0, wholeRadius, wholeRadius, NULL, kvImageEdgeExtend);
+                    vImageBoxConvolve_ARGB8888(outputBuffer, inputBuffer, tempBuffer, 0, 0, wholeRadius, wholeRadius, NULL, kvImageEdgeExtend);
+                    vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, tempBuffer, 0, 0, wholeRadius, wholeRadius, NULL, kvImageEdgeExtend);
+
+                    free(tempBuffer);
+
+                    //switch input and output
+                    vImage_Buffer *temp = inputBuffer;
+                    inputBuffer = outputBuffer;
+                    outputBuffer = temp;
+
+                    CGImageRef effectCGImage = vImageCreateCGImageFromBuffer(inputBuffer, &format, &cleanupBuffer, NULL, kvImageNoAllocate, NULL);
+                    if (effectCGImage == NULL) {
+                        //if creating the cgimage failed, the cleanup buffer on input buffer will not be called, we must dealloc ourselves
+                        free(inputBuffer->data);
+                    } else {
+                        // draw effect image
+                        CGContextSaveGState(ctx);
+                        CGContextDrawImage(ctx, CGRectMake(0, 0, inputSize.width, inputSize.height), effectCGImage);
+                        CGContextRestoreGState(ctx);
+                        CGImageRelease(effectCGImage);
+                    }
+
+                    // Cleanup
+                    free(outputBuffer->data);
+#if PIN_TARGET_IOS
+                    outputImage = UIGraphicsGetImageFromCurrentImageContext();
+#elif PIN_TARGET_MAC
+                    CGImageRef outputImageRef = CGBitmapContextCreateImage(ctx);
+                    outputImage = [[NSImage alloc] initWithCGImage:outputImageRef size:inputSize];
+                    CFRelease(outputImageRef);
+#endif
+
+                }
+            } else {
+                if (scratchBuffer.data) {
+                    free(scratchBuffer.data);
+                }
+                free(effectInBuffer.data);
+            }
+        } else {
+            if (effectInBuffer.data) {
+                free(effectInBuffer.data);
+            }
+        }
+    }
+
+#if PIN_TARGET_IOS
+    UIGraphicsEndImageContext();
+#endif
+
+    CGImageRelease(inputImageRef);
+
+    return outputImage;
+}
+
+//  Helper function to handle deferred cleanup of a buffer.
+static void cleanupBuffer(void *userData, void *buf_data)
+{
+    free(buf_data);
+}
+
+@end

--- a/Example/PINRemoteImage.xcodeproj/project.pbxproj
+++ b/Example/PINRemoteImage.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 				C9D363E7DDCEA7F35E576911 /* Pods */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 0;
 		};
 		6003F58B195388D20070C39A /* Products */ = {
 			isa = PBXGroup;

--- a/Pod/Classes/PINProgressiveImage.h
+++ b/Pod/Classes/PINProgressiveImage.h
@@ -43,4 +43,12 @@
  */
 - (nullable NSData *)data;
 
+/**
+ Applies a gaussian blur to the provided input image.
+ If the blur cannot be applied, the original image is returned.
+
+ @return PINImage a copy of inputImage with a gaussian blur applied
+ */
++ (nullable PINImage *)postProcessImage:(nullable PINImage *)inputImage withProgress:(float)progress;
+
 @end

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -325,25 +325,25 @@
         return inputImage;
     }
 
-	// Creating CI contexts is expensive. We store them in a reuse pool to improve performance.
+    // Creating CI contexts is expensive. We store them in a reuse pool to improve performance.
 
-	// TODO: Is it worth clearing this pool on memory warning? Probably not, since we're only going
-	// to create as many contexts as we have concurrent blur operations, but we need to profile
-	// the memory consumption of CIContext.
-	static NSMutableArray *contexts;
-	static NSLock *contextsLock;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
+    // TODO: Is it worth clearing this pool on memory warning? Probably not, since we're only going
+    // to create as many contexts as we have concurrent blur operations, but we need to profile
+    // the memory consumption of CIContext.
+    static NSMutableArray *contexts;
+    static NSLock *contextsLock;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
         contexts = [NSMutableArray array];
-		contextsLock = [[NSLock alloc] init];
-	});
+        contextsLock = [[NSLock alloc] init];
+    });
     
-	[contextsLock lock];
+    [contextsLock lock];
         CIContext *context = [contexts lastObject];
-		if (context != nil) {
+        if (context != nil) {
             [contexts removeLastObject];
-		}
-	[contextsLock unlock];
+        }
+    [contextsLock unlock];
 
     if (context == nil) {
         // NOTE: We use the software renderer because accessing the GPU when the app
@@ -390,10 +390,10 @@
 
     CGImageRef outputImageRef = [context createCGImage:blurred fromRect:bounds];
 
-	// Return our context to the reuse pool.
-	[contextsLock lock];
-		[contexts addObject:context];
-	[contextsLock unlock];
+    // Return our context to the reuse pool.
+    [contextsLock lock];
+        [contexts addObject:context];
+    [contextsLock unlock];
 
 #if PIN_TARGET_IOS
     outputImage = [UIImage imageWithCGImage:outputImageRef];

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -329,14 +329,14 @@
     CIContext *context = [CIContext contextWithOptions:nil];
 #if PIN_TARGET_IOS
     CGFloat imageScale = inputImage.scale;
-	CGSize maxInputSize = context.inputImageMaximumSize;
-	CGSize maxOutputSize = context.outputImageMaximumSize;
-	if (bounds.size.width > maxInputSize.width ||
-		bounds.size.height > maxInputSize.height ||
-		bounds.size.width > maxOutputSize.width ||
-		bounds.size.height > maxOutputSize.height) {
-		return inputImage;
-	}
+    CGSize maxInputSize = context.inputImageMaximumSize;
+    CGSize maxOutputSize = context.outputImageMaximumSize;
+    if (bounds.size.width > maxInputSize.width ||
+        bounds.size.height > maxInputSize.height ||
+        bounds.size.width > maxOutputSize.width ||
+        bounds.size.height > maxOutputSize.height) {
+        return inputImage;
+    }
 #elif PIN_TARGET_MAC
     // TODO: What scale factor should be used here?
     CGFloat imageScale = [[NSScreen mainScreen] backingScaleFactor];

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -338,16 +338,16 @@
         return inputImage;
     }
 
-	
+    
 #if PIN_CICONTEXT_MULTITHREADING
-	// Share one context across all threads.
-	static CIContext *context;
-	static dispatch_once_t onceToken;
-	dispatch_once(&onceToken, ^{
-		context = [CIContext contextWithOptions:@{ kCIContextUseSoftwareRenderer: @YES }];
-	});
+    // Share one context across all threads.
+    static CIContext *context;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        context = [CIContext contextWithOptions:@{ kCIContextUseSoftwareRenderer: @YES }];
+    });
 #else
-	// Create a reuse pool of contexts where each is confined to a thread.
+    // Create a reuse pool of contexts where each is confined to a thread.
     static NSMutableArray *contexts;
     static NSLock *contextsLock;
     static dispatch_once_t onceToken;
@@ -357,7 +357,7 @@
     });
     
     [contextsLock lock];
-		CIContext *context = [contexts lastObject];
+        CIContext *context = [contexts lastObject];
         if (context != nil) {
             [contexts removeLastObject];
         }
@@ -415,7 +415,7 @@
         [contexts addObject:context];
     [contextsLock unlock];
 #endif
-	
+    
 #if PIN_TARGET_IOS
     outputImage = [UIImage imageWithCGImage:outputImageRef];
 #elif PIN_TARGET_MAC

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -9,7 +9,7 @@
 #import "PINProgressiveImage.h"
 
 #import <ImageIO/ImageIO.h>
-#import <Accelerate/Accelerate.h>
+#import <CoreImage/CoreImage.h>
 
 #import "PINRemoteImage.h"
 #import "PINImage+DecodedImage.h"
@@ -312,20 +312,26 @@
 }
 
 //Must be called within lock
-//Heavily cribbed from https://developer.apple.com/library/ios/samplecode/UIImageEffects/Listings/UIImageEffects_UIImageEffects_m.html#//apple_ref/doc/uid/DTS40013396-UIImageEffects_UIImageEffects_m-DontLinkElementID_9
 - (PINImage *)postProcessImage:(PINImage *)inputImage withProgress:(float)progress
 {
     PINImage *outputImage = nil;
-    CGImageRef inputImageRef = CGImageRetain(inputImage.CGImage);
-    if (inputImageRef == nil) {
-        return nil;
+    CIImage *inputCIImage = [CIImage imageWithCGImage:inputImage.CGImage];
+    if (inputCIImage == nil) {
+        return inputImage;
     }
-    
-    CGSize inputSize = inputImage.size;
-    if (inputSize.width < 1 ||
-        inputSize.height < 1) {
-        CGImageRelease(inputImageRef);
-        return nil;
+	
+	CGRect bounds = (CGRect){ .size = inputImage.size };
+	
+    CIContext *context = [CIContext contextWithOptions:nil];
+	CGSize maxInputSize = context.inputImageMaximumSize;
+	CGSize maxOutputSize = context.outputImageMaximumSize;
+    if (bounds.size.width < 1 ||
+        bounds.size.height < 1 ||
+		bounds.size.width > maxInputSize.width ||
+		bounds.size.height > maxInputSize.height ||
+		bounds.size.width > maxOutputSize.width ||
+		bounds.size.height > maxOutputSize.height) {
+        return inputImage;
     }
 
 #if PIN_TARGET_IOS
@@ -335,139 +341,37 @@
     CGFloat imageScale = [[NSScreen mainScreen] backingScaleFactor];
 #endif
     
-    CGFloat radius = (inputImage.size.width / 25.0) * MAX(0, 1.0 - progress);
+    CGFloat radius = (bounds.size.width / 25.0) * MAX(0, 1.0 - progress);
     radius *= imageScale;
-    
-    //we'll round the radius to a whole number below anyway,
+	radius = floor(radius);
+	
     if (radius < FLT_EPSILON) {
-        CGImageRelease(inputImageRef);
         return inputImage;
     }
-    
-    CGContextRef ctx;
-#if PIN_TARGET_IOS
-    UIGraphicsBeginImageContextWithOptions(inputSize, YES, imageScale);
-    ctx = UIGraphicsGetCurrentContext();
-#elif PIN_TARGET_MAC
-    ctx = CGBitmapContextCreate(0, inputSize.width, inputSize.height, 8, 0, [NSColorSpace genericRGBColorSpace].CGColorSpace, kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little);
-#endif
-    
-    if (ctx) {
-#if PIN_TARGET_IOS
-        CGContextScaleCTM(ctx, 1.0, -1.0);
-        CGContextTranslateCTM(ctx, 0, -inputSize.height);
-#endif
-        
-        vImage_Buffer effectInBuffer;
-        vImage_Buffer scratchBuffer;
-        
-        vImage_Buffer *inputBuffer;
-        vImage_Buffer *outputBuffer;
-        
-        vImage_CGImageFormat format = {
-            .bitsPerComponent = 8,
-            .bitsPerPixel = 32,
-            .colorSpace = NULL,
-            // (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little)
-            // requests a BGRA buffer.
-            .bitmapInfo = kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little,
-            .version = 0,
-            .decode = NULL,
-            .renderingIntent = kCGRenderingIntentDefault
-        };
-        
-        vImage_Error e = vImageBuffer_InitWithCGImage(&effectInBuffer, &format, NULL, inputImage.CGImage, kvImagePrintDiagnosticsToConsole);
-        if (e == kvImageNoError)
-        {
-            e = vImageBuffer_Init(&scratchBuffer, effectInBuffer.height, effectInBuffer.width, format.bitsPerPixel, kvImageNoFlags);
-            if (e == kvImageNoError) {
-                inputBuffer = &effectInBuffer;
-                outputBuffer = &scratchBuffer;
-                
-                // A description of how to compute the box kernel width from the Gaussian
-                // radius (aka standard deviation) appears in the SVG spec:
-                // http://www.w3.org/TR/SVG/filters.html#feGaussianBlurElement
-                //
-                // For larger values of 's' (s >= 2.0), an approximation can be used: Three
-                // successive box-blurs build a piece-wise quadratic convolution kernel, which
-                // approximates the Gaussian kernel to within roughly 3%.
-                //
-                // let d = floor(s * 3*sqrt(2*pi)/4 + 0.5)
-                //
-                // ... if d is odd, use three box-blurs of size 'd', centered on the output pixel.
-                //
-                if (radius - 2. < __FLT_EPSILON__)
-                    radius = 2.;
-                uint32_t wholeRadius = floor((radius * 3. * sqrt(2 * M_PI) / 4 + 0.5) / 2);
-                
-                wholeRadius |= 1; // force wholeRadius to be odd so that the three box-blur methodology works.
-                
-                //calculate the size necessary for vImageBoxConvolve_ARGB8888, this does not actually do any operations.
-                NSInteger tempBufferSize = vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, NULL, 0, 0, wholeRadius, wholeRadius, NULL, kvImageGetTempBufferSize | kvImageEdgeExtend);
-                void *tempBuffer = malloc(tempBufferSize);
-                
-                if (tempBuffer) {
-                    //errors can be ignored because we've passed in allocated memory
-                    vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, tempBuffer, 0, 0, wholeRadius, wholeRadius, NULL, kvImageEdgeExtend);
-                    vImageBoxConvolve_ARGB8888(outputBuffer, inputBuffer, tempBuffer, 0, 0, wholeRadius, wholeRadius, NULL, kvImageEdgeExtend);
-                    vImageBoxConvolve_ARGB8888(inputBuffer, outputBuffer, tempBuffer, 0, 0, wholeRadius, wholeRadius, NULL, kvImageEdgeExtend);
-                    
-                    free(tempBuffer);
-                    
-                    //switch input and output
-                    vImage_Buffer *temp = inputBuffer;
-                    inputBuffer = outputBuffer;
-                    outputBuffer = temp;
-                    
-                    CGImageRef effectCGImage = vImageCreateCGImageFromBuffer(inputBuffer, &format, &cleanupBuffer, NULL, kvImageNoAllocate, NULL);
-                    if (effectCGImage == NULL) {
-                        //if creating the cgimage failed, the cleanup buffer on input buffer will not be called, we must dealloc ourselves
-                        free(inputBuffer->data);
-                    } else {
-                        // draw effect image
-                        CGContextSaveGState(ctx);
-                        CGContextDrawImage(ctx, CGRectMake(0, 0, inputSize.width, inputSize.height), effectCGImage);
-                        CGContextRestoreGState(ctx);
-                        CGImageRelease(effectCGImage);
-                    }
-                    
-                    // Cleanup
-                    free(outputBuffer->data);
-#if PIN_TARGET_IOS
-                    outputImage = UIGraphicsGetImageFromCurrentImageContext();
-#elif PIN_TARGET_MAC
-                    CGImageRef outputImageRef = CGBitmapContextCreateImage(ctx);
-                    outputImage = [[NSImage alloc] initWithCGImage:outputImageRef size:inputSize];
-                    CFRelease(outputImageRef);
-#endif
-                    
-                }
-            } else {
-                if (scratchBuffer.data) {
-                    free(scratchBuffer.data);
-                }
-                free(effectInBuffer.data);
-            }
-        } else {
-            if (effectInBuffer.data) {
-                free(effectInBuffer.data);
-            }
-        }
+	
+	// Clamp the image so that its edges extend infinitely and we don't get a black border.
+    CIFilter *clamp = [CIFilter filterWithName:@"CIAffineClamp" keysAndValues:kCIInputImageKey, inputCIImage, nil];
+    CIImage *clamped = clamp.outputImage;
+    if (clamped == nil) {
+        return inputImage;
     }
+	
+    CIFilter *blur = [CIFilter filterWithName:@"CIGaussianBlur" keysAndValues:kCIInputImageKey, clamped, kCIInputRadiusKey, @(radius), nil];
+    CIImage *blurred = blur.outputImage;
+    if (blurred == nil) {
+        return inputImage;
+    }
+
+    CGImageRef outputImageRef = [context createCGImage:blurred fromRect:bounds];
     
 #if PIN_TARGET_IOS
-    UIGraphicsEndImageContext();
+    outputImage = [UIImage imageWithCGImage:outputImageRef];
+#elif PIN_TARGET_MAC
+    outputImage = [[NSImage alloc] initWithCGImage:outputImageRef size:bounds.size];
 #endif
-
-    CGImageRelease(inputImageRef);
+    CFRelease(outputImageRef);
     
     return outputImage;
-}
-
-//  Helper function to handle deferred cleanup of a buffer.
-static void cleanupBuffer(void *userData, void *buf_data)
-{
-    free(buf_data);
 }
 
 @end

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -369,7 +369,7 @@
 #elif PIN_TARGET_MAC
     outputImage = [[NSImage alloc] initWithCGImage:outputImageRef size:bounds.size];
 #endif
-    CFRelease(outputImageRef);
+    CGImageRelease(outputImageRef);
     
     return outputImage;
 }

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -315,22 +315,22 @@
 - (PINImage *)postProcessImage:(PINImage *)inputImage withProgress:(float)progress
 {
     PINImage *outputImage = nil;
-    CIImage *inputCIImage = [CIImage imageWithCGImage:inputImage.CGImage];
+    CIImage *inputCIImage = [CIImage imageWithCGImage:inputImage.CGImage options:nil];
     if (inputCIImage == nil) {
         return inputImage;
     }
-	
-	CGRect bounds = (CGRect){ .size = inputImage.size };
-	
+    
+    CGRect bounds = (CGRect){ .size = inputImage.size };
+    
     CIContext *context = [CIContext contextWithOptions:nil];
-	CGSize maxInputSize = context.inputImageMaximumSize;
-	CGSize maxOutputSize = context.outputImageMaximumSize;
+    CGSize maxInputSize = context.inputImageMaximumSize;
+    CGSize maxOutputSize = context.outputImageMaximumSize;
     if (bounds.size.width < 1 ||
         bounds.size.height < 1 ||
-		bounds.size.width > maxInputSize.width ||
-		bounds.size.height > maxInputSize.height ||
-		bounds.size.width > maxOutputSize.width ||
-		bounds.size.height > maxOutputSize.height) {
+        bounds.size.width > maxInputSize.width ||
+        bounds.size.height > maxInputSize.height ||
+        bounds.size.width > maxOutputSize.width ||
+        bounds.size.height > maxOutputSize.height) {
         return inputImage;
     }
 
@@ -343,19 +343,19 @@
     
     CGFloat radius = (bounds.size.width / 25.0) * MAX(0, 1.0 - progress);
     radius *= imageScale;
-	radius = floor(radius);
-	
+    radius = floor(radius);
+    
     if (radius < FLT_EPSILON) {
         return inputImage;
     }
-	
-	// Clamp the image so that its edges extend infinitely and we don't get a black border.
+    
+    // Clamp the image so that its edges extend infinitely and we don't get a black border.
     CIFilter *clamp = [CIFilter filterWithName:@"CIAffineClamp" keysAndValues:kCIInputImageKey, inputCIImage, nil];
     CIImage *clamped = clamp.outputImage;
     if (clamped == nil) {
         return inputImage;
     }
-	
+    
     CIFilter *blur = [CIFilter filterWithName:@"CIGaussianBlur" keysAndValues:kCIInputImageKey, clamped, kCIInputRadiusKey, @(radius), nil];
     CIImage *blurred = blur.outputImage;
     if (blurred == nil) {

--- a/Pod/Classes/PINProgressiveImage.m
+++ b/Pod/Classes/PINProgressiveImage.m
@@ -321,21 +321,22 @@
     }
     
     CGRect bounds = (CGRect){ .size = inputImage.size };
-    
-    CIContext *context = [CIContext contextWithOptions:nil];
-    CGSize maxInputSize = context.inputImageMaximumSize;
-    CGSize maxOutputSize = context.outputImageMaximumSize;
     if (bounds.size.width < 1 ||
-        bounds.size.height < 1 ||
-        bounds.size.width > maxInputSize.width ||
-        bounds.size.height > maxInputSize.height ||
-        bounds.size.width > maxOutputSize.width ||
-        bounds.size.height > maxOutputSize.height) {
+        bounds.size.height < 1) {
         return inputImage;
     }
 
+    CIContext *context = [CIContext contextWithOptions:nil];
 #if PIN_TARGET_IOS
     CGFloat imageScale = inputImage.scale;
+	CGSize maxInputSize = context.inputImageMaximumSize;
+	CGSize maxOutputSize = context.outputImageMaximumSize;
+	if (bounds.size.width > maxInputSize.width ||
+		bounds.size.height > maxInputSize.height ||
+		bounds.size.width > maxOutputSize.width ||
+		bounds.size.height > maxOutputSize.height) {
+		return inputImage;
+	}
 #elif PIN_TARGET_MAC
     // TODO: What scale factor should be used here?
     CGFloat imageScale = [[NSScreen mainScreen] backingScaleFactor];


### PR DESCRIPTION
Since this uses the GPU directly, the performance running on iOS Simulator is very bad.

But on my iPhone 6, this performed more consistently and slightly faster in the example app than the prior Accelerate-based approach. Under accelerate, I saw between 125-600 ms per progressive render. With this approach, the range was 120-240ms. 

I haven't tested this under OS X yet. Is there an OS X project in the repo?