### PR TITLE
Save webp

### DIFF
--- a/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -18,6 +18,10 @@
 #import <FLAnimatedImage/FLAnimatedImage.h>
 #endif
 
+#ifdef PIN_WEBP
+#import "PINImage+WebP.h"
+#endif
+
 static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 	switch (info) {
 		case kCGImageAlphaNone:
@@ -60,7 +64,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 @implementation PINRemoteImage_Tests
 
 - (NSTimeInterval)timeoutTimeInterval {
-    return 10.0;
+    return 30.0;
 }
 
 - (dispatch_time_t)timeoutWithInterval:(NSTimeInterval)interval {
@@ -406,7 +410,12 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 
 - (void)waitForImageWithURLToBeCached:(NSURL *)URL
 {
-    NSString *key = [self.imageManager cacheKeyForURL:URL processorKey:nil];
+    [self waitForImageWithURLToBeCached:URL processorKey:nil];
+}
+
+- (void)waitForImageWithURLToBeCached:(NSURL *)URL processorKey:(NSString *)processorKey
+{
+    NSString *key = [self.imageManager cacheKeyForURL:URL processorKey:processorKey];
     for (NSUInteger idx = 0; idx < 100; idx++) {
         if ([[self.imageManager cache] objectExistsForKey:key]) {
             break;
@@ -849,6 +858,28 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 	
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
 }
+
+#if PIN_WEBP
+- (void)testDiskCacheOnWebP
+{
+    id<PINRemoteImageCaching> cache = self.imageManager.cache;
+    NSString *processorKey = @"webp";
+    NSURL *pngUrl = [self transparentPNGURL];
+    NSString *key = [self.imageManager cacheKeyForURL:pngUrl processorKey:processorKey];
+
+    [self.imageManager downloadImageWithURL:pngUrl options:PINRemoteImageManagerSaveProcessedImageAsWEBP processorKey:processorKey
+                                  processor:^UIImage *(PINRemoteImageManagerResult *result, NSUInteger *cost) {
+                                      return result.image;
+    } completion:nil];
+    [self waitForImageWithURLToBeCached:pngUrl processorKey:processorKey];
+
+    id diskCachedObj = [cache objectFromDiskForKey:key];
+    XCTAssertNotNil(diskCachedObj);
+    PINImage *image = [PINImage pin_imageWithWebPData:diskCachedObj];
+    XCTAssert(image, @"Image should be WebP");
+
+}
+#endif
 
 - (void)testDiskCacheOnLongURLs
 {

--- a/Pod/Classes/Categories/PINImage+WebP.h
+++ b/Pod/Classes/Categories/PINImage+WebP.h
@@ -19,6 +19,7 @@
 @interface PINImage (PINWebP)
 
 + (PINImage *)pin_imageWithWebPData:(NSData *)webPData;
++ (NSData *)pin_DataFromWebPimage:(PINImage *)image;
 
 @end
 

--- a/Pod/Classes/Categories/PINImage+WebP.m
+++ b/Pod/Classes/Categories/PINImage+WebP.m
@@ -111,7 +111,7 @@ static void releaseData(void *info, const void *data, size_t size)
     CFDataRef dataRef = CGDataProviderCopyData(dataProvider);
     
     WebPConfig config;
-    WebPConfigLosslessPreset(&config, 6);
+    WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, 75);
     
     WebPPicture picture;
     WebPPictureInit(&picture);
@@ -136,7 +136,6 @@ static void releaseData(void *info, const void *data, size_t size)
     NSData *data = [NSData dataWithBytes:writer.mem length:writer.size];
     
     WebPPictureFree(&picture);
-    
     free(rawData);
     
     return data;

--- a/Pod/Classes/Categories/PINImage+WebP.m
+++ b/Pod/Classes/Categories/PINImage+WebP.m
@@ -78,13 +78,8 @@ static void releaseData(void *info, const void *data, size_t size)
     return nil;
 }
 
-+ (NSData *)pin_DataFromWebPimage:(PINImage *)image {
-    
-    WebPConfig config;
-    WebPPicture picture;
-    WebPConfigPreset(&config, WEBP_PRESET_DEFAULT, 75);
-    WebPPictureInit(&picture);
-    
++ (NSData *)pin_DataFromWebPimage:(PINImage *)image
+{
     // convert color space.
     CGRect imageRect = CGRectMake(0, 0, image.size.width, image.size.height);
     CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
@@ -108,12 +103,17 @@ static void releaseData(void *info, const void *data, size_t size)
     CGDataProviderRef dataProvider = CGImageGetDataProvider(imageRef);
     CFDataRef dataRef = CGDataProviderCopyData(dataProvider);
     
+    WebPConfig config;
+    WebPConfigLosslessPreset(&config, 6);
+    
+    WebPPicture picture;
+    WebPPictureInit(&picture);
+    
     picture.colorspace = WEBP_YUV420A;
     picture.width = image.size.width;
     picture.height = image.size.height;
     
     WebPPictureImportRGBA(&picture, (uint8_t *)CFDataGetBytePtr(dataRef), (int) CGImageGetBytesPerRow(imageRef));
-    WebPPictureARGBToYUVA(&picture, picture.colorspace);
     WebPCleanupTransparentArea(&picture);
     
     CFRelease(dataRef);
@@ -129,6 +129,8 @@ static void releaseData(void *info, const void *data, size_t size)
     NSData *data = [NSData dataWithBytes:writer.mem length:writer.size];
     
     WebPPictureFree(&picture);
+    
+    free(rawData);
     
     return data;
     

--- a/Pod/Classes/Categories/PINImage+WebP.m
+++ b/Pod/Classes/Categories/PINImage+WebP.m
@@ -90,13 +90,20 @@ static void releaseData(void *info, const void *data, size_t size)
     NSUInteger bitmapByteCount = bytesPerRow * image.size.height;
     
     unsigned char *rawData = (unsigned char*) calloc(bitmapByteCount, sizeof(unsigned char));
-    
+
     CGContextRef context = CGBitmapContextCreate(rawData, image.size.width, image.size.height,
                                                  bitsPerComponent, bytesPerRow, colorSpace,
                                                  kCGImageAlphaPremultipliedLast | kCGImageByteOrder32Big);
-    
+
+    CGImageRef imageRef;
+    #if PIN_TARGET_IOS
     CGContextDrawImage(context, imageRect, image.CGImage);
-    CGImageRef imageRef = CGBitmapContextCreateImage(context);
+    imageRef = CGBitmapContextCreateImage(context);
+    #elif PIN_TARGET_MAC
+    NSGraphicsContext *graphicsContext = [NSGraphicsContext graphicsContextWithCGContext:context flipped:NO];
+    imageRef = [image CGImageForProposedRect:&imageRect context:graphicsContext hints:nil];
+    #endif
+    
     CGColorSpaceRelease(colorSpace);
     CGContextRelease(context);
     

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -53,8 +53,10 @@ typedef NS_OPTIONS(NSUInteger, PINRemoteImageManagerDownloadOptions) {
     PINRemoteImageManagerDownloadOptionsSkipEarlyCheck = 1 << 2,
     /** Save processed images as JPEGs in the cache. The default is PNG to support transparency */
     PINRemoteImageManagerSaveProcessedImageAsJPEG = 1 << 3,
+    /** Save processed images as WebP (if possible) in the cache. The default is PNG */
+    PINRemoteImageManagerSaveProcessedImageAsWEBP = 1 << 4,
     /** Ignore cache and force download */
-    PINRemoteImageManagerDownloadOptionsIgnoreCache = 1 << 4,
+    PINRemoteImageManagerDownloadOptionsIgnoreCache = 1 << 5,
 };
 
 /**

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -32,6 +32,10 @@
 #import "PINRemoteImageBasicCache.h"
 #endif
 
+#ifdef PIN_WEBP
+#import "PINImage+WebP.h"
+#endif
+
 
 #define PINRemoteImageManagerDefaultTimeout     30.0
 #define PINRemoteImageMaxRetries                3
@@ -706,14 +710,19 @@ static dispatch_once_t sharedDispatchToken;
                 [strongSelf callCompletionsWithKey:key image:image alternativeRepresentation:nil cached:NO error:error finalized:NO];
                 
                 if (error == nil) {
+                    
                     BOOL saveAsJPEG = (options & PINRemoteImageManagerSaveProcessedImageAsJPEG) != 0;
+                    BOOL saveAsWebP = (options & PINRemoteImageManagerSaveProcessedImageAsWEBP && PIN_WEBP) != 0;
+
                     NSData *diskData = nil;
-                    if (saveAsJPEG) {
+                    if (saveAsWebP) {
+                        diskData = [PINImage pin_DataFromWebPimage:image];
+                    } else if (saveAsJPEG) {
                         diskData = PINImageJPEGRepresentation(image, 1.0);
                     } else {
                         diskData = PINImagePNGRepresentation(image);
                     }
-                    
+    
                     [strongSelf materializeAndCacheObject:image cacheInDisk:diskData additionalCost:processCost key:key options:options outImage:nil outAltRep:nil];
                 }
                 

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -712,11 +712,16 @@ static dispatch_once_t sharedDispatchToken;
                 if (error == nil) {
                     
                     BOOL saveAsJPEG = (options & PINRemoteImageManagerSaveProcessedImageAsJPEG) != 0;
-                    BOOL saveAsWebP = (options & PINRemoteImageManagerSaveProcessedImageAsWEBP && PIN_WEBP) != 0;
-
+                    BOOL saveAsWebP = NO;
+                    #ifdef PIN_WEBP
+                    saveAsWebP = (options & PINRemoteImageManagerSaveProcessedImageAsWEBP && PIN_WEBP) != 0;
+                    #endif
+                
                     NSData *diskData = nil;
                     if (saveAsWebP) {
+                        #ifdef PIN_WEBP
                         diskData = [PINImage pin_DataFromWebPimage:image];
+                        #endif
                     } else if (saveAsJPEG) {
                         diskData = PINImageJPEGRepresentation(image, 1.0);
                     } else {


### PR DESCRIPTION
I added the option "PINRemoteImageManagerSaveProcessedImageAsWEBP" to save processed images as WebP (currently lossy in quality 75) instead of PNG. If needed we can change it to lossy or provide a option to choose (like the jpg option).