### PR TITLE
Add request configuration block to allow customizing HTTP request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [new] Added request configuration handler to allow customizing HTTP headers per request [#355](https://github.com/pinterest/PINRemoteImage/pull/355) [zachwaugh](https://github.com/zachwaugh)
 - [fixed] Moved storage of resume data to disk from memory. [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Hopefully fixes crashes occuring in PINURLSessionManager on iOS 9. [garrettmoon](https://github.com/garrettmoon)
 

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -121,6 +121,16 @@ typedef void(^PINRemoteImageManagerAuthenticationChallengeCompletionHandler)(NSU
  */
 typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * __nullable task, NSURLAuthenticationChallenge * __nonnull challenge, PINRemoteImageManagerAuthenticationChallengeCompletionHandler __nullable aHandler);
 
+
+/**
+ Request configuration handler. Used to modify a network request before it is executed.
+ Useful for adding custom, per-request headers.
+ 
+ @param request The request about to be executed
+ */
+typedef NSURLRequest * _Nonnull(^PINRemoteImageManagerRequestConfigurationHandler)(NSURLRequest * __nonnull request);
+
+
 /**
  Handler called for many PINRemoteImage tasks providing the progress of the download.
  
@@ -191,6 +201,13 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  * @param header A string field for header.
  */
 - (void)setValue:(nullable NSString *)value forHTTPHeaderField:(nullable NSString *)header;
+
+/**
+ Sets the Request Configuration Block.
+ 
+ @param configurationBlock A PINRemoteImageManagerRequestConfigurationHandler block.
+ */
+- (void)setRequestConfiguration:(nullable PINRemoteImageManagerRequestConfigurationHandler)configurationBlock;
 
 /**
  Set the Authentication Challenge Block.

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -287,7 +287,7 @@ static dispatch_once_t sharedDispatchToken;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         typeof(self) strongSelf = weakSelf;
         [strongSelf lock];
-        strongSelf.requestConfigurationHandler = configurationBlock;
+            strongSelf.requestConfigurationHandler = configurationBlock;
         [strongSelf unlock];
     });
 }

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -932,8 +932,8 @@ static dispatch_once_t sharedDispatchToken;
         request.allHTTPHeaderFields = headers;
     }
     
-    if (self.requestConfigurationHandler) {
-        request = [self.requestConfigurationHandler(request) mutableCopy];
+    if (_requestConfigurationHandler) {
+        request = [_requestConfigurationHandler(request) mutableCopy];
     }
     
     [NSURLProtocol setProperty:key forKey:PINRemoteImageCacheKey inRequest:request];


### PR DESCRIPTION
Replaces #321. I had a similar need to #211, where I want to customize request headers on a per request basis, so I added a request configuration block on PINRemoteImageManager as suggested in that thread. My specific use-case is I want to use PINRemoteImageManager to fetch authenticated images for me, which requires setting an Authorization header with our token. However, I don't want to send this for images to other domains, so I need it to be per request. This seemed like the most straightforward approach, but let me know if you think it should be implemented another way.