### PR TITLE
Fix crash that can occur if image creation failed.

### DIFF
--- a/Pod/Classes/PINAnimatedImage.m
+++ b/Pod/Classes/PINAnimatedImage.m
@@ -197,7 +197,9 @@ void releaseData(void *data, const void *imageData, size_t size)
                                       NULL,
                                       NO,
                                       kCGRenderingIntentDefault);
-  CFAutorelease(imageRef);
+  if (imageRef) {
+    CFAutorelease(imageRef);
+  }
   
   CGColorSpaceRelease(colorSpace);
   CGDataProviderRelease(dataProvider);


### PR DESCRIPTION
CFAutorelease crashes if you pass in NULL.