### PR TITLE
Ensure Opaque Images Have No Alpha Channel

### DIFF
--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -101,6 +101,11 @@
     return [self JPEGURL_Medium];
 }
 
+- (NSURL *)transparentPNGURL
+{
+	return [NSURL URLWithString:@"https://upload.wikimedia.org/wikipedia/commons/4/47/PNG_transparency_demonstration_1.png"];
+}
+
 - (NSURL *)nonTransparentWebPURL
 {
     return [NSURL URLWithString:@"https://www.gstatic.com/webp/gallery/5.webp"];
@@ -818,6 +823,75 @@
             __unused NSString *key = [self.imageManager cacheKeyForURL:defaultURL processorKey:nil];
         }
     }];
+}
+
+- (void)testThatNondecodedJPEGImageHasNoAlpha
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Downloading JPEG image"];
+	[self.imageManager downloadImageWithURL:[self JPEGURL]
+									options:PINRemoteImageManagerDownloadOptionsSkipDecode
+								 completion:^(PINRemoteImageManagerResult *result)
+	 {
+		 UIImage *outImage = result.image;
+		 
+		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
+		 XCTAssertEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Opaque image has an alpha channel.");
+		 
+		 [expectation fulfill];
+	 }];
+	[self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
+- (void)testThatDecodedJPEGImageHasNoAlpha
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Downloading JPEG image"];
+	[self.imageManager downloadImageWithURL:[self JPEGURL]
+									options:PINRemoteImageManagerDownloadOptionsNone
+								 completion:^(PINRemoteImageManagerResult *result)
+	 {
+		 UIImage *outImage = result.image;
+		 
+		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
+		 XCTAssertEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Opaque image has an alpha channel.");
+		 
+		 [expectation fulfill];
+	 }];
+	[self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
+
+- (void)testThatNondecodedTransparentPNGImageHasAlpha
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Downloading PNG image"];
+	[self.imageManager downloadImageWithURL:[self transparentPNGURL]
+									options:PINRemoteImageManagerDownloadOptionsSkipDecode
+								 completion:^(PINRemoteImageManagerResult *result)
+	 {
+		 UIImage *outImage = result.image;
+		 
+		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
+		 XCTAssertNotEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Transparent image has no alpha.");
+		 
+		 [expectation fulfill];
+	 }];
+	[self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
+- (void)testThatDecodedTransparentPNGImageHasAlpha
+{
+	XCTestExpectation *expectation = [self expectationWithDescription:@"Downloading PNG image"];
+	[self.imageManager downloadImageWithURL:[self transparentPNGURL]
+									options:PINRemoteImageManagerDownloadOptionsNone
+								 completion:^(PINRemoteImageManagerResult *result)
+	 {
+		 UIImage *outImage = result.image;
+		 
+		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
+		 XCTAssertNotEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Transparent image has no alpha.");
+		 
+		 [expectation fulfill];
+	 }];
+	[self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
 }
 
 @end

--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -18,6 +18,16 @@
 #import <FLAnimatedImage/FLAnimatedImage.h>
 #endif
 
+static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
+	switch (info) {
+		case kCGImageAlphaNone:
+		case kCGImageAlphaNoneSkipLast:
+		case kCGImageAlphaNoneSkipFirst:
+			return YES;
+		default:
+			return NO;
+	}
+}
 
 #if DEBUG
 @interface PINRemoteImageManager ()
@@ -835,7 +845,7 @@
 		 UIImage *outImage = result.image;
 		 
 		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
-		 XCTAssertEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Opaque image has an alpha channel.");
+		 XCTAssert(PINImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(outImage.CGImage)), @"Opaque image has an alpha channel.");
 		 
 		 [expectation fulfill];
 	 }];
@@ -852,7 +862,7 @@
 		 UIImage *outImage = result.image;
 		 
 		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
-		 XCTAssertEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Opaque image has an alpha channel.");
+		 XCTAssert(PINImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(outImage.CGImage)), @"Opaque image has an alpha channel.");
 		 
 		 [expectation fulfill];
 	 }];
@@ -870,7 +880,7 @@
 		 UIImage *outImage = result.image;
 		 
 		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
-		 XCTAssertNotEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Transparent image has no alpha.");
+		 XCTAssertFalse(PINImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(outImage.CGImage)), @"Transparent image has no alpha.");
 		 
 		 [expectation fulfill];
 	 }];
@@ -887,7 +897,7 @@
 		 UIImage *outImage = result.image;
 		 
 		 XCTAssert(outImage && [outImage isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
-		 XCTAssertNotEqual(CGImageGetAlphaInfo(outImage.CGImage), kCGImageAlphaNone, @"Transparent image has no alpha.");
+		 XCTAssertFalse(PINImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(outImage.CGImage)), @"Transparent image has no alpha.");
 		 
 		 [expectation fulfill];
 	 }];


### PR DESCRIPTION
~~It seems that even when downloading plain old JPEGs, we always return images with an alpha channel which is detrimental to performance.~~ 

~~I'm going to try and fix it!~~

Pairs nicely with https://github.com/facebook/AsyncDisplayKit/pull/2197

**EDIT** I'm dumb. But unit tests are good!