### PR TITLE
Suppress warning in format string.

### DIFF
--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -150,7 +150,7 @@
                     break;
                     
                 default:
-                    NSAssert(NO, @"invalid priority: %d", priority);
+                    NSAssert(NO, @"invalid priority: %lu", priority);
                     break;
             }
             [queue addObject:downloadTask];

--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -150,7 +150,7 @@
                     break;
                     
                 default:
-                    NSAssert(NO, @"invalid priority: %lu", priority);
+                    NSAssert(NO, @"invalid priority: %tu", priority);
                     break;
             }
             [queue addObject:downloadTask];


### PR DESCRIPTION
This PR suppresses a warning due to a format string using `%d` instead of `%lu`.

![screen shot 2017-03-31 at 10 09 50 am](https://cloud.githubusercontent.com/assets/522951/24561100/67abb5c0-15fa-11e7-90d6-45f8db2a8249.png)
