### PR TITLE
Add handler to allow customizing a network request

### DIFF
--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -121,6 +121,16 @@ typedef void(^PINRemoteImageManagerAuthenticationChallengeCompletionHandler)(NSU
  */
 typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * __nullable task, NSURLAuthenticationChallenge * __nonnull challenge, PINRemoteImageManagerAuthenticationChallengeCompletionHandler __nullable aHandler);
 
+
+/**
+ Request configuration handler. Used to modify a network request before it is executed.
+ Useful for adding custom, per-request headers.
+ 
+ @param request The request about to be executed
+ */
+typedef NSURLRequest * _Nonnull(^PINRemoteImageManagerRequestConfigurationHandler)(NSURLRequest * __nonnull request);
+
+
 /**
  Handler called for many PINRemoteImage tasks providing the progress of the download.
  
@@ -191,6 +201,13 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  * @param header A string field for header.
  */
 - (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)header;
+
+/**
+ Sets the Request Configuration Block.
+ 
+ @param configurationBlock A PINRemoteImageManagerRequestConfigurationHandler block.
+ */
+- (void)setRequestConfiguration:(nullable PINRemoteImageManagerRequestConfigurationHandler)configurationBlock;
 
 /**
  Set the Authentication Challenge Block.

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -139,6 +139,7 @@ typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error
 @property (nonatomic, assign) float lowQualityBPSThreshold;
 @property (nonatomic, assign) BOOL shouldUpgradeLowQualityImages;
 @property (nonatomic, copy) PINRemoteImageManagerAuthenticationChallenge authenticationChallengeHandler;
+@property (nonatomic, copy) PINRemoteImageManagerRequestConfigurationHandler requestConfigurationHandler;
 @property (nonatomic, strong) NSMutableDictionary <NSString *, NSString *> *httpHeaderFields;
 #if DEBUG
 @property (nonatomic, assign) float currentBPS;
@@ -291,6 +292,16 @@ static dispatch_once_t sharedDispatchToken;
         typeof(self) strongSelf = weakSelf;
         [strongSelf lock];
             strongSelf.httpHeaderFields[[header copy]] = [value copy];
+        [strongSelf unlock];
+    });
+}
+
+- (void)setRequestConfiguration:(PINRemoteImageManagerRequestConfigurationHandler)configurationBlock {
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        typeof(self) strongSelf = weakSelf;
+        [strongSelf lock];
+        strongSelf.requestConfigurationHandler = configurationBlock;
         [strongSelf unlock];
     });
 }
@@ -916,6 +927,11 @@ static dispatch_once_t sharedDispatchToken;
     if (self.httpHeaderFields.count > 0) {
         request.allHTTPHeaderFields = [self.httpHeaderFields copy];
     }
+    
+    if (self.requestConfigurationHandler) {
+        request = [self.requestConfigurationHandler(request) mutableCopy];
+    }
+    
     [NSURLProtocol setProperty:key forKey:PINRemoteImageCacheKey inRequest:request];
     
     __weak typeof(self) weakSelf = self;

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -246,6 +246,33 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
 }
 
+- (void)testRequestConfigurationIsUsedForImageRequest
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Requestion configuration block was called image request"];
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    configuration.HTTPAdditionalHeaders = @{ @"X-Custom-Header" : @"Custom Header Value" };
+
+    self.imageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:configuration];
+    [self.imageManager setRequestConfiguration:^NSURLRequest * _Nonnull(NSURLRequest * _Nonnull request) {
+        NSMutableURLRequest *mutableRequest = [request mutableCopy];
+        [mutableRequest setValue:@"Custom Header 2 Value" forHTTPHeaderField:@"X-Custom-Header-2"];
+        return mutableRequest;
+    }];
+    
+    self.imageManager.sessionManager.delegate = self;
+    [self.imageManager downloadImageWithURL:[self headersURL]
+                                    options:PINRemoteImageManagerDownloadOptionsNone
+                                 completion:^(PINRemoteImageManagerResult *result)
+     {
+         NSDictionary *headers = [[NSJSONSerialization JSONObjectWithData:self.data options:NSJSONReadingMutableContainers error:nil] valueForKey:@"headers"];
+         XCTAssert([headers[@"X-Custom-Header"] isEqualToString:@"Custom Header Value"]);
+         XCTAssert([headers[@"X-Custom-Header-2"] isEqualToString:@"Custom Header 2 Value"]);
+
+         [expectation fulfill];
+     }];
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
 - (void)testSkipFLAnimatedImageDownload
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Download animated image"];


### PR DESCRIPTION
I had a similar need to https://github.com/pinterest/PINRemoteImage/issues/211, where I want to customize request headers on a per request basis, so I added a request configuration block on `PINRemoteImageManager` as suggested in that thread. My specific use-case is I want to use PINRemoteImageManager to fetch authenticated images for me, which requires setting an `Authorization` header with our token. However, I don't want to send this for images to other domains, so I need it to be per request. This seemed like the most straightforward approach, but let me know if you think it should be implemented another way.