### PR TITLE
Add option to bypass cache

### DIFF
--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -239,6 +239,23 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
 }
 
+- (void)testIgnoreCache
+{
+    [self.imageManager downloadImageWithURL:[self JPEGURL] completion:nil];
+    [self waitForImageWithURLToBeCached:[self JPEGURL]];
+
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Download ignoring cache"];
+    [self.imageManager downloadImageWithURL:[self JPEGURL]
+                                    options:PINRemoteImageManagerDownloadOptionsIgnoreCache
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         XCTAssert(result.resultType == PINRemoteImageResultTypeDownload, @"Image was fetched from cache");
+
+         [expectation fulfill];
+     }];
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
 - (void)testJPEGDownload
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Downloading JPEG image"];

--- a/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -590,6 +590,19 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     
 }
 
+- (void)testImageFromCacheReturnsNilErrorForCacheMiss
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Image from cache"];
+
+    [self.imageManager imageFromCacheWithCacheKey:[self.imageManager cacheKeyForURL:[self JPEGURL] processorKey:nil] options:PINRemoteImageManagerDownloadOptionsNone completion:^(PINRemoteImageManagerResult * _Nonnull result) {
+         XCTAssert(result.image == nil, @"Image was found in cache");
+         XCTAssert(result.error == nil, @"Error was returned in cache miss");
+
+         [expectation fulfill];
+     }];
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
 - (void)testProcessingLoad
 {
     dispatch_group_t group = dispatch_group_create();

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -53,6 +53,8 @@ typedef NS_OPTIONS(NSUInteger, PINRemoteImageManagerDownloadOptions) {
     PINRemoteImageManagerDownloadOptionsSkipEarlyCheck = 1 << 2,
     /** Save processed images as JPEGs in the cache. The default is PNG to support transparency */
     PINRemoteImageManagerSaveProcessedImageAsJPEG = 1 << 3,
+    /** Ignore cache and force download */
+    PINRemoteImageManagerDownloadOptionsIgnoreCache = 1 << 4,
 };
 
 /**

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -564,12 +564,14 @@ static dispatch_once_t sharedDispatchToken;
         UUID = [NSUUID UUID];
     }
 
-    //Check to see if the image is in memory cache and we're on the main thread.
-    //If so, special case this to avoid flashing the UI
-    id object = [self.cache objectFromMemoryForKey:key];
-    if (object) {
-        if ([self earlyReturnWithOptions:options url:url key:key object:object completion:completion]) {
-            return nil;
+    if ((options & PINRemoteImageManagerDownloadOptionsIgnoreCache) == 0) {
+        //Check to see if the image is in memory cache and we're on the main thread.
+        //If so, special case this to avoid flashing the UI
+        id object = [self.cache objectFromMemoryForKey:key];
+        if (object) {
+            if ([self earlyReturnWithOptions:options url:url key:key object:object completion:completion]) {
+                return nil;
+            }
         }
     }
     
@@ -1520,6 +1522,11 @@ static dispatch_once_t sharedDispatchToken;
 
 - (void)objectForKey:(NSString *)key options:(PINRemoteImageManagerDownloadOptions)options completion:(void (^)(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation))completion
 {
+    if (options & PINRemoteImageManagerDownloadOptionsIgnoreCache) {
+        completion(NO, NO, nil, nil);
+        return;
+    }
+
     void (^materialize)(id object) = ^(id object) {
         PINImage *image = nil;
         id alternativeRepresentation = nil;

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1522,7 +1522,7 @@ static dispatch_once_t sharedDispatchToken;
 
 - (void)objectForKey:(NSString *)key options:(PINRemoteImageManagerDownloadOptions)options completion:(void (^)(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation))completion
 {
-    if (options & PINRemoteImageManagerDownloadOptionsIgnoreCache) {
+    if ((options & PINRemoteImageManagerDownloadOptionsIgnoreCache) != 0) {
         completion(NO, NO, nil, nil);
         return;
     }

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1523,7 +1523,7 @@ static dispatch_once_t sharedDispatchToken;
 - (void)objectForKey:(NSString *)key options:(PINRemoteImageManagerDownloadOptions)options completion:(void (^)(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation))completion
 {
     if ((options & PINRemoteImageManagerDownloadOptionsIgnoreCache) != 0) {
-        completion(NO, NO, nil, nil);
+        completion(NO, YES, nil, nil);
         return;
     }
 
@@ -1549,7 +1549,7 @@ static dispatch_once_t sharedDispatchToken;
           if (object) {
               materialize(object);
           } else {
-              completion(NO, NO, nil, nil);
+              completion(NO, YES, nil, nil);
           }
         }];
     }


### PR DESCRIPTION
Related to https://github.com/pinterest/PINRemoteImage/issues/123, we need a way to expire the cache for images that have the same url, but the content changes. Since PINRemoteImage doesn't have a way of handling this automatically, we need some way of handling this ourselves.

For that, I added a new `PINRemoteImageManagerDownloadOptionsIgnoreCache` option. When that is set, it will bypass the memory and disk cache checks and force the image to be downloaded. This way we can load from cache, but periodically force an update based on external factors. I'm not very familiar with the internals, so let me know if there is a better way to achieve this, but wanted to get a conversation going. Thanks!