### PR TITLE
Rename strongify and weakify to PINStrongify and PINWeakify [#trivial]

### DIFF
--- a/Source/Classes/PINRemoteImageDownloadTask.m
+++ b/Source/Classes/PINRemoteImageDownloadTask.m
@@ -200,9 +200,9 @@
     
     if (hasProgressBlocks) {
         if (PINNSOperationSupportsBlur) {
-            weakify(self);
+            PINWeakify(self);
             [self.manager.concurrentOperationQueue addOperation:^{
-                strongify(self);
+                PINStrongify(self);
                 CGFloat renderedImageQuality = 1.0;
                 PINImage *image = [progressImage currentImageBlurred:self.manager.shouldBlurProgressive maxProgressiveRenderSize:self.manager.maxProgressiveRenderSize renderedImageQuality:&renderedImageQuality];
                 if (image) {

--- a/Source/Classes/PINRemoteImageMacros.h
+++ b/Source/Classes/PINRemoteImageMacros.h
@@ -45,9 +45,9 @@
 #define PINNSURLSessionTaskSupportsPriority (kCFCoreFoundationVersionNumber >= kCFCoreFoundationVersionNumber10_10)
 #endif
 
-#define weakify(var) __weak typeof(var) PINWeak_##var = var;
+#define PINWeakify(var) __weak typeof(var) PINWeak_##var = var;
 
-#define strongify(var)                                                                                           \
+#define PINStrongify(var)                                                                                           \
 _Pragma("clang diagnostic push") _Pragma("clang diagnostic ignored \"-Wshadow\"") __strong typeof(var) var = \
 PINWeak_##var;                                                                                           \
 _Pragma("clang diagnostic pop")

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -757,7 +757,7 @@ static dispatch_once_t sharedDispatchToken;
         PINRemoteImageDownloadTask *task = [self.tasks objectForKey:key];
     [self unlock];
     
-    weakify(self)
+    PINWeakify(self)
     [task scheduleDownloadWithRequest:[self requestWithURL:url key:key]
                                resume:resume
                             skipRetry:(options & PINRemoteImageManagerDownloadOptionsSkipRetry)
@@ -766,7 +766,7 @@ static dispatch_once_t sharedDispatchToken;
     {
         [_concurrentOperationQueue addOperation:^
         {
-            strongify(self)
+            PINStrongify(self)
             NSError *remoteImageError = error;
             PINImage *image = nil;
             id alternativeRepresentation = nil;

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -1124,9 +1124,9 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 {
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    weakify(self);
+    PINWeakify(self);
     [self.imageManager setEstimatedRemainingTimeThresholdForProgressiveDownloads:0.001 completion:^{
-        strongify(self);
+        PINStrongify(self);
         [self.imageManager setProgressiveRendersMaxProgressiveRenderSize:CGSizeMake(10000, 10000) completion:^{
             dispatch_semaphore_signal(semaphore);
         }];
@@ -1199,9 +1199,9 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     //Test that images aren't canceled if the cost of resuming is high (i.e. time to first byte is longer than the time left to download)
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     
-    weakify(self);
+    PINWeakify(self);
     [self.imageManager setEstimatedRemainingTimeThresholdForProgressiveDownloads:0.001 completion:^{
-        strongify(self);
+        PINStrongify(self);
         [self.imageManager setProgressiveRendersMaxProgressiveRenderSize:CGSizeMake(10000, 10000) completion:^{
             dispatch_semaphore_signal(semaphore);
         }];


### PR DESCRIPTION
Rename weakify and strongify due to name clash.

Resolves #379 

@garrettmoon, @nguyenhuy I'm not pretty sure if we should not just remove the macros all along as there are really not that many cases, otherwise are you guys good with renaming the macro?