### PR TITLE
Add ability to configure header after initialize PINRemoteImageManager

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -184,10 +184,10 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 - (nonnull id<PINRemoteImageCaching>)defaultImageCache;
 
 /**
- * Set the custom header directly to every requests. Headers set from this method will override any header from NSURLSessionConfiguration.
+ * Sets a custom header to be included in every request. Headers set from this method will override any header from NSURLSessionConfiguration.
  *
- * @param value A value for the header
- * @param header  A string field for header
+ * @param value A value for the header. Pass in nil to remove a previously set value.
+ * @param header A string field for header.
  */
 - (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)header;
 

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -184,6 +184,14 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 - (nonnull id<PINRemoteImageCaching>)defaultImageCache;
 
 /**
+ * Set the custom header directly to every requests. Headers set from this method will override any header from NSURLSessionConfiguration.
+ *
+ * @param value A value for the header
+ * @param header  A string field for header
+ */
+- (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)header;
+
+/**
  Set the Authentication Challenge Block.
  
  @param challengeBlock A PINRemoteImageManagerAuthenticationChallenge block.

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -288,12 +288,7 @@ static dispatch_once_t sharedDispatchToken;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         typeof(self) strongSelf = weakSelf;
         [strongSelf lock];
-            if (value) {
-                strongSelf.httpHeaderFields[header] = value;
-            }
-            else {
-                [strongSelf.httpHeaderFields removeObjectForKey:header];
-            }
+            strongSelf.httpHeaderFields[[header copy]] = [value copy];
         [strongSelf unlock];
     });
 }


### PR DESCRIPTION
This will come in handy when we want to access secure image which usually require us to provide `Authorization` header.