### PR TITLE
Fix deadlock when canceling processor task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [fixed] Fixes a deadlock with canceling processor tasks [#374](https://github.com/pinterest/PINRemoteImage/pull/374) [zachwaugh](https://github.com/zachwaugh)
 - [fixed] Fixes a deadlock in the retry system. [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes a threadsafety issue in accessing callbacks. [garrettmoon](https://github.com/garrettmoon)
 - [new] PINRemoteImageManager now respects the request timout value of session configuration. [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINRemoteImageProcessorTask.m
+++ b/Source/Classes/PINRemoteImageProcessorTask.m
@@ -16,8 +16,8 @@
 {
     BOOL noMoreCompletions = [super cancelWithUUID:UUID resume:resume];
     [self.lock lockWithBlock:^{
-        if (noMoreCompletions && self.downloadTaskUUID) {
-            [self.manager cancelTaskWithUUID:self.downloadTaskUUID];
+        if (noMoreCompletions && _downloadTaskUUID) {
+            [self.manager cancelTaskWithUUID:_downloadTaskUUID];
             _downloadTaskUUID = nil;
         }
     }];


### PR DESCRIPTION
Use direct ivar access for `_downloadTaskUUID` since `self.downloadTaskUUID` uses a lock as well and causes a deadlock when called here. Fixes #372 