### PR TITLE
Add Pods/ directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,7 @@ xcuserdata
 # you should judge for yourself, the pros and cons are mentioned at:
 # http://guides.cocoapods.org/using/using-cocoapods.html#should-i-ignore-the-pods-directory-in-source-control
 #
-# Pods/
+Pods/
 
 # Carthage
 Carthage/Checkouts


### PR DESCRIPTION
We should add the `Pods/` directory to `.gitignore` else there are a lot of untracked changes if the examples were build.