### PR TITLE
Add support for @2x and @3x in URL for scaling images

### DIFF
--- a/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
+++ b/Examples/Example/PINRemoteImage Tests/PINRemoteImage_Tests.m
@@ -136,10 +136,10 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     return [NSURL URLWithString:@"https://placekitten.com/g/200/301?longarg=helloMomHowAreYouDoing.IamFineJustMovedToLiveWithANiceChapWeTravelTogetherInHisBlueBoxThroughSpaceAndTimeMaybeYouveMetHimAlready.YesterdayWeMetACultureOfPeopleWithTentaclesWhoSingWithAVeryCelestialVoice.SoGood.SeeYouSoon.MaybeYesterday.WhoKnows.XOXO"];
 }
 
-//- (NSURL *)scaledImageURL
-//{
-//    return [NSURL URLWithString:@"http://www.grenadabluewatersailing.com/wp-content/uploads/2014/09/Coconut-wikipedia.com_-300x225@2x.jpg"];
-//}
+- (NSURL *)scaledImageURL
+{
+    return [NSURL URLWithString:@"http://excitedpixel.com/img/logo@2x.png"];
+}
 
 #pragma mark - <PINURLSessionManagerDelegate>
 
@@ -425,21 +425,21 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     XCTAssert(encodedDrawTime / decodedDrawTime > 2, @"Drawing decoded image should be much faster");
 }
 
-//- (void)testScalingWithURLPostfix
-//{
-//    
-//    XCTestExpectation *expectation = [self expectationWithDescription:@"Error on scaling"];
-//    [self.imageManager downloadImageWithURL:[self scaledImageURL]
-//                                    options:PINRemoteImageManagerDownloadOptionsNone
-//                                 completion:^(PINRemoteImageManagerResult *result)
-//     {
-//         XCTAssert(result.image != nil);
-//         XCTAssert(result.image.scale == 2.0);
-//         
-//         [expectation fulfill];
-//    }];
-//    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
-//}
+- (void)testScalingWithURLPostfix
+{
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Error on scaling"];
+    [self.imageManager downloadImageWithURL:[self scaledImageURL]
+                                    options:PINRemoteImageManagerDownloadOptionsNone
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         XCTAssert(result.image != nil);
+         XCTAssert(result.image.scale == 2.0);
+         
+         [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
 
 - (void)drawImage:(UIImage *)image
 {

--- a/Pod/Classes/Categories/PINImage+ScaledImage.m
+++ b/Pod/Classes/Categories/PINImage+ScaledImage.m
@@ -19,13 +19,13 @@ static inline PINImage *PINScaledImageForKey(NSString * __nullable key, PINImage
     
     CGFloat scale = 1.0;
     if (key.length >= 8) {
-        NSRange range = [key rangeOfString:@"_2x."];
-        if (range.location != NSNotFound) {
+        if ([key rangeOfString:@"_2x."].location != NSNotFound ||
+            [key rangeOfString:@"@2x."].location != NSNotFound) {
             scale = 2.0;
         }
         
-        range = [key rangeOfString:@"_3x."];
-        if (range.location != NSNotFound) {
+        if ([key rangeOfString:@"_3x."].location != NSNotFound ||
+            [key rangeOfString:@"@3x."].location != NSNotFound) {
             scale = 3.0;
         }
     }


### PR DESCRIPTION
Add support for @2x and @3x in URL for automatic scaling images as well as reenable tests.