### PR TITLE
Refactors downloading and fixes download start time.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [fixed] Fixed bytes per second on download tasks (which could affect if an image is progressively rendered) [#360](https://github.com/pinterest/PINRemoteImage/pull/360) [garrettmoon](https://github.com/garrettmoon)
 - [new] Added request configuration handler to allow customizing HTTP headers per request [#355](https://github.com/pinterest/PINRemoteImage/pull/355) [zachwaugh](https://github.com/zachwaugh)
 - [fixed] Moved storage of resume data to disk from memory. [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Hopefully fixes crashes occuring in PINURLSessionManager on iOS 9. [garrettmoon](https://github.com/garrettmoon)

--- a/PINRemoteImage.xcodeproj/project.pbxproj
+++ b/PINRemoteImage.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		680B83CF1ECFABD400210A55 /* NSURLSessionTask+Timing.h in Headers */ = {isa = PBXBuildFile; fileRef = 680B83CD1ECFABD400210A55 /* NSURLSessionTask+Timing.h */; };
+		680B83D01ECFABD400210A55 /* NSURLSessionTask+Timing.m in Sources */ = {isa = PBXBuildFile; fileRef = 680B83CE1ECFABD400210A55 /* NSURLSessionTask+Timing.m */; };
 		6818C1551E551B5A00875DB7 /* PINCache.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6818C1541E551B5A00875DB7 /* PINCache.framework */; };
 		6818C1661E551CC600875DB7 /* decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 6818C15E1E551CC600875DB7 /* decode.h */; };
 		6818C1671E551CC600875DB7 /* demux.h in Headers */ = {isa = PBXBuildFile; fileRef = 6818C15F1E551CC600875DB7 /* demux.h */; };
@@ -155,6 +157,7 @@
 		6818C2851E551DA800875DB7 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = 6818C26B1E551DA800875DB7 /* utils.h */; };
 		6858C0751C9CC5BA00E420EB /* PINRemoteLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 6858C0731C9CC5BA00E420EB /* PINRemoteLock.h */; };
 		6858C0761C9CC5BA00E420EB /* PINRemoteLock.m in Sources */ = {isa = PBXBuildFile; fileRef = 6858C0741C9CC5BA00E420EB /* PINRemoteLock.m */; };
+		686D48D01ED38FC0003DB4C2 /* PINRemoteImageTask+Subclassing.h in Headers */ = {isa = PBXBuildFile; fileRef = 686D48CE1ED38FC0003DB4C2 /* PINRemoteImageTask+Subclassing.h */; };
 		687D3FC91E5650790027B131 /* PINOperation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 687D3FC81E5650790027B131 /* PINOperation.framework */; };
 		68A0FC1C1E523434000B552D /* PINRemoteImageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 68A0FC1B1E523434000B552D /* PINRemoteImageTests.m */; };
 		68A0FC1E1E523434000B552D /* PINRemoteImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F1B918D11BCF239200710963 /* PINRemoteImage.framework */; };
@@ -292,6 +295,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		680B83C71ECE5F9D00210A55 /* PINRemoteImageManager+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "PINRemoteImageManager+Private.h"; path = "../PINRemoteImageManager+Private.h"; sourceTree = "<group>"; };
+		680B83CD1ECFABD400210A55 /* NSURLSessionTask+Timing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSURLSessionTask+Timing.h"; sourceTree = "<group>"; };
+		680B83CE1ECFABD400210A55 /* NSURLSessionTask+Timing.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSURLSessionTask+Timing.m"; sourceTree = "<group>"; };
 		6818C1541E551B5A00875DB7 /* PINCache.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PINCache.framework; path = "Carthage/Checkouts/PINCache/build/Debug-iphoneos/PINCache.framework"; sourceTree = "<group>"; };
 		6818C1561E551BAB00875DB7 /* PINOperation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PINOperation.framework; path = "Carthage/Checkouts/PINOperation/build/Debug-iphoneos/PINOperation.framework"; sourceTree = "<group>"; };
 		6818C15E1E551CC600875DB7 /* decode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = decode.h; sourceTree = "<group>"; };
@@ -442,6 +448,7 @@
 		6818C2AE1E564FF900875DB7 /* PINCache.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = PINCache.xcodeproj; path = Carthage/Checkouts/PINCache/PINCache.xcodeproj; sourceTree = "<group>"; };
 		6858C0731C9CC5BA00E420EB /* PINRemoteLock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PINRemoteLock.h; sourceTree = "<group>"; };
 		6858C0741C9CC5BA00E420EB /* PINRemoteLock.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINRemoteLock.m; sourceTree = "<group>"; };
+		686D48CE1ED38FC0003DB4C2 /* PINRemoteImageTask+Subclassing.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PINRemoteImageTask+Subclassing.h"; sourceTree = "<group>"; };
 		687D3FC81E5650790027B131 /* PINOperation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PINOperation.framework; path = "Carthage/Checkouts/PINCache/Carthage/Checkouts/PINOperation/build/Debug-iphoneos/PINOperation.framework"; sourceTree = "<group>"; };
 		68A0FC191E523434000B552D /* PINRemoteImageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PINRemoteImageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		68A0FC1B1E523434000B552D /* PINRemoteImageTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageTests.m; sourceTree = "<group>"; };
@@ -894,12 +901,16 @@
 		F1B918DD1BCF23C800710963 /* Categories */ = {
 			isa = PBXGroup;
 			children = (
+				680B83C71ECE5F9D00210A55 /* PINRemoteImageManager+Private.h */,
 				68A6B1D91E5248BF003A92D1 /* PINImage+ScaledImage.m */,
 				68A6B1DA1E5248BF003A92D1 /* PINImage+ScaledImage.h */,
 				9DD47FA01C699FDC00F12CA0 /* PINImage+DecodedImage.h */,
 				9DD47FA11C699FDC00F12CA0 /* PINImage+DecodedImage.m */,
 				9DD47FA21C699FDC00F12CA0 /* PINImage+WebP.h */,
 				9DD47FA31C699FDC00F12CA0 /* PINImage+WebP.m */,
+				680B83CD1ECFABD400210A55 /* NSURLSessionTask+Timing.h */,
+				680B83CE1ECFABD400210A55 /* NSURLSessionTask+Timing.m */,
+				686D48CE1ED38FC0003DB4C2 /* PINRemoteImageTask+Subclassing.h */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -972,12 +983,14 @@
 				6818C1661E551CC600875DB7 /* decode.h in Headers */,
 				6818C1FE1E551D1D00875DB7 /* neon.h in Headers */,
 				6818C1691E551CC600875DB7 /* extras.h in Headers */,
+				686D48D01ED38FC0003DB4C2 /* PINRemoteImageTask+Subclassing.h in Headers */,
 				6818C1671E551CC600875DB7 /* demux.h in Headers */,
 				F1B919001BCF23C900710963 /* NSData+ImageDetectors.h in Headers */,
 				F1B9191E1BCF23C900710963 /* PINURLSessionManager.h in Headers */,
 				6818C2791E551DA800875DB7 /* huffman.h in Headers */,
 				6818C2771E551DA800875DB7 /* huffman_encode.h in Headers */,
 				6818C2301E551D7500875DB7 /* cost.h in Headers */,
+				680B83CF1ECFABD400210A55 /* NSURLSessionTask+Timing.h in Headers */,
 				F1B919061BCF23C900710963 /* FLAnimatedImageView+PINRemoteImage.h in Headers */,
 				6818C16D1E551CC600875DB7 /* types.h in Headers */,
 				F1B919111BCF23C900710963 /* PINRemoteImageCallbacks.h in Headers */,
@@ -1231,6 +1244,7 @@
 				6818C22B1E551D7500875DB7 /* analysis.c in Sources */,
 				6818C1E51E551D1D00875DB7 /* dec.c in Sources */,
 				6818C1DD1E551D1D00875DB7 /* cpu.c in Sources */,
+				680B83D01ECFABD400210A55 /* NSURLSessionTask+Timing.m in Sources */,
 				6818C20A1E551D1E00875DB7 /* yuv_sse2.c in Sources */,
 				6818C2451E551D7500875DB7 /* webpenc.c in Sources */,
 				6818C2311E551D7500875DB7 /* delta_palettization.c in Sources */,

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.h
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.h
@@ -1,0 +1,17 @@
+//
+//  NSURLSessionTask+Timing.h
+//  PINRemoteImage
+//
+//  Created by Garrett Moon on 5/19/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSURLSessionTask (Timing)
+
+- (void)PIN_setupSessionTaskObserver;
+- (CFTimeInterval)PIN_startTime;
+- (CFTimeInterval)PIN_endTime;
+
+@end

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.m
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.m
@@ -78,7 +78,9 @@
             @autoreleasepool {
                 //remove state observer
                 PINURLSessionTaskObserver *observer = objc_getAssociatedObject((__bridge id)obj, @selector(PIN_setupSessionTaskObserver));
-                [(__bridge id)obj removeObserver:observer forKeyPath:@"state"];
+                if (observer) {
+                    [(__bridge id)obj removeObserver:observer forKeyPath:@"state"];
+                }
             }
             
             //casting original implementation is necessary to ensure ARC doesn't attempt to retain during dealloc

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.m
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.m
@@ -1,0 +1,114 @@
+//
+//  NSURLSessionTask+Timing.m
+//  PINRemoteImage
+//
+//  Created by Garrett Moon on 5/19/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#import "NSURLSessionTask+Timing.h"
+
+#import <objc/runtime.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface PINURLSessionTaskObserver : NSObject
+{
+    id selfCopy;
+}
+
+@property (atomic, assign) CFTimeInterval startTime;
+@property (atomic, assign) CFTimeInterval endTime;
+@property (nonatomic, weak, readonly) NSURLSessionTask *task;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithTask:(NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
+
+@end
+
+@implementation PINURLSessionTaskObserver
+
+- (instancetype)initWithTask:(NSURLSessionTask *)task
+{
+    if (self = [super init]) {
+        _task = task;
+        _startTime = 0;
+        _endTime = 0;
+        [_task addObserver:self forKeyPath:@"state" options:0 context:nil];
+    }
+    return self;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
+{
+    NSURLSessionTask *task = (NSURLSessionTask *)object;
+    switch (task.state) {
+        case NSURLSessionTaskStateRunning:
+            if (self.startTime == 0) {
+                self.startTime = CACurrentMediaTime();
+            }
+            break;
+
+        case NSURLSessionTaskStateCompleted:
+            NSAssert(self.startTime != 0, @"Expect that task was started before it's completed.");
+            if (self.endTime == 0) {
+                self.endTime = CACurrentMediaTime();
+            }
+            break;
+            
+        default:
+            break;
+    }
+}
+
+@end
+
+@implementation NSURLSessionTask (Additions)
+
+- (void)PIN_setupSessionTaskObserver
+{
+    // It's necessary to swizzle dealloc here to remove the observer :(
+    // I wasn't able to figure out another way; kvo assertion about observed objects being observed occurs
+    // *before* associated objects are dealloc'd
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        SEL deallocSelector = NSSelectorFromString(@"dealloc");
+        Method deallocMethod = class_getInstanceMethod([NSURLSessionTask class], deallocSelector);
+        IMP originalImplementation = method_getImplementation(deallocMethod);
+        IMP newImplementation = imp_implementationWithBlock(^(void *obj){
+            @autoreleasepool {
+                //remove state observer
+                PINURLSessionTaskObserver *observer = objc_getAssociatedObject((__bridge id)obj, @selector(PIN_setupSessionTaskObserver));
+                [(__bridge id)obj removeObserver:observer forKeyPath:@"state"];
+            }
+            
+            //casting original implementation is necessary to ensure ARC doesn't attempt to retain during dealloc
+            ((void (*)(void *, SEL))originalImplementation)(obj, deallocSelector);
+        });
+        class_replaceMethod([NSURLSessionTask class], deallocSelector, newImplementation, method_getTypeEncoding(deallocMethod));
+    });
+    
+    PINURLSessionTaskObserver *observer = [[PINURLSessionTaskObserver alloc] initWithTask:self];
+    objc_setAssociatedObject(self, @selector(PIN_setupSessionTaskObserver), observer, OBJC_ASSOCIATION_RETAIN);
+}
+
+- (CFTimeInterval)PIN_startTime
+{
+    PINURLSessionTaskObserver *observer = objc_getAssociatedObject(self, @selector(PIN_setupSessionTaskObserver));
+    NSAssert(observer != nil, @"setupSessionTaskObserver should have been called before.");
+    if (observer == nil) {
+        return 0;
+    }
+    return observer.startTime;
+}
+
+- (CFTimeInterval)PIN_endTime
+{
+    PINURLSessionTaskObserver *observer = objc_getAssociatedObject(self, @selector(PIN_setupSessionTaskObserver));
+    NSAssert(observer != nil, @"setupSessionTaskObserver should have been called before.");
+    if (observer == nil) {
+        return 0;
+    }
+    return observer.endTime;
+}
+
+@end

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.m
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.m
@@ -12,16 +12,11 @@
 #import <QuartzCore/QuartzCore.h>
 
 @interface PINURLSessionTaskObserver : NSObject
-{
-    id selfCopy;
-}
 
 @property (atomic, assign) CFTimeInterval startTime;
 @property (atomic, assign) CFTimeInterval endTime;
-@property (nonatomic, weak, readonly) NSURLSessionTask *task;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithTask:(NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -30,10 +25,8 @@
 - (instancetype)initWithTask:(NSURLSessionTask *)task
 {
     if (self = [super init]) {
-        _task = task;
         _startTime = 0;
         _endTime = 0;
-        [_task addObserver:self forKeyPath:@"state" options:0 context:nil];
     }
     return self;
 }

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.m
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.m
@@ -17,6 +17,7 @@
 @property (atomic, assign) CFTimeInterval endTime;
 
 - (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithTask:(NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -27,6 +28,7 @@
     if (self = [super init]) {
         _startTime = 0;
         _endTime = 0;
+        [task addObserver:self forKeyPath:@"state" options:0 context:nil];
     }
     return self;
 }

--- a/Source/Classes/Categories/PINRemoteImageTask+Subclassing.h
+++ b/Source/Classes/Categories/PINRemoteImageTask+Subclassing.h
@@ -1,0 +1,16 @@
+//
+//  PINRemoteImageTask+Subclassing.h
+//  PINRemoteImage
+//
+//  Created by Garrett Moon on 5/22/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#import "PINRemoteImageTask.h"
+
+@interface PINRemoteImageTask (Subclassing)
+
+- (nonnull NSMutableDictionary *)__locked_callbackBlocks;
+- (BOOL)__locked_cancelWithUUID:(nonnull NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume;
+
+@end

--- a/Source/Classes/Categories/PINRemoteImageTask+Subclassing.h
+++ b/Source/Classes/Categories/PINRemoteImageTask+Subclassing.h
@@ -10,7 +10,7 @@
 
 @interface PINRemoteImageTask (Subclassing)
 
-- (nonnull NSMutableDictionary *)__locked_callbackBlocks;
-- (BOOL)__locked_cancelWithUUID:(nonnull NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume;
+- (nonnull NSMutableDictionary *)l_callbackBlocks;
+- (BOOL)l_cancelWithUUID:(nonnull NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume;
 
 @end

--- a/Source/Classes/Categories/PINRemoteImageTask+Subclassing.h
+++ b/Source/Classes/Categories/PINRemoteImageTask+Subclassing.h
@@ -8,9 +8,13 @@
 
 #import "PINRemoteImageTask.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface PINRemoteImageTask (Subclassing)
 
-- (nonnull NSMutableDictionary *)l_callbackBlocks;
-- (BOOL)l_cancelWithUUID:(nonnull NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume;
+- (NSMutableDictionary *)l_callbackBlocks;
+- (BOOL)l_cancelWithUUID:(NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Classes/PINProgressiveImage.h
+++ b/Source/Classes/PINProgressiveImage.h
@@ -16,12 +16,19 @@
 
 #import "PINRemoteImageMacros.h"
 
+@class PINRemoteImageDownloadTask;
+
 /** An object which store the data of a downloading image and vends progressive scans **/
 @interface PINProgressiveImage : NSObject
 
 @property (atomic, copy, nonnull) NSArray *progressThresholds;
 @property (atomic, assign) CFTimeInterval estimatedRemainingTimeThreshold;
-@property (atomic, assign) CFTimeInterval startTime;
+@property (nonatomic, strong, readonly, nonnull) NSURLSessionDataTask * dataTask;
+@property (nonatomic, readonly) float bytesPerSecond;
+@property (nonatomic, readonly) CFTimeInterval estimatedRemainingTime;
+
+- (nonnull instancetype)init NS_UNAVAILABLE;
+- (nonnull instancetype)initWithDataTask:(nonnull NSURLSessionDataTask *)dataTask;
 
 - (void)updateProgressiveImageWithData:(nonnull NSData *)data expectedNumberOfBytes:(int64_t)expectedNumberOfBytes isResume:(BOOL)isResume;
 

--- a/Source/Classes/PINProgressiveImage.m
+++ b/Source/Classes/PINProgressiveImage.m
@@ -117,10 +117,7 @@
 - (float)l_bytesPerSecond
 {
     NSAssert(_dataTask.PIN_startTime != 0, @"Start time needs to be set by now.");
-    CFTimeInterval endTime = CACurrentMediaTime();
-    if (_dataTask.PIN_endTime != 0) {
-        endTime = _dataTask.PIN_endTime;
-    }
+    CFTimeInterval endTime = _dataTask.PIN_endTime ?: CACurrentMediaTime();
     CFTimeInterval taskLength = endTime - _dataTask.PIN_startTime;
     int64_t downloadedBytes = _dataTask.countOfBytesReceived;
     

--- a/Source/Classes/PINProgressiveImage.m
+++ b/Source/Classes/PINProgressiveImage.m
@@ -109,12 +109,12 @@
 {
     __block float bytesPerSecond;
     [self.lock lockWithBlock:^{
-        bytesPerSecond = [self __locked_bytesPerSecond];
+        bytesPerSecond = [self l_bytesPerSecond];
     }];
     return bytesPerSecond;
 }
 
-- (float)__locked_bytesPerSecond
+- (float)l_bytesPerSecond
 {
     NSAssert(_dataTask.PIN_startTime != 0, @"Start time needs to be set by now.");
     CFTimeInterval endTime = CACurrentMediaTime();
@@ -135,12 +135,12 @@
 {
     __block CFTimeInterval estimatedRemainingTime;
     [self.lock lockWithBlock:^{
-        estimatedRemainingTime = [self __locked_estimatedRemainingTime];
+        estimatedRemainingTime = [self l_estimatedRemainingTime];
     }];
     return estimatedRemainingTime;
 }
 
-- (CFTimeInterval)__locked_estimatedRemainingTime
+- (CFTimeInterval)l_estimatedRemainingTime
 {
     if (_dataTask.countOfBytesExpectedToReceive == NSURLSessionTransferSizeUnknown) {
         return MAXFLOAT;
@@ -150,7 +150,7 @@
         return 0;
     }
     
-    float bytesPerSecond = [self __locked_bytesPerSecond];
+    float bytesPerSecond = [self l_bytesPerSecond];
     if (bytesPerSecond == 0) {
         return MAXFLOAT;
     }
@@ -175,7 +175,7 @@
         }
         [self.mutableData appendData:data];
         
-        while ([self __locked_hasCompletedFirstScan] == NO && self.scannedByte < self.mutableData.length) {
+        while ([self l_hasCompletedFirstScan] == NO && self.scannedByte < self.mutableData.length) {
     #if DEBUG
             CFTimeInterval start = CACurrentMediaTime();
     #endif
@@ -183,7 +183,7 @@
             if (startByte > 0) {
                 startByte--;
             }
-            if ([self __locked_scanForSOSinData:self.mutableData startByte:startByte scannedByte:&_scannedByte]) {
+            if ([self l_scanForSOSinData:self.mutableData startByte:startByte scannedByte:&_scannedByte]) {
                 self.sosCount++;
             }
     #if DEBUG
@@ -211,12 +211,12 @@
             return nil;
         }
         
-        if (_estimatedRemainingTimeThreshold > 0 && [self __locked_estimatedRemainingTime] < _estimatedRemainingTimeThreshold) {
+        if (_estimatedRemainingTimeThreshold > 0 && [self l_estimatedRemainingTime] < _estimatedRemainingTimeThreshold) {
             [self.lock unlock];
             return nil;
         }
         
-        if ([self __locked_hasCompletedFirstScan] == NO) {
+        if ([self l_hasCompletedFirstScan] == NO) {
             [self.lock unlock];
             return nil;
         }
@@ -274,7 +274,7 @@
             CGImageRef image = CGImageSourceCreateImageAtIndex(self.imageSource, 0, NULL);
             if (image) {
                 if (blurred) {
-                    currentImage = [self __locked_postProcessImage:[PINImage imageWithCGImage:image] withProgress:progress];
+                    currentImage = [self l_postProcessImage:[PINImage imageWithCGImage:image] withProgress:progress];
                 } else {
                     currentImage = [PINImage imageWithCGImage:image];
                 }
@@ -299,7 +299,7 @@
 
 #pragma mark - private
 
-- (BOOL)__locked_scanForSOSinData:(NSData *)data startByte:(NSUInteger)startByte scannedByte:(NSUInteger *)scannedByte
+- (BOOL)l_scanForSOSinData:(NSData *)data startByte:(NSUInteger)startByte scannedByte:(NSUInteger *)scannedByte
 {
     //check if we have a complete scan
     Byte scanMarker[2];
@@ -324,13 +324,13 @@
     return NO;
 }
 
-- (BOOL)__locked_hasCompletedFirstScan
+- (BOOL)l_hasCompletedFirstScan
 {
     return self.sosCount >= 2;
 }
 
 //Heavily cribbed from https://developer.apple.com/library/ios/samplecode/UIImageEffects/Listings/UIImageEffects_UIImageEffects_m.html#//apple_ref/doc/uid/DTS40013396-UIImageEffects_UIImageEffects_m-DontLinkElementID_9
-- (PINImage *)__locked_postProcessImage:(PINImage *)inputImage withProgress:(float)progress
+- (PINImage *)l_postProcessImage:(PINImage *)inputImage withProgress:(float)progress
 {
     PINImage *outputImage = nil;
     CGImageRef inputImageRef = CGImageRetain(inputImage.CGImage);

--- a/Source/Classes/PINProgressiveImage.m
+++ b/Source/Classes/PINProgressiveImage.m
@@ -175,7 +175,7 @@
         }
         [self.mutableData appendData:data];
         
-        while ([self hasCompletedFirstScan] == NO && self.scannedByte < self.mutableData.length) {
+        while ([self __locked_hasCompletedFirstScan] == NO && self.scannedByte < self.mutableData.length) {
     #if DEBUG
             CFTimeInterval start = CACurrentMediaTime();
     #endif
@@ -183,7 +183,7 @@
             if (startByte > 0) {
                 startByte--;
             }
-            if ([self scanForSOSinData:self.mutableData startByte:startByte scannedByte:&_scannedByte]) {
+            if ([self __locked_scanForSOSinData:self.mutableData startByte:startByte scannedByte:&_scannedByte]) {
                 self.sosCount++;
             }
     #if DEBUG
@@ -216,7 +216,7 @@
             return nil;
         }
         
-        if ([self hasCompletedFirstScan] == NO) {
+        if ([self __locked_hasCompletedFirstScan] == NO) {
             [self.lock unlock];
             return nil;
         }
@@ -274,7 +274,7 @@
             CGImageRef image = CGImageSourceCreateImageAtIndex(self.imageSource, 0, NULL);
             if (image) {
                 if (blurred) {
-                    currentImage = [self postProcessImage:[PINImage imageWithCGImage:image] withProgress:progress];
+                    currentImage = [self __locked_postProcessImage:[PINImage imageWithCGImage:image] withProgress:progress];
                 } else {
                     currentImage = [PINImage imageWithCGImage:image];
                 }
@@ -299,8 +299,7 @@
 
 #pragma mark - private
 
-//Must be called within lock
-- (BOOL)scanForSOSinData:(NSData *)data startByte:(NSUInteger)startByte scannedByte:(NSUInteger *)scannedByte
+- (BOOL)__locked_scanForSOSinData:(NSData *)data startByte:(NSUInteger)startByte scannedByte:(NSUInteger *)scannedByte
 {
     //check if we have a complete scan
     Byte scanMarker[2];
@@ -325,15 +324,13 @@
     return NO;
 }
 
-//Must be called within lock
-- (BOOL)hasCompletedFirstScan
+- (BOOL)__locked_hasCompletedFirstScan
 {
     return self.sosCount >= 2;
 }
 
-//Must be called within lock
 //Heavily cribbed from https://developer.apple.com/library/ios/samplecode/UIImageEffects/Listings/UIImageEffects_UIImageEffects_m.html#//apple_ref/doc/uid/DTS40013396-UIImageEffects_UIImageEffects_m-DontLinkElementID_9
-- (PINImage *)postProcessImage:(PINImage *)inputImage withProgress:(float)progress
+- (PINImage *)__locked_postProcessImage:(PINImage *)inputImage withProgress:(float)progress
 {
     PINImage *outputImage = nil;
     CGImageRef inputImageRef = CGImageRetain(inputImage.CGImage);

--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -10,6 +10,7 @@
 
 #import "PINURLSessionManager.h"
 #import "PINRemoteLock.h"
+#import "NSURLSessionTask+Timing.h"
 
 @interface PINRemoteImageDownloadQueue ()
 {
@@ -76,6 +77,7 @@
         
         [self scheduleDownloadsIfNeeded];
     }];
+    [dataTask PIN_setupSessionTaskObserver];
     
     [self setQueuePriority:priority forTask:dataTask addIfNecessary:YES];
     
@@ -104,6 +106,7 @@
             NSURLSessionDataTask *task = [queue firstObject];
             [queue removeObjectAtIndex:0];
             [task resume];
+            
             
             [_runningTasks addObject:task];
         }

--- a/Source/Classes/PINRemoteImageDownloadTask.h
+++ b/Source/Classes/PINRemoteImageDownloadTask.h
@@ -17,8 +17,6 @@
 
 @property (nonatomic, strong, nullable) NSURL *URL;
 @property (nonatomic, copy, nullable) NSString *ifRange;
-@property (nonatomic, assign) long long totalBytes;
-@property (nonatomic, strong, nullable) PINResume *resume;
 @property (nonatomic, copy, readonly, nullable) NSData *data;
 
 @property (nonatomic, assign) NSUInteger numberOfRetries;

--- a/Source/Classes/PINRemoteImageDownloadTask.h
+++ b/Source/Classes/PINRemoteImageDownloadTask.h
@@ -6,24 +6,32 @@
 //
 //
 
+#import <PINOperation/PINOperation.h>
+
+#import "PINRemoteImageManager+Private.h"
 #import "PINRemoteImageTask.h"
 #import "PINProgressiveImage.h"
 #import "PINResume.h"
 
 @interface PINRemoteImageDownloadTask : PINRemoteImageTask
 
-@property (nonatomic, strong, nullable) NSURLSessionDataTask *urlSessionTask;
-@property (nonatomic, assign) CFTimeInterval sessionTaskStartTime;
-@property (nonatomic, assign) CFTimeInterval sessionTaskEndTime;
-@property (nonatomic, assign) BOOL hasProgressBlocks;
+@property (nonatomic, strong, nullable) NSURL *URL;
 @property (nonatomic, copy, nullable) NSString *ifRange;
 @property (nonatomic, assign) long long totalBytes;
 @property (nonatomic, strong, nullable) PINResume *resume;
-@property (nonatomic, strong, nullable) PINProgressiveImage *progressImage;
+@property (nonatomic, copy, readonly, nullable) NSData *data;
 
 @property (nonatomic, assign) NSUInteger numberOfRetries;
+@property (nonatomic, readonly) float bytesPerSecond;
+@property (nonatomic, readonly) CFTimeInterval estimatedRemainingTime;
 
-- (void)callProgressDownloadWithQueue:(nonnull dispatch_queue_t)queue completedBytes:(int64_t)completedBytes totalBytes:(int64_t)totalBytes;
-- (void)callProgressImageWithQueue:(nonnull dispatch_queue_t)queue withImage:(nonnull PINImage *)image renderedImageQuality:(CGFloat)renderedImageQuality;
+- (void)scheduleDownloadWithRequest:(nonnull NSURLRequest *)request
+                             resume:(nullable PINResume *)resume
+                          skipRetry:(BOOL)skipRetry
+                           priority:(PINRemoteImageManagerPriority)priority
+                  completionHandler:(nonnull PINRemoteImageManagerDataCompletion)completionHandler;
+
+- (void)didReceiveData:(nonnull NSData *)data;
+- (void)didReceiveResponse:(nonnull NSURLResponse *)response;
 
 @end

--- a/Source/Classes/PINRemoteImageDownloadTask.m
+++ b/Source/Classes/PINRemoteImageDownloadTask.m
@@ -8,44 +8,53 @@
 
 #import "PINRemoteImageDownloadTask.h"
 
+#import "PINRemoteImageTask+Subclassing.h"
 #import "PINRemoteImage.h"
 #import "PINRemoteImageCallbacks.h"
+#import "PINRemoteLock.h"
+
+#define PINRemoteImageMaxRetries                       3
+#define PINRemoteImageRetryDelayBase                   4
 
 @interface PINRemoteImageDownloadTask ()
+{
+    PINProgressiveImage *_progressImage;
+}
 
 @end
 
 @implementation PINRemoteImageDownloadTask
 
-- (instancetype)init
+- (instancetype)initWithManager:(PINRemoteImageManager *)manager
 {
-    if (self = [super init]) {
+    if (self = [super initWithManager:manager]) {
         _numberOfRetries = 0;
     }
     return self;
 }
 
-- (BOOL)hasProgressBlocks
+- (void)callProgressDownload
 {
-    __block BOOL hasProgressBlocks = NO;
-    [self.callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
-        if (callback.progressImageBlock) {
-            hasProgressBlocks = YES;
-            *stop = YES;
-        }
+    NSDictionary *callbackBlocks = self.callbackBlocks;
+    #if PINRemoteImageLogging
+    NSString *key = self.key;
+    #endif
+    
+    __block int64_t completedBytes;
+    __block int64_t totalBytes;
+    
+    [self.lock lockWithBlock:^{
+        completedBytes = _progressImage.dataTask.countOfBytesReceived;
+        totalBytes = _progressImage.dataTask.countOfBytesExpectedToReceive;
     }];
-    return hasProgressBlocks;
-}
-
-- (void)callProgressDownloadWithQueue:(nonnull dispatch_queue_t)queue completedBytes:(int64_t)completedBytes totalBytes:(int64_t)totalBytes
-{
-    [self.callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
+    
+    [callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
         if (callback.progressDownloadBlock != nil) {
-            PINLog(@"calling progress for UUID: %@ key: %@", UUID, self.key);
+            PINLog(@"calling progress for UUID: %@ key: %@", UUID, key);
             PINRemoteImageManagerProgressDownload progressDownloadBlock = callback.progressDownloadBlock;
             //The code run asynchronously below is *not* guaranteed to be run in the manager's lock!
             //All access to the callbacks and self should be done outside the block below!
-            dispatch_async(queue, ^
+            dispatch_async(self.manager.callbackQueue, ^
             {
                 progressDownloadBlock(completedBytes, totalBytes);
             });
@@ -53,16 +62,22 @@
     }];
 }
 
-- (void)callProgressImageWithQueue:(nonnull dispatch_queue_t)queue withImage:(nonnull PINImage *)image renderedImageQuality:(CGFloat)renderedImageQuality
+- (void)callProgressImageWithImage:(nonnull PINImage *)image renderedImageQuality:(CGFloat)renderedImageQuality
 {
-    [self.callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
+    NSDictionary *callbackBlocks = self.callbackBlocks;
+#if PINRemoteImageLogging
+    NSString *key = self.key;
+#endif
+    
+    
+    [callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
         if (callback.progressImageBlock != nil) {
-            PINLog(@"calling progress for UUID: %@ key: %@", UUID, self.key);
+            PINLog(@"calling progress for UUID: %@ key: %@", UUID, key);
             PINRemoteImageManagerImageCompletion progressImageBlock = callback.progressImageBlock;
             CFTimeInterval requestTime = callback.requestTime;
             //The code run asynchronously below is *not* guaranteed to be run in the manager's lock!
             //All access to the callbacks and self should be done outside the block below!
-            dispatch_async(queue, ^
+            dispatch_async(self.manager.callbackQueue, ^
             {
                 progressImageBlock([PINRemoteImageManagerResult imageResultWithImage:image
                                                            alternativeRepresentation:nil
@@ -76,15 +91,32 @@
     }];
 }
 
-- (BOOL)cancelWithUUID:(NSUUID *)UUID manager:(PINRemoteImageManager *)manager
+- (BOOL)cancelWithUUID:(NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume
 {
-    BOOL noMoreCompletions = [super cancelWithUUID:UUID manager:manager];
-    if (noMoreCompletions) {
-        [self.urlSessionTask cancel];
-        PINLog(@"Canceling download of URL: %@, UUID: %@", self.urlSessionTask.originalRequest.URL, UUID);
-    } else {
-        PINLog(@"Decrementing download of URL: %@, UUID: %@", self.urlSessionTask.originalRequest.URL, UUID);
-    }
+    __block BOOL noMoreCompletions;
+    [self.lock lockWithBlock:^{
+        noMoreCompletions = [super __locked_cancelWithUUID:UUID resume:resume];
+        
+        if (noMoreCompletions) {
+            [self.manager.urlSessionTaskQueue removeDownloadTaskFromQueue:_progressImage.dataTask];
+            [_progressImage.dataTask cancel];
+            
+            if (resume && _ifRange && _totalBytes > 0) {
+                NSData *progressData = _progressImage.data;
+                if (progressData.length > 0) {
+                    *resume = [PINResume resumeData:progressData ifRange:_ifRange totalBytes:_totalBytes];
+                }
+            }
+            
+            PINLog(@"Canceling download of URL: %@, UUID: %@", _progressImage.dataTask.originalRequest.URL, UUID);
+        }
+#if PINRemoteImageLogging
+        else {
+            PINLog(@"Decrementing download of URL: %@, UUID: %@", _progressImage.dataTask.originalRequest.URL, UUID);
+        }
+#endif
+    }];
+    
     return noMoreCompletions;
 }
 
@@ -92,8 +124,22 @@
 {
     [super setPriority:priority];
     if (PINNSURLSessionTaskSupportsPriority) {
-        self.urlSessionTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
+        [self.lock lockWithBlock:^{
+            if (_progressImage.dataTask) {
+                _progressImage.dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
+                [self.manager.urlSessionTaskQueue setQueuePriority:priority forTask:_progressImage.dataTask];
+            }
+        }];
     }
+}
+
+- (NSURL *)URL
+{
+    __block NSURL *url;
+    [self.lock lockWithBlock:^{
+        url = _progressImage.dataTask.originalRequest.URL;
+    }];
+    return url;
 }
 
 - (nonnull PINRemoteImageManagerResult *)imageResultWithImage:(nullable PINImage *)image
@@ -111,6 +157,215 @@
                                                   resultType:resultType
                                                         UUID:UUID
                                         bytesSavedByResuming:bytesSavedByResuming];
+}
+
+- (void)didReceiveData:(NSData *_Nonnull)data
+{
+    [self callProgressDownload];
+    
+    __block int64_t expectedNumberOfBytes;
+    [self.lock lockWithBlock:^{
+        expectedNumberOfBytes = _progressImage.dataTask.countOfBytesExpectedToReceive;
+    }];
+    
+    [self updateData:data isResume:NO expectedBytes:expectedNumberOfBytes];
+}
+
+- (void)updateData:(NSData *)data isResume:(BOOL)isResume expectedBytes:(int64_t)expectedBytes
+{
+    __block PINProgressiveImage *progressImage;
+    __block BOOL hasProgressBlocks = NO;
+    [self.lock lockWithBlock:^{
+        progressImage = _progressImage;
+        [[self __locked_callbackBlocks] enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
+            if (callback.progressImageBlock) {
+                hasProgressBlocks = YES;
+                *stop = YES;
+            }
+        }];
+    }];
+    
+    [progressImage updateProgressiveImageWithData:data expectedNumberOfBytes:expectedBytes isResume:isResume];
+    
+    if (hasProgressBlocks) {
+        if (PINNSOperationSupportsBlur) {
+            weakify(self);
+            [self.manager.concurrentOperationQueue addOperation:^{
+                strongify(self);
+                CGFloat renderedImageQuality = 1.0;
+                PINImage *image = [progressImage currentImageBlurred:self.manager.shouldBlurProgressive maxProgressiveRenderSize:self.manager.maxProgressiveRenderSize renderedImageQuality:&renderedImageQuality];
+                if (image) {
+                    [self callProgressImageWithImage:image renderedImageQuality:renderedImageQuality];
+                }
+            } withPriority:PINOperationQueuePriorityLow];
+        }
+    }
+}
+
+- (void)didReceiveResponse:(nonnull NSURLResponse *)response
+{
+    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+        NSHTTPURLResponse *httpResponse = (NSHTTPURLResponse *)response;
+        
+        // Got partial data back for a resume
+        if (httpResponse.statusCode == 206) {
+            __block PINResume *resume;
+            [self.lock lockWithBlock:^{
+                resume = self.resume;
+            }];
+            
+            [self updateData:resume.resumeData isResume:YES expectedBytes:resume.totalBytes];
+        } else {
+            //Check if there's resume data and we didn't get back a 206, get rid of it
+            self.resume = nil;
+        }
+        
+        // Check to see if the server supports resume
+        if ([[httpResponse allHeaderFields][@"Accept-Ranges"] isEqualToString:@"bytes"]) {
+            NSString *ifRange = nil;
+            NSString *etag = nil;
+            
+            if ((etag = [httpResponse allHeaderFields][@"ETag"])) {
+                if ([etag hasPrefix:@"W/"] == NO) {
+                    ifRange = etag;
+                }
+            } else {
+                ifRange = [httpResponse allHeaderFields][@"Last-Modified"];
+            }
+            
+            if (ifRange.length > 0) {
+                [self.lock lockWithBlock:^{
+                    _ifRange = ifRange;
+                    _totalBytes = httpResponse.expectedContentLength;
+                }];
+            }
+        }
+    }
+}
+
+- (void)scheduleDownloadWithRequest:(NSURLRequest *)request
+                             resume:(PINResume *)resume
+                          skipRetry:(BOOL)skipRetry
+                           priority:(PINRemoteImageManagerPriority)priority
+                  completionHandler:(PINRemoteImageManagerDataCompletion)completionHandler
+{
+    [self.lock lockWithBlock:^{
+        if (_progressImage != nil || [self __locked_callbackBlocks].count == 0 || _numberOfRetries > 0) {
+            return;
+        }
+        _resume = resume;
+        
+        NSURLRequest *adjustedRequest = request;
+        if (_resume) {
+            NSMutableURLRequest *mutableRequest = [request mutableCopy];
+            NSMutableDictionary *headers = [[mutableRequest allHTTPHeaderFields] mutableCopy];
+            headers[@"If-Range"] = _resume.ifRange;
+            headers[@"Range"] = [NSString stringWithFormat:@"bytes=%tu-", _resume.resumeData.length];
+            mutableRequest.allHTTPHeaderFields = headers;
+            adjustedRequest = mutableRequest;
+        }
+        
+        _progressImage = [[PINProgressiveImage alloc] initWithDataTask:[self.manager.urlSessionTaskQueue addDownloadWithSessionManager:self.manager.sessionManager
+                                                                                                                               request:adjustedRequest
+                                                                                                                              priority:priority
+                                                                                                                     completionHandler:^(NSURLResponse * _Nonnull response, NSError * _Nonnull remoteError)
+        {
+            [self.manager.concurrentOperationQueue addOperation:^{
+                NSError *error = remoteError;
+#if PINRemoteImageLogging
+                if (error && error.code != NSURLErrorCancelled) {
+                    PINLog(@"Failed downloading image: %@ with error: %@", url, error);
+                } else if (error == nil && response.expectedContentLength == 0) {
+                    PINLog(@"image is empty at URL: %@", url);
+                } else {
+                    PINLog(@"Finished downloading image: %@", url);
+                }
+#endif
+                
+                if (error.code != NSURLErrorCancelled) {
+                    NSData *data = self.progressImage.data;
+                    
+                    if (error == nil && data == nil) {
+                        error = [NSError errorWithDomain:PINRemoteImageManagerErrorDomain
+                                                    code:PINRemoteImageManagerErrorImageEmpty
+                                                userInfo:nil];
+                    }
+                    
+                    if (error && [[self class] retriableError:error]) {
+                        //attempt to retry after delay
+                        __block BOOL retry = NO;
+                        __block NSUInteger newNumberOfRetries = 0;
+                        [self.lock lockWithBlock:^{
+                            if (_numberOfRetries < PINRemoteImageMaxRetries && skipRetry == NO) {
+                                retry = YES;
+                                newNumberOfRetries = ++_numberOfRetries;
+                                
+                                // Clear out the exsiting progress image or else new data from retry will be appended
+                                _progressImage = nil;
+                            }
+                        }];
+                        
+                        if (retry) {
+                            int64_t delay = powf(PINRemoteImageRetryDelayBase, newNumberOfRetries);
+                            PINLog(@"Retrying download of %@ in %d seconds.", URL, delay);
+                            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                                [self.lock lockWithBlock:^{
+                                    if (_progressImage == nil && [self __locked_callbackBlocks].count > 0) {
+                                        //If completionBlocks.count == 0, we've canceled before we were even able to start.
+                                        //If there was an error, do not attempt to use resume data
+                                        [self scheduleDownloadWithRequest:request resume:nil skipRetry:skipRetry priority:priority completionHandler:completionHandler];
+                                    }
+                                }];
+                            });
+                            return;
+                        }
+                    }
+                    
+                    completionHandler(data, error);
+                }
+            }];
+        }]];
+        
+        if (PINNSURLSessionTaskSupportsPriority) {
+            _progressImage.dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
+        }
+    }];
+}
+
+- (PINProgressiveImage *)progressImage
+{
+    __block PINProgressiveImage *progressImage = nil;
+    [self.lock lockWithBlock:^{
+        progressImage = _progressImage;
+    }];
+    return progressImage;
+}
+
++ (BOOL)retriableError:(NSError *)remoteImageError
+{
+    if ([remoteImageError.domain isEqualToString:PINURLErrorDomain]) {
+        return remoteImageError.code >= 500;
+    } else if ([remoteImageError.domain isEqualToString:NSURLErrorDomain] && remoteImageError.code == NSURLErrorUnsupportedURL) {
+        return NO;
+    } else if ([remoteImageError.domain isEqualToString:PINRemoteImageManagerErrorDomain]) {
+        return NO;
+    }
+    return YES;
+}
+
+- (float)bytesPerSecond
+{
+    return self.progressImage.bytesPerSecond;
+}
+
+- (CFTimeInterval)estimatedRemainingTime
+{
+    return self.progressImage.estimatedRemainingTime;
+}
+
+- (NSData *)data
+{
+    return self.progressImage.data;
 }
 
 @end

--- a/Source/Classes/PINRemoteImageDownloadTask.m
+++ b/Source/Classes/PINRemoteImageDownloadTask.m
@@ -96,7 +96,7 @@
 {
     __block BOOL noMoreCompletions;
     [self.lock lockWithBlock:^{
-        noMoreCompletions = [super __locked_cancelWithUUID:UUID resume:resume];
+        noMoreCompletions = [super l_cancelWithUUID:UUID resume:resume];
         
         if (noMoreCompletions) {
             [self.manager.urlSessionTaskQueue removeDownloadTaskFromQueue:_progressImage.dataTask];
@@ -181,7 +181,7 @@
     __block BOOL hasProgressBlocks = NO;
     [self.lock lockWithBlock:^{
         progressImage = _progressImage;
-        [[self __locked_callbackBlocks] enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
+        [[self l_callbackBlocks] enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
             if (callback.progressImageBlock) {
                 hasProgressBlocks = YES;
                 *stop = YES;
@@ -255,7 +255,7 @@
                   completionHandler:(PINRemoteImageManagerDataCompletion)completionHandler
 {
     [self.lock lockWithBlock:^{
-        if (_progressImage != nil || [self __locked_callbackBlocks].count == 0 || _numberOfRetries > 0) {
+        if (_progressImage != nil || [self l_callbackBlocks].count == 0 || _numberOfRetries > 0) {
             return;
         }
         _resume = resume;
@@ -315,7 +315,7 @@
                             PINLog(@"Retrying download of %@ in %d seconds.", URL, delay);
                             dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
                                 [self.lock lockWithBlock:^{
-                                    if (_progressImage == nil && [self __locked_callbackBlocks].count > 0) {
+                                    if (_progressImage == nil && [self l_callbackBlocks].count > 0) {
                                         //If completionBlocks.count == 0, we've canceled before we were even able to start.
                                         //If there was an error, do not attempt to use resume data
                                         [self scheduleDownloadWithRequest:request resume:nil skipRetry:skipRetry priority:priority completionHandler:completionHandler];

--- a/Source/Classes/PINRemoteImageMacros.h
+++ b/Source/Classes/PINRemoteImageMacros.h
@@ -45,6 +45,13 @@
 #define PINNSURLSessionTaskSupportsPriority (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber10_10)
 #endif
 
+#define weakify(var) __weak typeof(var) PINWeak_##var = var;
+
+#define strongify(var)                                                                                           \
+_Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wshadow\"") __strong typeof(var) var = \
+PINWeak_##var;                                                                                           \
+_Pragma("clang diagnostic pop")
+
 #define BlockAssert(condition, desc, ...)	\
 do {				\
 __PRAGMA_PUSH_NO_EXTRA_ARG_WARNINGS \

--- a/Source/Classes/PINRemoteImageManager+Private.h
+++ b/Source/Classes/PINRemoteImageManager+Private.h
@@ -1,0 +1,30 @@
+//
+//  PINRemoteImageManager+Private.h
+//  PINRemoteImage
+//
+//  Created by Garrett Moon on 5/18/17.
+//  Copyright © 2017 Pinterest. All rights reserved.
+//
+
+#ifndef PINRemoteImageManager_Private_h
+#define PINRemoteImageManager_Private_h
+
+#import "PINRemoteImageDownloadQueue.h"
+
+typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSError *error);
+
+@interface PINRemoteImageManager (private)
+
+@property (nonatomic, strong, readonly) dispatch_queue_t callbackQueue;
+@property (nonatomic, strong, readonly) PINOperationQueue *concurrentOperationQueue;
+@property (nonatomic, strong, readonly) PINRemoteImageDownloadQueue *urlSessionTaskQueue;
+@property (nonatomic, strong, readonly) PINURLSessionManager *sessionManager;
+
+@property (nonatomic, readonly) NSArray <NSNumber *> *progressThresholds;
+@property (nonatomic, readonly) NSTimeInterval estimatedRemainingTimeThreshold;
+@property (nonatomic, readonly) BOOL shouldBlurProgressive;
+@property (nonatomic, readonly) CGSize maxProgressiveRenderSize;
+
+@end
+
+#endif /* PINRemoteImageManager_Private_h */

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -1018,7 +1018,7 @@ static dispatch_once_t sharedDispatchToken;
                 [strongSelf.canceledTasks addObject:UUID];
             }
             
-            if ([taskToEvaluate cancelWithUUID:UUID resume:storeResumeData ? &resume : nil]) {
+            if ([taskToEvaluate cancelWithUUID:UUID resume:storeResumeData ? &resume : NULL]) {
                 [strongSelf.tasks removeObjectForKey:taskKey];
             }
         [strongSelf unlock];

--- a/Source/Classes/PINRemoteImageTask.h
+++ b/Source/Classes/PINRemoteImageTask.h
@@ -7,17 +7,27 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <PINOperation/PINOperation.h>
 
 #import "PINRemoteImageCallbacks.h"
 #import "PINRemoteImageManager.h"
 #import "PINRemoteImageMacros.h"
+#import "PINRemoteLock.h"
+#import "PINResume.h"
 
 @interface PINRemoteImageTask : NSObject
 
-@property (nonatomic, strong, nonnull) NSMutableDictionary<NSUUID *, PINRemoteImageCallbacks *> *callbackBlocks;
+@property (nonatomic, strong, readonly, nonnull) PINRemoteLock *lock;
+
+@property (nonatomic, copy, readonly, nonnull) NSDictionary<NSUUID *, PINRemoteImageCallbacks *> *callbackBlocks;
+
+@property (nonatomic, weak, nullable) PINRemoteImageManager *manager;
 #if PINRemoteImageLogging
 @property (nonatomic, copy, nullable) NSString *key;
 #endif
+
+- (_Nonnull instancetype)init NS_UNAVAILABLE;
+- (_Nonnull instancetype)initWithManager:(nonnull PINRemoteImageManager *)manager NS_DESIGNATED_INITIALIZER;
 
 - (void)addCallbacksWithCompletionBlock:(nonnull PINRemoteImageManagerImageCompletion)completionBlock
                      progressImageBlock:(nullable PINRemoteImageManagerImageCompletion)progressImageBlock
@@ -26,15 +36,14 @@
 
 - (void)removeCallbackWithUUID:(nonnull NSUUID *)UUID;
 
-- (void)callCompletionsWithQueue:(nonnull dispatch_queue_t)queue
-                          remove:(BOOL)remove
-                       withImage:(nullable PINImage *)image
+- (void)callCompletionsWithImage:(nullable PINImage *)image
        alternativeRepresentation:(nullable id)alternativeRepresentation
                           cached:(BOOL)cached
-                           error:(nullable NSError *)error;
+                           error:(nullable NSError *)error
+                          remove:(BOOL)remove;
 
 //returns YES if no more attached completionBlocks
-- (BOOL)cancelWithUUID:(nonnull NSUUID *)UUID manager:(nullable PINRemoteImageManager *)manager;
+- (BOOL)cancelWithUUID:(nonnull NSUUID *)UUID resume:(PINResume * _Nullable * _Nullable)resume;
 
 - (void)setPriority:(PINRemoteImageManagerPriority)priority;
 

--- a/Source/Classes/PINRemoteImageTask.m
+++ b/Source/Classes/PINRemoteImageTask.m
@@ -9,13 +9,25 @@
 #import "PINRemoteImageTask.h"
 
 #import "PINRemoteImageCallbacks.h"
+#import "PINRemoteImageManager+Private.h"
+
+@interface PINRemoteImageTask ()
+{
+    NSMutableDictionary<NSUUID *, PINRemoteImageCallbacks *> *_callbackBlocks;
+}
+
+@end
 
 @implementation PINRemoteImageTask
 
-- (instancetype)init
+@synthesize lock = _lock;
+
+- (instancetype)initWithManager:(PINRemoteImageManager *)manager
 {
     if (self = [super init]) {
-        self.callbackBlocks = [[NSMutableDictionary alloc] init];
+        _lock = [[PINRemoteLock alloc] initWithName:@"Task Lock"];
+        _manager = manager;
+        _callbackBlocks = [[NSMutableDictionary alloc] init];
     }
     return self;
 }
@@ -35,20 +47,37 @@
     completion.progressImageBlock = progressImageBlock;
     completion.progressDownloadBlock = progressDownloadBlock;
     
-    [self.callbackBlocks setObject:completion forKey:UUID];
+    [self.lock lockWithBlock:^{
+        [_callbackBlocks setObject:completion forKey:UUID];
+    }];
 }
 
 - (void)removeCallbackWithUUID:(NSUUID *)UUID
 {
-    [self.callbackBlocks removeObjectForKey:UUID];
+    [self.lock lockWithBlock:^{
+        [self __locked_removeCallbackWithUUID:UUID];
+    }];
 }
 
-- (void)callCompletionsWithQueue:(dispatch_queue_t)queue
-                          remove:(BOOL)remove
-                       withImage:(PINImage *)image
+- (void)__locked_removeCallbackWithUUID:(NSUUID *)UUID
+{
+    [_callbackBlocks removeObjectForKey:UUID];
+}
+
+- (NSDictionary<NSUUID *, PINRemoteImageCallbacks *> *)callbackBlocks
+{
+    __block NSDictionary *callbackBlocks;
+    [self.lock lockWithBlock:^{
+        callbackBlocks = [_callbackBlocks copy];
+    }];
+    return callbackBlocks;
+}
+
+- (void)callCompletionsWithImage:(PINImage *)image
        alternativeRepresentation:(id)alternativeRepresentation
                           cached:(BOOL)cached
                            error:(NSError *)error
+                          remove:(BOOL)remove;
 {
     __weak typeof(self) weakSelf = self;
     [self.callbackBlocks enumerateKeysAndObjectsUsingBlock:^(NSUUID *UUID, PINRemoteImageCallbacks *callback, BOOL *stop) {
@@ -60,7 +89,7 @@
             
             //The code run asynchronously below is *not* guaranteed to be run in the manager's lock!
             //All access to the callbacks and self should be done outside the block below!
-            dispatch_async(queue, ^
+            dispatch_async(self.manager.callbackQueue, ^
             {
                 PINRemoteImageResultType result;
                 if (image || alternativeRepresentation) {
@@ -82,11 +111,21 @@
     }];
 }
 
-- (BOOL)cancelWithUUID:(NSUUID *)UUID manager:(PINRemoteImageManager *)manager
+- (BOOL)cancelWithUUID:(NSUUID *)UUID resume:(PINResume **)resume
 {
     BOOL noMoreCompletions = NO;
     [self removeCallbackWithUUID:UUID];
     if ([self.callbackBlocks count] == 0) {
+        noMoreCompletions = YES;
+    }
+    return noMoreCompletions;
+}
+
+- (BOOL)__locked_cancelWithUUID:(NSUUID *)UUID resume:(PINResume **)resume
+{
+    BOOL noMoreCompletions = NO;
+    [self __locked_removeCallbackWithUUID:UUID];
+    if ([_callbackBlocks count] == 0) {
         noMoreCompletions = YES;
     }
     return noMoreCompletions;
@@ -110,6 +149,11 @@
                                                        error:error
                                                   resultType:resultType
                                                         UUID:UUID];
+}
+
+- (NSMutableDictionary *)__locked_callbackBlocks
+{
+    return _callbackBlocks;
 }
 
 @end

--- a/Source/Classes/PINRemoteImageTask.m
+++ b/Source/Classes/PINRemoteImageTask.m
@@ -113,11 +113,10 @@
 
 - (BOOL)cancelWithUUID:(NSUUID *)UUID resume:(PINResume **)resume
 {
-    BOOL noMoreCompletions = NO;
-    [self removeCallbackWithUUID:UUID];
-    if ([self.callbackBlocks count] == 0) {
-        noMoreCompletions = YES;
-    }
+    __block BOOL noMoreCompletions;
+    [self.lock lockWithBlock:^{
+        noMoreCompletions = [self __locked_cancelWithUUID:UUID resume:resume];
+    }];
     return noMoreCompletions;
 }
 

--- a/Source/Classes/PINRemoteImageTask.m
+++ b/Source/Classes/PINRemoteImageTask.m
@@ -55,11 +55,11 @@
 - (void)removeCallbackWithUUID:(NSUUID *)UUID
 {
     [self.lock lockWithBlock:^{
-        [self __locked_removeCallbackWithUUID:UUID];
+        [self l_removeCallbackWithUUID:UUID];
     }];
 }
 
-- (void)__locked_removeCallbackWithUUID:(NSUUID *)UUID
+- (void)l_removeCallbackWithUUID:(NSUUID *)UUID
 {
     [_callbackBlocks removeObjectForKey:UUID];
 }
@@ -115,15 +115,15 @@
 {
     __block BOOL noMoreCompletions;
     [self.lock lockWithBlock:^{
-        noMoreCompletions = [self __locked_cancelWithUUID:UUID resume:resume];
+        noMoreCompletions = [self l_cancelWithUUID:UUID resume:resume];
     }];
     return noMoreCompletions;
 }
 
-- (BOOL)__locked_cancelWithUUID:(NSUUID *)UUID resume:(PINResume **)resume
+- (BOOL)l_cancelWithUUID:(NSUUID *)UUID resume:(PINResume **)resume
 {
     BOOL noMoreCompletions = NO;
-    [self __locked_removeCallbackWithUUID:UUID];
+    [self l_removeCallbackWithUUID:UUID];
     if ([_callbackBlocks count] == 0) {
         noMoreCompletions = YES;
     }
@@ -150,7 +150,7 @@
                                                         UUID:UUID];
 }
 
-- (NSMutableDictionary *)__locked_callbackBlocks
+- (NSMutableDictionary *)l_callbackBlocks
 {
     return _callbackBlocks;
 }

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -141,11 +141,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 
 - (NSURL *)progressiveURL
 {
-<<<<<<< HEAD
     return [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/1200x/80/03/1b/80031b76573a358ed4fed5de391b6d36.jpg"];
-=======
-    return [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/750x/80/03/1b/80031b76573a358ed4fed5de391b6d36.jpg"];
->>>>>>> Refactors downloading and fixes download start time.
 }
 
 - (NSArray <NSURL *> *)bigURLs

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -141,7 +141,11 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 
 - (NSURL *)progressiveURL
 {
+<<<<<<< HEAD
     return [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/1200x/80/03/1b/80031b76573a358ed4fed5de391b6d36.jpg"];
+=======
+    return [NSURL URLWithString:@"https://s-media-cache-ak0.pinimg.com/750x/80/03/1b/80031b76573a358ed4fed5de391b6d36.jpg"];
+>>>>>>> Refactors downloading and fixes download start time.
 }
 
 - (NSArray <NSURL *> *)bigURLs
@@ -179,13 +183,13 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     self.data = [[NSMutableData alloc] init];
     // Put setup code here. This method is called before the invocation of each test method in the class.
     self.imageManager = [[PINRemoteImageManager alloc] init];
+    [self.imageManager.cache removeAllObjects];
 }
 
 - (void)tearDown
 {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
     //clear disk cache
-    [self.imageManager.cache removeAllObjects];
     self.imageManager = nil;
     [super tearDown];
 }
@@ -1091,10 +1095,11 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 - (void)testResume
 {
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-    __weak typeof(self) weakSelf = self;
+    
+    weakify(self);
     [self.imageManager setEstimatedRemainingTimeThresholdForProgressiveDownloads:0.001 completion:^{
-        typeof(weakSelf) strongSelf = weakSelf;
-        [strongSelf.imageManager setProgressiveRendersMaxProgressiveRenderSize:CGSizeMake(10000, 10000) completion:^{
+        strongify(self);
+        [self.imageManager setProgressiveRendersMaxProgressiveRenderSize:CGSizeMake(10000, 10000) completion:^{
             dispatch_semaphore_signal(semaphore);
         }];
     }];


### PR DESCRIPTION
Download start time was being incorrectly computed since the timer
was started when the image was added to the queue instead of when the
image was actually started downloading.

When attempting to address this, I decided to do some much needed cleanup
and refactoring by moving much of the download work to PINRemoteImageDownloadTask