### PR TITLE
Fix infinite loop in synchronousImageFromCache method

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -1143,7 +1143,7 @@ static dispatch_once_t sharedDispatchToken;
 
 - (nonnull PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options
 {
-    return [self synchronousImageFromCacheWithURL:url processorKey:processorKey options:options];
+    return [self synchronousImageFromCacheWithURL:url processorKey:processorKey cacheKey:nil options:options];
 }
 
 - (PINRemoteImageManagerResult *)synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(NSString *)processorKey cacheKey:(NSString *)cacheKey options:(PINRemoteImageManagerDownloadOptions)options


### PR DESCRIPTION
`[PINRemoteImageManager synchronousImageFromCacheWithURL:(NSURL *)url processorKey:(nullable NSString *)processorKey options:(PINRemoteImageManagerDownloadOptions)options]` currently calls itself, creating an infinite loop. I'm assuming it's meant to call the more specific method below.