### PR TITLE
Add an image manually to the cache.

### DIFF
--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -424,6 +424,22 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
                              progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
                                 completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
+
+/**
+ Adds an image manually into the memory and disk cache.
+ 
+ @param data NSData with the raw image data.
+ @param url NSURL where the image resides.
+ @processorKey NSString key to uniquely identify processor and process. Will be used for caching processed images.
+ @additionalCost NSUInteger the additional cost (for cache eviction purposes) to generate the processed image
+ 
+ @return A BOOL indicating if the image was successfully added to the cache.
+ */
+- (BOOL) insertImageDataIntoCache:(nonnull NSData*)data
+                          withURL:(nonnull NSURL *)url
+                     processorKey:(nullable NSString *)processorKey
+                   additionalCost:(NSUInteger)additionalCost;
+
 /**
  Returns the cacheKey for a given URL and processorKey. Exposed to be overridden if necessary or to be used with imageFromCacheWithCacheKey
  @see imageFromCacheWithCacheKey:completion:

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -751,6 +751,25 @@ static dispatch_once_t sharedDispatchToken;
     [self unlock];
 }
 
+-(BOOL) insertImageDataIntoCache:(nonnull NSData*)data
+                         withURL:(nonnull NSURL *)url
+                    processorKey:(nullable NSString *)processorKey
+                  additionalCost:(NSUInteger)additionalCost
+{
+  
+  if (url != nil) {
+    NSString *key = [self cacheKeyForURL:url processorKey:processorKey];
+    
+    PINRemoteImageManagerDownloadOptions options = PINRemoteImageManagerDownloadOptionsSkipDecode & PINRemoteImageManagerDownloadOptionsSkipEarlyCheck;
+    PINRemoteImageMemoryContainer *container = [[PINRemoteImageMemoryContainer alloc] init];
+    container.data = data;
+    
+    return [self materializeAndCacheObject: container cacheInDisk: data additionalCost: additionalCost key:key options:options outImage: nil outAltRep: nil];
+  }
+  
+  return NO;
+}
+
 - (BOOL)earlyReturnWithOptions:(PINRemoteImageManagerDownloadOptions)options url:(NSURL *)url key:(NSString *)key object:(id)object completion:(PINRemoteImageManagerImageCompletion)completion
 {
     PINImage *image = nil;


### PR DESCRIPTION
I needed to add an image manually to the cache and saw this issue referenced here: https://github.com/pinterest/PINRemoteImage/issues/284

It seems to work, but is there anything I am missing?