### PR TITLE
Clear old cache data asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
 
+- [new] Improve disk cache migration performance [#391](https://github.com/pinterest/PINRemoteImage/pull/391) [chuganzy](https://github.com/chuganzy)
+
 ## 3.0.0 Beta 11
 - [fixed] Fixes a deadlock with canceling processor tasks [#374](https://github.com/pinterest/PINRemoteImage/pull/374) [zachwaugh](https://github.com/zachwaugh)
 - [fixed] Fixes a deadlock in the retry system. [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -230,7 +230,12 @@ static dispatch_once_t sharedDispatchToken;
     if ([pinDefaults integerForKey:kPINRemoteImageDiskCacheVersionKey] != kPINRemoteImageDiskCacheVersion) {
         //remove the old version of the disk cache
         NSURL *diskCacheURL = [PINDiskCache cacheURLWithRootPath:cacheURLRoot prefix:PINDiskCachePrefix name:kPINRemoteImageDiskCacheName];
-        [[NSFileManager defaultManager] removeItemAtURL:diskCacheURL error:nil];
+        NSFileManager *fileManager = [NSFileManager defaultManager];
+        NSURL *dstURL = [[fileManager temporaryDirectory] URLByAppendingPathComponent:kPINRemoteImageDiskCacheName];
+        [fileManager moveItemAtURL:diskCacheURL toURL:dstURL error:nil];
+        dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+            [fileManager removeItemAtURL:dstURL error:nil];
+        });
         [pinDefaults setInteger:kPINRemoteImageDiskCacheVersion forKey:kPINRemoteImageDiskCacheVersionKey];
     }
   


### PR DESCRIPTION
About 23x faster.
Actually, we faced to `ATE_BAD_FOOD` issue due to this process on our app.