### PR TITLE
PINCache initializer no longer accepts file extension #trivial

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -245,7 +245,7 @@ static dispatch_once_t sharedDispatchToken;
             return [NSKeyedUnarchiver unarchiveObjectWithData:data];
         }
         return data;
-    } fileExtension:nil];
+    }];
 #else
     return [[PINRemoteImageBasicCache alloc] init];
 #endif


### PR DESCRIPTION
The extension parameter was removed in https://github.com/pinterest/PINCache/pull/192.