### PR TITLE
Fixes a crash for resumed images with long keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [fixed] Fixes a deadlock with canceling processor tasks [#374](https://github.com/pinterest/PINRemoteImage/pull/374) [zachwaugh](https://github.com/zachwaugh)
 - [fixed] Fixes a deadlock in the retry system. [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes a threadsafety issue in accessing callbacks. [garrettmoon](https://github.com/garrettmoon)
+- [fixed] Fixes a crash with resumed downloads when a key is long. [garrettmoon](https://github.com/garrettmoon)
 - [new] PINRemoteImageManager now respects the request timeout value of session configuration. [garrettmoon](https://github.com/garrettmoon)
 - [new] Updated to latest PINCache beta 5. [garrettmoon](https://github.com/garrettmoon)
 - [new] Added support for getting NSURLResponse from a PINRemoteImageManagerResult object. [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -1517,9 +1517,6 @@ static dispatch_once_t sharedDispatchToken;
     if (processorKey.length > 0) {
         cacheKey = [cacheKey stringByAppendingFormat:@"-<%@>", processorKey];
     }
-    if (resume) {
-        cacheKey = [PINRemoteImageCacheKeyResumePrefix stringByAppendingString:cacheKey];
-    }
 
     //PINDiskCache uses this key as the filename of the file written to disk
     //Due to the current filesystem used in Darwin, this name must be limited to 255 chars.
@@ -1541,6 +1538,10 @@ static dispatch_once_t sharedDispatchToken;
             [hexString appendFormat:@"%02lx", (unsigned long)digest[i]];
         }
         cacheKey = [hexString copy];
+    }
+    //The resume key must not be hashed, it is used to decide whether or not to decode from the disk cache.
+    if (resume) {
+      cacheKey = [PINRemoteImageCacheKeyResumePrefix stringByAppendingString:cacheKey];
     }
 
     return cacheKey;


### PR DESCRIPTION
Keys that are long would get their key hashed. This meant that when en/decoding
the object, it wouldn't be recognized as an object that needed to be un/archived.