### PR TITLE
Need to clear out existing progress data on retry

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -831,6 +831,9 @@ static dispatch_once_t sharedDispatchToken;
                 if (task.numberOfRetries < PINRemoteImageMaxRetries) {
                     retry = YES;
                     newNumberOfRetries = ++task.numberOfRetries;
+                  
+                    // Clear out the exsiting progress image or else new data from retry will be appended
+                    task.progressImage = nil;
                     task.urlSessionTaskOperation = nil;
                 }
                 [strongSelf unlock];


### PR DESCRIPTION
Finally found it! When retrying a download, we need to clear out the old fetched data, otherwise we'll append the new data on top of the old. This addresses #260 260