### PR TITLE
PINAnimatedImageManager cleanup in +initialize rather than +load

### DIFF
--- a/Pod/Classes/PINAnimatedImageManager.m
+++ b/Pod/Classes/PINAnimatedImageManager.m
@@ -43,7 +43,7 @@ static dispatch_once_t startupCleanupOnce;
 
 @implementation PINAnimatedImageManager
 
-+ (void)load
++ (void)initialize
 {
   if (self == [PINAnimatedImageManager class]) {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{


### PR DESCRIPTION
Performing cleanup (specifically, calling -cleanupFiles) in +load can delay on-device app launch time noticeably. Let’s try moving this work to +initialize instead.