### PR TITLE
Put in more asserts to fix iOS 9 crash :/ #trivial

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -618,11 +618,11 @@ static dispatch_once_t sharedDispatchToken;
                               //Remove completion and try again
                               typeof(self) strongSelf = weakSelf;
                               [strongSelf lock];
-                              PINRemoteImageTask *task = [strongSelf.tasks objectForKey:key];
-                              [task removeCallbackWithUUID:UUID];
-                              if (task.callbackBlocks.count == 0) {
-                                  [strongSelf.tasks removeObjectForKey:key];
-                              }
+                                  PINRemoteImageTask *task = [strongSelf.tasks objectForKey:key];
+                                  [task removeCallbackWithUUID:UUID];
+                                  if (task.callbackBlocks.count == 0) {
+                                      [strongSelf.tasks removeObjectForKey:key];
+                                  }
                               [strongSelf unlock];
                               
                               //Skip early check

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -153,7 +153,6 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
-    NSLog(@"task: %@ completed with error: %@", task, error);
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -78,6 +78,11 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
     
+    NSAssert(delegateQueue != nil, @"There seems to be an issue in iOS 9 where this can be nil. If you can reliably reproduce hitting this, *please* open an issue: https://github.com/pinterest/PINRemoteImage/issues");
+    if (delegateQueue == nil) {
+        return;
+    }
+    
     __weak typeof(self) weakSelf = self;
     dispatch_async(delegateQueue, ^{
         typeof(self) strongSelf = weakSelf;
@@ -108,6 +113,11 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
+    
+    NSAssert(delegateQueue != nil, @"There seems to be an issue in iOS 9 where this can be nil. If you can reliably reproduce hitting this, *please* open an issue: https://github.com/pinterest/PINRemoteImage/issues");
+    if (delegateQueue == nil) {
+        return;
+    }
 
     __weak typeof(self) weakSelf = self;
     dispatch_async(delegateQueue, ^{
@@ -123,10 +133,10 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
     });
 }
 
-- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)dataTask didReceiveData:(NSData *)data
+- (void)URLSession:(NSURLSession *)session dataTask:(NSURLSessionDataTask *)task didReceiveData:(NSData *)data
 {
     [self lock];
-        dispatch_queue_t delegateQueue = self.delegateQueues[@(dataTask.taskIdentifier)];
+        dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];
     
     NSAssert(delegateQueue != nil, @"There seems to be an issue in iOS 9 where this can be nil. If you can reliably reproduce hitting this, *please* open an issue: https://github.com/pinterest/PINRemoteImage/issues");
@@ -137,12 +147,13 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
     __weak typeof(self) weakSelf = self;
     dispatch_async(delegateQueue, ^{
         typeof(self) strongSelf = weakSelf;
-        [strongSelf.delegate didReceiveData:data forTask:dataTask];
+        [strongSelf.delegate didReceiveData:data forTask:task];
     });
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task didCompleteWithError:(NSError *)error
 {
+    NSLog(@"task: %@ completed with error: %@", task, error);
     [self lock];
         dispatch_queue_t delegateQueue = self.delegateQueues[@(task.taskIdentifier)];
     [self unlock];


### PR DESCRIPTION
Finally tracked down an iOS 9 device and was able to reproduce the two cases we've been seeing. In both instances the OS is calling delegate methods after completion so it's definitely an OS level bug. This should work around it.