### PR TITLE
Configurable callback queue #169

### DIFF
--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -258,7 +258,7 @@
                                     options:PINRemoteImageManagerDownloadOptionsNone
                                  completion:^(PINRemoteImageManagerResult *result)
      {
-         XCTAssertFalse([[NSThread currentThread] isMainThread]);
+         XCTAssertFalse([NSThread isMainThread]);
          [expectation fulfill];
      }];
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];

--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -244,7 +244,7 @@
                                     options:PINRemoteImageManagerDownloadOptionsNone
                                  completion:^(PINRemoteImageManagerResult *result)
      {
-         XCTAssertTrue([[NSThread currentThread] isMainThread]);
+         XCTAssertTrue([NSThread isMainThread]);
          [expectation fulfill];
      }];
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -131,6 +131,12 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 @property (nonatomic, readonly, nonnull) PINCache * cache;
 
 /**
+ The dispatch queue that will be used for completion and progress callbacks (`PINRemoteImageManagerImageCompletion`) against image download requests.
+ Defaults to the main queue.
+ */
+@property (nonatomic, strong, nonnull) dispatch_queue_t callbackQueue;
+
+/**
  Create and return a PINRemoteImageManager created with the specified configuration. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc.
  @param configuration The configuration used to create the PINRemoteImageManager.
  @return A PINRemoteImageManager with the specified configuration.

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -120,7 +120,6 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
 @property (nonatomic, assign) BOOL shouldBlurProgressive;
 @property (nonatomic, assign) CGSize maxProgressiveRenderSize;
 @property (nonatomic, assign) NSTimeInterval estimatedRemainingTimeThreshold;
-@property (nonatomic, strong) dispatch_queue_t callbackQueue;
 @property (nonatomic, strong) NSOperationQueue *concurrentOperationQueue;
 @property (nonatomic, strong) NSOperationQueue *urlSessionTaskQueue;
 @property (nonatomic, strong) NSMutableArray <PINTaskQOS *> *taskQOS;
@@ -187,7 +186,7 @@ static dispatch_once_t sharedDispatchToken;
         if (!configuration) {
             configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
         }
-        _callbackQueue = dispatch_queue_create("PINRemoteImageManagerCallbackQueue", DISPATCH_QUEUE_CONCURRENT);
+        _callbackQueue = dispatch_get_main_queue();
         _lock = [[PINRemoteLock alloc] initWithName:@"PINRemoteImageManager"];
         _concurrentOperationQueue = [[NSOperationQueue alloc] init];
         _concurrentOperationQueue.name = @"PINRemoteImageManager Concurrent Operation Queue";


### PR DESCRIPTION
This PR exposes the callback queue on PINRemoteImageManager and having it default to the main thread.

This makes it less likely for this library to trip up most developers and now makes it so that those comfortable with async dev can set a different queue.

This was discussed in #169 

## TODO:

- [ ] Add initialiser that accepts a callback queue rather than allow it to be set at any point in the managers lifetime