### PR TITLE
Support for high resolution images

### DIFF
--- a/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -136,6 +136,11 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     return [NSURL URLWithString:@"https://placekitten.com/g/200/301?longarg=helloMomHowAreYouDoing.IamFineJustMovedToLiveWithANiceChapWeTravelTogetherInHisBlueBoxThroughSpaceAndTimeMaybeYouveMetHimAlready.YesterdayWeMetACultureOfPeopleWithTentaclesWhoSingWithAVeryCelestialVoice.SoGood.SeeYouSoon.MaybeYesterday.WhoKnows.XOXO"];
 }
 
+- (NSURL *)scaledImageURL
+{
+    return [NSURL URLWithString:@"http://www.grenadabluewatersailing.com/wp-content/uploads/2014/09/Coconut-wikipedia.com_-300x225@2x.jpg"];
+}
+
 #pragma mark - <PINURLSessionManagerDelegate>
 
 - (void)didReceiveData:(NSData *)data forTask:(NSURLSessionTask *)task
@@ -418,6 +423,22 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     XCTAssert(outImageEncoded && [outImageEncoded isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
     XCTAssert(outImageDecoded && [outImageDecoded isKindOfClass:[UIImage class]], @"Failed downloading image or image is not a UIImage.");
     XCTAssert(encodedDrawTime / decodedDrawTime > 2, @"Drawing decoded image should be much faster");
+}
+
+- (void)testScalingWithURLPostfix
+{
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Error on scaling"];
+    [self.imageManager downloadImageWithURL:[self scaledImageURL]
+                                    options:PINRemoteImageManagerDownloadOptionsNone
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         XCTAssert(result.image != nil);
+         XCTAssert(result.image.scale == 2.0);
+         
+         [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
 }
 
 - (void)drawImage:(UIImage *)image

--- a/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -640,7 +640,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Image from cache"];
 
-    [self.imageManager imageFromCacheWithURL:[self JPEGURL] options:PINRemoteImageManagerDownloadOptionsNone completion:^(PINRemoteImageManagerResult * _Nonnull result) {
+    [self.imageManager imageFromCacheWithURL:[self JPEGURL] processorKey:nil options:PINRemoteImageManagerDownloadOptionsNone completion:^(PINRemoteImageManagerResult * _Nonnull result) {
          XCTAssert(result.image == nil, @"Image was found in cache");
          XCTAssert(result.error == nil, @"Error was returned in cache miss");
 

--- a/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -136,10 +136,10 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     return [NSURL URLWithString:@"https://placekitten.com/g/200/301?longarg=helloMomHowAreYouDoing.IamFineJustMovedToLiveWithANiceChapWeTravelTogetherInHisBlueBoxThroughSpaceAndTimeMaybeYouveMetHimAlready.YesterdayWeMetACultureOfPeopleWithTentaclesWhoSingWithAVeryCelestialVoice.SoGood.SeeYouSoon.MaybeYesterday.WhoKnows.XOXO"];
 }
 
-- (NSURL *)scaledImageURL
-{
-    return [NSURL URLWithString:@"http://www.grenadabluewatersailing.com/wp-content/uploads/2014/09/Coconut-wikipedia.com_-300x225@2x.jpg"];
-}
+//- (NSURL *)scaledImageURL
+//{
+//    return [NSURL URLWithString:@"http://www.grenadabluewatersailing.com/wp-content/uploads/2014/09/Coconut-wikipedia.com_-300x225@2x.jpg"];
+//}
 
 #pragma mark - <PINURLSessionManagerDelegate>
 
@@ -425,21 +425,21 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     XCTAssert(encodedDrawTime / decodedDrawTime > 2, @"Drawing decoded image should be much faster");
 }
 
-- (void)testScalingWithURLPostfix
-{
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Error on scaling"];
-    [self.imageManager downloadImageWithURL:[self scaledImageURL]
-                                    options:PINRemoteImageManagerDownloadOptionsNone
-                                 completion:^(PINRemoteImageManagerResult *result)
-     {
-         XCTAssert(result.image != nil);
-         XCTAssert(result.image.scale == 2.0);
-         
-         [expectation fulfill];
-    }];
-    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
-}
+//- (void)testScalingWithURLPostfix
+//{
+//    
+//    XCTestExpectation *expectation = [self expectationWithDescription:@"Error on scaling"];
+//    [self.imageManager downloadImageWithURL:[self scaledImageURL]
+//                                    options:PINRemoteImageManagerDownloadOptionsNone
+//                                 completion:^(PINRemoteImageManagerResult *result)
+//     {
+//         XCTAssert(result.image != nil);
+//         XCTAssert(result.image.scale == 2.0);
+//         
+//         [expectation fulfill];
+//    }];
+//    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+//}
 
 - (void)drawImage:(UIImage *)image
 {
@@ -640,7 +640,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Image from cache"];
 
-    [self.imageManager imageFromCacheWithCacheKey:[self.imageManager cacheKeyForURL:[self JPEGURL] processorKey:nil] options:PINRemoteImageManagerDownloadOptionsNone completion:^(PINRemoteImageManagerResult * _Nonnull result) {
+    [self.imageManager imageFromCacheWithURL:[self JPEGURL] options:PINRemoteImageManagerDownloadOptionsNone completion:^(PINRemoteImageManagerResult * _Nonnull result) {
          XCTAssert(result.image == nil, @"Image was found in cache");
          XCTAssert(result.error == nil, @"Error was returned in cache miss");
 

--- a/Examples/Example/PINRemoteImage/PINRemoteImage-Info.plist
+++ b/Examples/Example/PINRemoteImage/PINRemoteImage-Info.plist
@@ -24,6 +24,13 @@
 	<string>1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSExceptionAllowsInsecureHTTPLoads</key>
+		<true/>
+	</dict>
 	<key>UIMainStoryboardFile</key>
 	<string>Main</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/PINRemoteImage/PINRemoteImage.xcodeproj/project.pbxproj
+++ b/PINRemoteImage/PINRemoteImage.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		68F0EA931CB32EC900F1FD41 /* PINAlternateRepresentationProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 68F0EA8F1CB32EC900F1FD41 /* PINAlternateRepresentationProvider.m */; };
 		68F0EA941CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.h in Headers */ = {isa = PBXBuildFile; fileRef = 68F0EA901CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.h */; };
 		68F0EA951CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 68F0EA911CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.m */; };
+		693818D41E4D14480006014D /* PINImage+ScaledImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 693818D21E4D14480006014D /* PINImage+ScaledImage.h */; };
+		693818D51E4D14480006014D /* PINImage+ScaledImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 693818D31E4D14480006014D /* PINImage+ScaledImage.m */; };
 		9DD47F9C1C699F4B00F12CA0 /* PINButton+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD47F981C699F4B00F12CA0 /* PINButton+PINRemoteImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9DD47F9D1C699F4B00F12CA0 /* PINButton+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD47F991C699F4B00F12CA0 /* PINButton+PINRemoteImage.m */; };
 		9DD47F9E1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD47F9A1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -76,6 +78,8 @@
 		68F0EA8F1CB32EC900F1FD41 /* PINAlternateRepresentationProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINAlternateRepresentationProvider.m; sourceTree = "<group>"; };
 		68F0EA901CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageMemoryContainer.h; sourceTree = "<group>"; };
 		68F0EA911CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageMemoryContainer.m; sourceTree = "<group>"; };
+		693818D21E4D14480006014D /* PINImage+ScaledImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PINImage+ScaledImage.h"; sourceTree = "<group>"; };
+		693818D31E4D14480006014D /* PINImage+ScaledImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PINImage+ScaledImage.m"; sourceTree = "<group>"; };
 		9DD47F981C699F4B00F12CA0 /* PINButton+PINRemoteImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PINButton+PINRemoteImage.h"; sourceTree = "<group>"; };
 		9DD47F991C699F4B00F12CA0 /* PINButton+PINRemoteImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PINButton+PINRemoteImage.m"; sourceTree = "<group>"; };
 		9DD47F9A1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PINImageView+PINRemoteImage.h"; sourceTree = "<group>"; };
@@ -236,6 +240,8 @@
 				F1B918DF1BCF23C800710963 /* NSData+ImageDetectors.m */,
 				9DD47FA01C699FDC00F12CA0 /* PINImage+DecodedImage.h */,
 				9DD47FA11C699FDC00F12CA0 /* PINImage+DecodedImage.m */,
+				693818D21E4D14480006014D /* PINImage+ScaledImage.h */,
+				693818D31E4D14480006014D /* PINImage+ScaledImage.m */,
 				9DD47FA21C699FDC00F12CA0 /* PINImage+WebP.h */,
 				9DD47FA31C699FDC00F12CA0 /* PINImage+WebP.m */,
 			);
@@ -282,6 +288,7 @@
 				F1B919111BCF23C900710963 /* PINRemoteImageCallbacks.h in Headers */,
 				F1B9190E1BCF23C900710963 /* PINProgressiveImage.h in Headers */,
 				6858C0751C9CC5BA00E420EB /* PINRemoteLock.h in Headers */,
+				693818D41E4D14480006014D /* PINImage+ScaledImage.h in Headers */,
 				F1B919181BCF23C900710963 /* PINRemoteImageManagerResult.h in Headers */,
 				F1B9191A1BCF23C900710963 /* PINRemoteImageProcessorTask.h in Headers */,
 				9DD47FA41C699FDC00F12CA0 /* PINImage+DecodedImage.h in Headers */,
@@ -379,6 +386,7 @@
 				F1B9191B1BCF23C900710963 /* PINRemoteImageProcessorTask.m in Sources */,
 				F1B9190D1BCF23C900710963 /* PINDataTaskOperation.m in Sources */,
 				9DD47FA71C699FDC00F12CA0 /* PINImage+WebP.m in Sources */,
+				693818D51E4D14480006014D /* PINImage+ScaledImage.m in Sources */,
 				9DD47F9F1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.m in Sources */,
 				F1B919171BCF23C900710963 /* PINRemoteImageManager.m in Sources */,
 			);

--- a/Pod/Classes/Categories/PINImage+ScaledImage.h
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.h
@@ -16,8 +16,6 @@
 
 #import "PINRemoteImageMacros.h"
 
-extern PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage * __nullable image);
-
 @interface PINImage (PINScaledImage)
 
 - (PINImage *)pin_scaledImageForKey:(NSString *)key;

--- a/Pod/Classes/Categories/PINImage+ScaledImage.h
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.h
@@ -1,0 +1,26 @@
+//
+//  UIImage+ScaledImage.h
+//  Pods
+//
+//  Created by Michael Schneider on 2/9/17.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#if PIN_TARGET_IOS
+#import <UIKit/UIKit.h>
+#elif PIN_TARGET_MAC
+#import <Cocoa/Cocoa.h>
+#endif
+
+#import "PINRemoteImageMacros.h"
+
+extern PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage * __nullable image);
+
+@interface PINImage (PINScaledImage)
+
+- (PINImage *)pin_scaledImageForKey:(NSString *)key;
++ (PINImage *)pin_scaledImageForImage:(UIImage *)image withKey:(NSString *)key;
+
+@end

--- a/Pod/Classes/Categories/PINImage+ScaledImage.h
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.h
@@ -19,6 +19,6 @@
 @interface PINImage (PINScaledImage)
 
 - (PINImage *)pin_scaledImageForKey:(NSString *)key;
-+ (PINImage *)pin_scaledImageForImage:(UIImage *)image withKey:(NSString *)key;
++ (PINImage *)pin_scaledImageForImage:(PINImage *)image withKey:(NSString *)key;
 
 @end

--- a/Pod/Classes/Categories/PINImage+ScaledImage.m
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.m
@@ -45,7 +45,7 @@ static inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage
     return PINScaledImageForKey(key, self);
 }
 
-+ (PINImage *)pin_scaledImageForImage:(UIImage *)image withKey:(NSString *)key
++ (PINImage *)pin_scaledImageForImage:(PINImage *)image withKey:(NSString *)key
 {
     return PINScaledImageForKey(key, image);
 }

--- a/Pod/Classes/Categories/PINImage+ScaledImage.m
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.m
@@ -16,12 +16,12 @@ static inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage
 #if PIN_TARGET_IOS
     CGFloat scale = 1.0;
     if (key.length >= 8) {
-        NSRange range = [key rangeOfString:@"@2x."];
+        NSRange range = [key rangeOfString:@"_2x."];
         if (range.location != NSNotFound) {
             scale = 2.0;
         }
         
-        range = [key rangeOfString:@"@3x."];
+        range = [key rangeOfString:@"_3x."];
         if (range.location != NSNotFound) {
             scale = 3.0;
         }

--- a/Pod/Classes/Categories/PINImage+ScaledImage.m
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.m
@@ -1,0 +1,53 @@
+//
+//  UIImage+ScaledImage.m
+//  Pods
+//
+//  Created by Michael Schneider on 2/9/17.
+//
+//
+
+#import "PINImage+ScaledImage.h"
+
+inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage * __nullable image) {
+    if (image == nil) {
+        return nil;
+    }
+    
+#if PIN_TARGET_IOS
+    CGFloat scale = 1.0;
+    if (key.length >= 8) {
+        NSRange range = [key rangeOfString:@"@2x."];
+        if (range.location != NSNotFound) {
+            scale = 2.0;
+        }
+        
+        range = [key rangeOfString:@"@3x."];
+        if (range.location != NSNotFound) {
+            scale = 3.0;
+        }
+    }
+    
+    if (scale != image.scale) {
+        return [[UIImage alloc] initWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
+    }
+    
+    return image;
+
+#elif PIN_TARGET_MAC
+    return image;
+#endif
+}
+
+@implementation PINImage (ScaledImage)
+
+- (PINImage *)pin_scaledImageForKey:(NSString *)key
+{
+    return PINScaledImageForKey(key, self);
+}
+
++ (PINImage *)pin_scaledImageForImage:(UIImage *)image withKey:(NSString *)key
+{
+    return PINScaledImageForKey(key, image);
+}
+
+@end

--- a/Pod/Classes/Categories/PINImage+ScaledImage.m
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.m
@@ -8,7 +8,7 @@
 
 #import "PINImage+ScaledImage.h"
 
-inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage * __nullable image) {
+static inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage * __nullable image) {
     if (image == nil) {
         return nil;
     }

--- a/Pod/Classes/Categories/PINImage+ScaledImage.m
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.m
@@ -14,6 +14,9 @@ static inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage
     }
     
 #if PIN_TARGET_IOS
+    
+    NSCAssert(image.CGImage != NULL, @"CGImage should not be NULL");
+    
     CGFloat scale = 1.0;
     if (key.length >= 8) {
         NSRange range = [key rangeOfString:@"_2x."];

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -476,7 +476,7 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.
  */
-- (void)imageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion __attribute__((deprecated));;
+- (void)imageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion __attribute__((deprecated));
 
 /**
  Directly get an image from the underlying cache.
@@ -489,15 +489,15 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 - (void)imageFromCacheWithURL:(nonnull NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion;
 
 /**
- Directly get an image from the underlying memory cache synchronously.
- @see cacheKeyForURL:processorKey:
+ @deprecated
+ @see synchronousImageFromCacheWithURL:processorKey:options:
  
  @param cacheKey NSString key to look up image in the cache.
  @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
  
  @return A PINRemoteImageManagerResult
  */
-- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options;
+- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options __attribute__((deprecated));
 
 /**
  Directly get an image from the underlying memory cache synchronously.

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -482,15 +482,6 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  Directly get an image from the underlying cache.
  
  @param url NSURL to look up image in the cache.
- @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
- @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.
- */
-- (void)imageFromCacheWithURL:(nonnull NSURL *)url options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion;
-
-/**
- Directly get an image from the underlying cache.
- 
- @param url NSURL to look up image in the cache.
  @param processorKey NSString key to uniquely identify processor and process.
  @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -438,8 +438,8 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  
  @param data NSData with the raw image data.
  @param url NSURL where the image resides.
- @processorKey NSString key to uniquely identify processor and process. Will be used for caching processed images.
- @additionalCost NSUInteger the additional cost (for cache eviction purposes) to generate the processed image
+ @param processorKey NSString key to uniquely identify processor and process. Will be used for caching processed images.
+ @param additionalCost NSUInteger the additional cost (for cache eviction purposes) to generate the processed image
  
  @return A BOOL indicating if the image was successfully added to the cache.
  */
@@ -476,7 +476,16 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.
  */
-- (void)imageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion;
+- (void)imageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion __attribute__((deprecated));;
+
+/**
+ Directly get an image from the underlying cache.
+ 
+ @param url NSURL to look up image in the cache.
+ @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.
+ */
+- (void)imageFromCacheWithURL:(nonnull NSURL *)url options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion;
 
 /**
  Directly get an image from the underlying memory cache synchronously.
@@ -488,6 +497,16 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  @return A PINRemoteImageManagerResult
  */
 - (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithCacheKey:(nonnull NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options;
+
+/**
+ Directly get an image from the underlying memory cache synchronously.
+ 
+ @param url NSURL to look up image in the cache.
+ @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
+ 
+ @return A PINRemoteImageManagerResult
+ */
+- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url options:(PINRemoteImageManagerDownloadOptions)options;
 
 /**
  Cancel a download. Canceling will only cancel the download if all other downloads are also canceled with their associated UUIDs. Canceling *does not* guarantee that your completion will not be called. You can use the UUID provided on the result object verify the completion you want called is being called.

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -460,7 +460,7 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 - (nonnull NSString *)cacheKeyForURL:(nonnull NSURL *)url processorKey:(nullable NSString *)processorKey;
 
 /**
- @see imageFromCacheWithCacheKey:options:completion: instead
+ @see imageFromCacheWithURL:processorKey:options:completion:
  @deprecated
  
  @param cacheKey NSString key to look up image in the cache.
@@ -469,8 +469,8 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
 - (void)imageFromCacheWithCacheKey:(nonnull NSString *)cacheKey completion:(nonnull PINRemoteImageManagerImageCompletion)completion __attribute__((deprecated));
 
 /**
- Directly get an image from the underlying cache.
- @see cacheKeyForURL:processorKey:
+ @see imageFromCacheWithURL:processorKey:options:completion:
+ @deprecated
  
  @param cacheKey NSString key to look up image in the cache.
  @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
@@ -486,6 +486,16 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.
  */
 - (void)imageFromCacheWithURL:(nonnull NSURL *)url options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion;
+
+/**
+ Directly get an image from the underlying cache.
+ 
+ @param url NSURL to look up image in the cache.
+ @param processorKey NSString key to uniquely identify processor and process.
+ @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache.
+ */
+- (void)imageFromCacheWithURL:(nonnull NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options completion:(nonnull PINRemoteImageManagerImageCompletion)completion;
 
 /**
  Directly get an image from the underlying memory cache synchronously.

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -508,7 +508,7 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  
  @return A PINRemoteImageManagerResult
  */
-- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options;
+- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(nonnull NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options;
 
 /**
  Cancel a download. Canceling will only cancel the download if all other downloads are also canceled with their associated UUIDs. Canceling *does not* guarantee that your completion will not be called. You can use the UUID provided on the result object verify the completion you want called is being called.

--- a/Pod/Classes/PINRemoteImageManager.h
+++ b/Pod/Classes/PINRemoteImageManager.h
@@ -503,11 +503,12 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  Directly get an image from the underlying memory cache synchronously.
  
  @param url NSURL to look up image in the cache.
+ @param processorKey NSString key to uniquely identify processor and process
  @param options options will be used to determine if the cached image should be decompressed or FLAnimatedImages should be returned.
  
  @return A PINRemoteImageManagerResult
  */
-- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url options:(PINRemoteImageManagerDownloadOptions)options;
+- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options;
 
 /**
  Cancel a download. Canceling will only cancel the download if all other downloads are also canceled with their associated UUIDs. Canceling *does not* guarantee that your completion will not be called. You can use the UUID provided on the result object verify the completion you want called is being called.

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1117,7 +1117,7 @@ static dispatch_once_t sharedDispatchToken;
         }
     }
     
-    [self objectForURL:url key:cacheKey options:options completion:^(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation) {
+    [self objectForURL:url processorKey:processorKey key:cacheKey options:options completion:^(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation) {
         NSError *error = nil;
         if (valid == NO) {
             error = [NSError errorWithDomain:PINRemoteImageManagerErrorDomain
@@ -1565,17 +1565,17 @@ static dispatch_once_t sharedDispatchToken;
 
 - (void)objectForKey:(NSString *)key options:(PINRemoteImageManagerDownloadOptions)options completion:(void (^)(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation))completion
 {
-    return [self objectForURL:nil key:key options:options completion:completion];
+    return [self objectForURL:nil processorKey:nil key:key options:options completion:completion];
 }
 
-- (void)objectForURL:(NSURL *)url key:(NSString *)key options:(PINRemoteImageManagerDownloadOptions)options completion:(void (^)(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation))completion
+- (void)objectForURL:(NSURL *)url processorKey:(NSString *)processorKey key:(NSString *)key options:(PINRemoteImageManagerDownloadOptions)options completion:(void (^)(BOOL found, BOOL valid, PINImage *image, id alternativeRepresentation))completion
 {
     if ((options & PINRemoteImageManagerDownloadOptionsIgnoreCache) != 0) {
         completion(NO, YES, nil, nil);
         return;
     }
     
-    key = key ?: [self cacheKeyForURL:url processorKey:nil];
+    key = key ?: [self cacheKeyForURL:url processorKey:processorKey];
 
     void (^materialize)(id object) = ^(id object) {
         PINImage *image = nil;

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1100,6 +1100,15 @@ static dispatch_once_t sharedDispatchToken;
     return [self imageFromCacheWithURL:url cacheKey:nil options:options completion:completion];
 }
 
+- (void)imageFromCacheWithURL:(nonnull NSURL *)url
+                 processorKey:(nullable NSString *)processorKey
+                      options:(PINRemoteImageManagerDownloadOptions)options
+                   completion:(nonnull PINRemoteImageManagerImageCompletion)completion
+{
+    NSString *cacheKey = [self cacheKeyForURL:url processorKey:processorKey];
+    return [self imageFromCacheWithURL:url cacheKey:cacheKey options:options completion:completion];
+}
+
 - (void)imageFromCacheWithURL:(NSURL *)url
                      cacheKey:(NSString *)cacheKey
                       options:(PINRemoteImageManagerDownloadOptions)options

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1090,7 +1090,7 @@ static dispatch_once_t sharedDispatchToken;
                            options:(PINRemoteImageManagerDownloadOptions)options
                         completion:(PINRemoteImageManagerImageCompletion)completion
 {
-    return [self imageFromCacheWithURL:nil cacheKey:cacheKey options:options completion:completion];
+    [self imageFromCacheWithURL:nil processorKey:nil cacheKey:cacheKey options:options completion:completion];
 }
 
 - (void)imageFromCacheWithURL:(nonnull NSURL *)url
@@ -1098,11 +1098,11 @@ static dispatch_once_t sharedDispatchToken;
                       options:(PINRemoteImageManagerDownloadOptions)options
                    completion:(nonnull PINRemoteImageManagerImageCompletion)completion
 {
-    NSString *cacheKey = [self cacheKeyForURL:url processorKey:processorKey];
-    return [self imageFromCacheWithURL:url cacheKey:cacheKey options:options completion:completion];
+    [self imageFromCacheWithURL:url processorKey:processorKey cacheKey:nil options:options completion:completion];
 }
 
 - (void)imageFromCacheWithURL:(NSURL *)url
+                 processorKey:(NSString *)processorKey
                      cacheKey:(NSString *)cacheKey
                       options:(PINRemoteImageManagerDownloadOptions)options
                    completion:(PINRemoteImageManagerImageCompletion)completion
@@ -1110,7 +1110,7 @@ static dispatch_once_t sharedDispatchToken;
     CFTimeInterval requestTime = CACurrentMediaTime();
     
     if ((PINRemoteImageManagerDownloadOptionsSkipEarlyCheck & options) == NO && [NSThread isMainThread]) {
-        PINRemoteImageManagerResult *result = [self synchronousImageFromCacheWithURL:url cacheKey:cacheKey options:options];
+        PINRemoteImageManagerResult *result = [self synchronousImageFromCacheWithURL:url processorKey:processorKey cacheKey:cacheKey options:options];
         if (result.image && result.error) {
             completion((result));
             return;
@@ -1138,19 +1138,19 @@ static dispatch_once_t sharedDispatchToken;
 
 - (PINRemoteImageManagerResult *)synchronousImageFromCacheWithCacheKey:(NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options
 {
-    return [self synchronousImageFromCacheWithURL:nil cacheKey:cacheKey options:options];
+    return [self synchronousImageFromCacheWithURL:nil processorKey:nil cacheKey:cacheKey options:options];
 }
 
-- (PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url options:(PINRemoteImageManagerDownloadOptions)options
+- (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options
 {
-    return [self synchronousImageFromCacheWithURL:url cacheKey:nil options:options];
+    return [self synchronousImageFromCacheWithURL:url processorKey:processorKey options:options];
 }
 
-- (PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url cacheKey:(NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options
+- (PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(NSString *)processorKey cacheKey:(NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options
 {
     CFTimeInterval requestTime = CACurrentMediaTime();
     
-    cacheKey = cacheKey ?: [self cacheKeyForURL:url processorKey:nil];
+    cacheKey = cacheKey ?: [self cacheKeyForURL:url processorKey:processorKey];
     
     id object = [self.cache objectFromMemoryForKey:cacheKey];
     PINImage *image;

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -25,6 +25,7 @@
 
 #import "NSData+ImageDetectors.h"
 #import "PINImage+DecodedImage.h"
+#import "PINImage+ScaledImage.h"
 
 #if USE_PINCACHE
 #import "PINCache+PINRemoteImageCaching.h"
@@ -1452,6 +1453,7 @@ static dispatch_once_t sharedDispatchToken;
         }];
         if (image == nil) {
             image = [PINImage pin_decodedImageWithData:container.data skipDecodeIfPossible:skipDecode];
+            image = [PINImage pin_scaledImageForImage:image withKey:key];
             if (skipDecode == NO) {
                 [container.lock lockWithBlock:^{
                     updateMemoryCache = YES;

--- a/Pod/Classes/PINRemoteImageManager.m
+++ b/Pod/Classes/PINRemoteImageManager.m
@@ -1094,13 +1094,6 @@ static dispatch_once_t sharedDispatchToken;
 }
 
 - (void)imageFromCacheWithURL:(nonnull NSURL *)url
-                      options:(PINRemoteImageManagerDownloadOptions)options
-                   completion:(nonnull PINRemoteImageManagerImageCompletion)completion
-{
-    return [self imageFromCacheWithURL:url cacheKey:nil options:options completion:completion];
-}
-
-- (void)imageFromCacheWithURL:(nonnull NSURL *)url
                  processorKey:(nullable NSString *)processorKey
                       options:(PINRemoteImageManagerDownloadOptions)options
                    completion:(nonnull PINRemoteImageManagerImageCompletion)completion

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ PINRemoteImage also has two methods to improve the experience of downloading ima
 PINRemoteImageManager's methods. There are **built-in categories** on **UIImageView**, **FLAnimatedImageView** and **UIButton**, and it's very easy to implement a new category. See [UIImageView+PINRemoteImage](/Pod/Classes/Image Categories/UIImageView+PINRemoteImage.h) of the existing categories for reference.
 
 
-###Download an image and set it on an image view:
+### Download an image and set it on an image view:
 
 **Objective-C**
 ```objc
@@ -32,7 +32,7 @@ let imageView = UIImageView()
 imageView.pin_setImage(from: URL(string: "https://pinterest.com/kitten.jpg")!)
 ```
 
-###Download a progressive jpeg and get attractive blurred updates:
+### Download a progressive jpeg and get attractive blurred updates:
 
 **Objective-C**
 ```objc
@@ -48,7 +48,7 @@ imageView.pin_updateWithProgress = true
 imageView.pin_setImage(from: URL(string: "https://pinterest.com/progressiveKitten.jpg")!)
 ```
 
-###Download a WebP file
+### Download a WebP file
 
 **Objective-C**
 ```objc
@@ -62,7 +62,7 @@ let imageView = UIImageView()
 imageView.pin_setImage(from: URL(string: "https://pinterest.com/googleKitten.webp")!)
 ```
 
-###Download a GIF and display with FLAnimatedImageView
+### Download a GIF and display with FLAnimatedImageView
 
 **Objective-C**
 ```objc
@@ -76,7 +76,7 @@ let animatedImageView = FLAnimatedImageView()
 animatedImageView.pin_setImage(from: URL(string: "http://pinterest.com/flyingKitten.gif")!)
 ```
 
-###Download and process an image
+### Download and process an image
 
 **Objective-C**
 ```objc
@@ -161,7 +161,7 @@ imageView.pin_setImage(from: URL(string: "https://s-media-cache-ak0.pinimg.com/7
 }
 ```
 
-###Handle Authentication
+### Handle Authentication
 
 **Objective-C**
 ```objc
@@ -174,6 +174,22 @@ aCompletion(NSURLSessionAuthChallengePerformDefaultHandling, nil)];
 PINRemoteImageManager.shared().setAuthenticationChallenge { (task, challenge, completion) in
   completion?(.performDefaultHandling, nil)
 }
+```
+
+### Support for high resolution images
+Currently there are two ways PINRemoteImage is supporting high resolution images:
+1. If the URL will contains a `@2x` or a `@3x` postfix it will automatically handled from PINRemoteImage and the resulting image will be returned with the right scale.
+2. If it's not possible to provide an URL with the `@2x` or `@3x` postfix, it also can be handled within the completion handler:
+```objc
+NSURL *url = ...;
+__weak UIImageView *weakImageView = self.imageView;
+[self.imageView pin_setImageFromURL:url completion:^(PINRemoteImageManagerResult * _Nonnull result) {
+  CGFloat scale = UIScreen.mainScreen.scale;
+  if (scale > 1.0) {
+    UIImage *image = result.image;
+    weakImageView.image = [UIImage imageWithCGImage:image.CGImage scale:scale orientation:image.imageOrientation];
+    }
+}];
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -178,8 +178,8 @@ PINRemoteImageManager.shared().setAuthenticationChallenge { (task, challenge, co
 
 ### Support for high resolution images
 Currently there are two ways PINRemoteImage is supporting high resolution images:
-1. If the URL will contains a `@2x` or a `@3x` postfix it will automatically handled from PINRemoteImage and the resulting image will be returned with the right scale.
-2. If it's not possible to provide an URL with the `@2x` or `@3x` postfix, it also can be handled within the completion handler:
+1. If the URL contains an `_2x.` or an `_3x.` postfix it will be automatically handled by PINRemoteImage and the resulting image will be returned at the right scale.
+2. If it's not possible to provide an URL with an `_2x.` or `_3x.` postfix, you can also handle it with a completion handler:
 ```objc
 NSURL *url = ...;
 __weak UIImageView *weakImageView = self.imageView;


### PR DESCRIPTION
The problem is that currently PINRemoteImage in `pin_decodedImageWithData:skipDecodeIfPossible` is decoding image data always with a scale of 1.0. This is most of the time the right way as images are served in 1x. The problem appears if retina images are served from the server like @2x or @3x images. The decoding of this image data will produce not the right result.

This PR adds support for automatic scaling of images there are served if image URLs contain a @2x or @3x.

cc #152 