### PR TITLE
Fix runaway NSData

### DIFF
--- a/Pod/Classes/PINAnimatedImageManager.m
+++ b/Pod/Classes/PINAnimatedImageManager.m
@@ -392,6 +392,7 @@ ERROR;}) \
               if (frameImage == nil) {
                 NSError *frameImageError = [NSError errorWithDomain:kPINAnimatedImageErrorDomain code:PINAnimatedImageErrorImageFrameError userInfo:nil];
                 HANDLE_PROCESSING_ERROR(frameImageError);
+                return;
               }
               
               NSData *frameData = (__bridge_transfer NSData *)CGDataProviderCopyData(CGImageGetDataProvider(frameImage));


### PR DESCRIPTION
Previously we were generating all the frames of the GIF and dispatching
to write the data to the disk. This presents a problem if the disk backs
up though and it can end up with theoretically every frame in memory. Instead,
generate a frame and write it one frame at a time. Slower, but prevents
this runaway memory situation.