### PR TITLE
[PINRemoteImageManager] Use the good old NSTemporaryDirectory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Add your own contributions to the next release on the line below this with your name.
 - [new] Added a way to specify custom retry logic when network error happens [#386](https://github.com/pinterest/PINRemoteImage/pull/386)
 
-- [new] Improve disk cache migration performance [#391](https://github.com/pinterest/PINRemoteImage/pull/391) [chuganzy](https://github.com/chuganzy)
+- [new] Improve disk cache migration performance [#391](https://github.com/pinterest/PINRemoteImage/pull/391) [chuganzy](https://github.com/chuganzy), [#394](https://github.com/pinterest/PINRemoteImage/pull/394) [nguyenhuy](https://github.com/nguyenhuy)
 
 ## 3.0.0 Beta 11
 - [fixed] Fixes a deadlock with canceling processor tasks [#374](https://github.com/pinterest/PINRemoteImage/pull/374) [zachwaugh](https://github.com/zachwaugh)

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -242,7 +242,7 @@ static dispatch_once_t sharedDispatchToken;
         //remove the old version of the disk cache
         NSURL *diskCacheURL = [PINDiskCache cacheURLWithRootPath:cacheURLRoot prefix:PINDiskCachePrefix name:kPINRemoteImageDiskCacheName];
         NSFileManager *fileManager = [NSFileManager defaultManager];
-        NSURL *dstURL = [[fileManager temporaryDirectory] URLByAppendingPathComponent:kPINRemoteImageDiskCacheName];
+        NSURL *dstURL = [[[NSURL alloc] initFileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:kPINRemoteImageDiskCacheName];
         [fileManager moveItemAtURL:diskCacheURL toURL:dstURL error:nil];
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
             [fileManager removeItemAtURL:dstURL error:nil];


### PR DESCRIPTION
The method call to `-[NSFileManager temporaryDirectory]` was added in [#391](https://github.com/pinterest/PINRemoteImage/pull/391/files#diff-9cae23e914261e3df9a01ab2a607b263R234). However, it is only available on iOS 10.0+ and MacOS 10.12+ ([source](https://developer.apple.com/documentation/foundation/nsfilemanager/1642996-temporarydirectory?language=objc)), thus causing crashes on iOS 9. 

Fix by switching to `NSTemporaryDirectory()`. Although it's not the preferred way (see the discussion [here](https://developer.apple.com/documentation/foundation/1409211-nstemporarydirectory)), it's good enough for now.