### PR TITLE
Fix early synchronous cache check

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -1055,7 +1055,7 @@ static dispatch_once_t sharedDispatchToken;
     
     if ((PINRemoteImageManagerDownloadOptionsSkipEarlyCheck & options) == NO && [NSThread isMainThread]) {
         PINRemoteImageManagerResult *result = [self synchronousImageFromCacheWithURL:url processorKey:processorKey cacheKey:cacheKey options:options];
-        if (result.image && result.error) {
+        if (result.image && result.error == nil) {
             completion((result));
             return;
         }


### PR DESCRIPTION
👋 This fixes the early synchronous cache check which currently will never execute when an image is successfully returned from `-synchronousImageFromCacheWithURL:` because the error checking logic is inverted.