### PR TITLE
Compatibility with network debugging framework 

### DIFF
--- a/Pod/Classes/PINURLSessionManager.m
+++ b/Pod/Classes/PINURLSessionManager.m
@@ -72,6 +72,11 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
 
 #pragma mark NSURLSessionDataDelegate
 
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveResponse:(NSURLResponse *)response completionHandler:(void (^)(NSURLSessionResponseDisposition))completionHandler
+{
+    completionHandler(NSURLSessionResponseAllow);
+}
+
 - (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential *credential))completionHandler
 {
     if ([self.delegate respondsToSelector:@selector(didReceiveAuthenticationChallenge:forTask:completionHandler:)]) {


### PR DESCRIPTION
PINURLSessionManager currently can not work with network debugging framework such as FLEX or PonyDebugger, because these frameworks will hook NSURLSessionDataDelegate method `-URLSession:dataTask:didReceiveResponse:completionHandler:`. According to Apple's document, delegate who implement this method must call completionHandler or system will not proceed the request. 
Though it is those framework's duty to avoid hook this function when delegate didn't implement this, by adding this method will quick fix compatibility.