### PR TITLE
Update README.md, installation by CocoaPods

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ aCompletion(NSURLSessionAuthChallengePerformDefaultHandling, nil)];
 ### CocoaPods
 
 Add [PINRemoteImage](http://cocoapods.org/?q=name%3APINRemoteImage) to your `Podfile` and run `pod install`.
+
 If you'd like to use WebP images, add [PINRemoteImage/WebP](http://cocoapods.org/?q=name%3APINRemoteImage) to your `Podfile` and run `pod install`.
 
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ aCompletion(NSURLSessionAuthChallengePerformDefaultHandling, nil)];
 ### CocoaPods
 
 Add [PINRemoteImage](http://cocoapods.org/?q=name%3APINRemoteImage) to your `Podfile` and run `pod install`.
+If you'd like to use WebP images, add [PINRemoteImage/WebP](http://cocoapods.org/?q=name%3APINRemoteImage) to your `Podfile` and run `pod install`.
 
 
 ### Carthage


### PR DESCRIPTION
- Just add second line with WebP subspec to installation by CocoaPods, to clarify _how to install_ for users that would like to use WebP images.