### PR TITLE
add handling for image returned with 404 http response (fixes #399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - [new] Improve disk cache migration performance [#391](https://github.com/pinterest/PINRemoteImage/pull/391) [chuganzy](https://github.com/chuganzy), [#394](https://github.com/pinterest/PINRemoteImage/pull/394) [nguyenhuy](https://github.com/nguyenhuy)
 
+- [fixed] Fixes an edge case when image returned with 404 response, we now treat it as image instead of error [#399](https://github.com/pinterest/PINRemoteImage/pull/396) [maxwang](https://github.com/wsdwsd0829)
+
 ## 3.0.0 Beta 11
 - [fixed] Fixes a deadlock with canceling processor tasks [#374](https://github.com/pinterest/PINRemoteImage/pull/374) [zachwaugh](https://github.com/zachwaugh)
 - [fixed] Fixes a deadlock in the retry system. [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -780,17 +780,6 @@ static dispatch_once_t sharedDispatchToken;
                              priority:priority
                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
     {
-        //404 http response may have image data
-        BOOL hasDefaultImage = NO;
-        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-          NSHTTPURLResponse* urlResponse = (NSHTTPURLResponse*)response;
-          if (urlResponse.statusCode == 404
-              && [urlResponse.allHeaderFields[@"content-type"] rangeOfString:@"image"].location != NSNotFound) {
-            hasDefaultImage = YES;
-            error = nil;
-          }
-        }
-
         [_concurrentOperationQueue addOperation:^
         {
             PINStrongify(self)
@@ -798,7 +787,7 @@ static dispatch_once_t sharedDispatchToken;
             PINImage *image = nil;
             id alternativeRepresentation = nil;
              
-            if (remoteImageError == nil || hasDefaultImage) {
+            if (remoteImageError == nil) {
                  //stores the object in the caches
                  [self materializeAndCacheObject:data cacheInDisk:data additionalCost:0 url:url key:key options:options outImage:&image outAltRep:&alternativeRepresentation];
              }

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -780,6 +780,17 @@ static dispatch_once_t sharedDispatchToken;
                              priority:priority
                     completionHandler:^(NSData *data, NSURLResponse *response, NSError *error)
     {
+        //404 http response may have image data
+        BOOL hasDefaultImage = NO;
+        if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
+          NSHTTPURLResponse* urlResponse = (NSHTTPURLResponse*)response;
+          if (urlResponse.statusCode == 404
+              && [urlResponse.allHeaderFields[@"content-type"] rangeOfString:@"image"].location != NSNotFound) {
+            hasDefaultImage = YES;
+            error = nil;
+          }
+        }
+
         [_concurrentOperationQueue addOperation:^
         {
             PINStrongify(self)
@@ -787,17 +798,17 @@ static dispatch_once_t sharedDispatchToken;
             PINImage *image = nil;
             id alternativeRepresentation = nil;
              
-            if (remoteImageError == nil) {
+            if (remoteImageError == nil || hasDefaultImage) {
                  //stores the object in the caches
                  [self materializeAndCacheObject:data cacheInDisk:data additionalCost:0 url:url key:key options:options outImage:&image outAltRep:&alternativeRepresentation];
              }
-             
+
              if (error == nil && image == nil && alternativeRepresentation == nil) {
                  remoteImageError = [NSError errorWithDomain:PINRemoteImageManagerErrorDomain
                                                         code:PINRemoteImageManagerErrorFailedToDecodeImage
                                                     userInfo:nil];
              }
-             
+
             [self callCompletionsWithKey:key image:image alternativeRepresentation:alternativeRepresentation cached:NO response:response error:remoteImageError finalized:YES];
          } withPriority:operationPriorityWithImageManagerPriority(priority)];
     }];

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -171,6 +171,7 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
     if (!error && [task.response isKindOfClass:[NSHTTPURLResponse class]]) {
         NSHTTPURLResponse *response = (NSHTTPURLResponse *)task.response;
         NSInteger statusCode = [response statusCode];
+        //If a 404 response contains an image, we treat it as a successful request and return the image
         BOOL recoverable = [self responseRecoverableFrom404:response];
         if (statusCode >= 400 && recoverable == NO) {
             error = [NSError errorWithDomain:PINURLErrorDomain

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -169,10 +169,10 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
     }
     
     if (!error && [task.response isKindOfClass:[NSHTTPURLResponse class]]) {
-        NSHTTPURLResponse* response = (NSHTTPURLResponse *)task.response;
+        NSHTTPURLResponse *response = (NSHTTPURLResponse *)task.response;
         NSInteger statusCode = [response statusCode];
         BOOL recoverable = [self responseRecoverableFrom404:response];
-        if (statusCode >= 400 && !recoverable) {
+        if (statusCode >= 400 && recoverable == NO) {
             error = [NSError errorWithDomain:PINURLErrorDomain
                                         code:statusCode
                                     userInfo:@{NSLocalizedDescriptionKey : @"HTTP Error Response."}];
@@ -216,15 +216,10 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
     [self storeTimeToFirstByte:[firstByte timeIntervalSinceDate:requestStart] forHost:task.originalRequest.URL.host];
 }
 
-- (BOOL)responseRecoverableFrom404:(NSHTTPURLResponse*)response {
-    if ([response isKindOfClass:[NSHTTPURLResponse class]]) {
-      NSHTTPURLResponse* urlResponse = (NSHTTPURLResponse*)response;
-      if (urlResponse.statusCode == 404
-          && [urlResponse.allHeaderFields[@"content-type"] rangeOfString:@"image"].location != NSNotFound) {
-        return YES;
-      }
-    }
-    return NO;
+- (BOOL)responseRecoverableFrom404:(NSHTTPURLResponse*)response
+{
+    return response.statusCode == 404
+            && [response.allHeaderFields[@"content-type"] rangeOfString:@"image"].location != NSNotFound;
 }
 
 /* We don't bother locking around the timeToFirstByteCache because NSCache itself is

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -188,6 +188,14 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     return bigURLs;
 }
 
+- (NSURL *)imageFrom404URL
+{
+    NSString *base64EncodedUrl = @"aHR0cHM6Ly9pLnl0aW1nLmNvbS92aS9PRzlRbW9jNGVZcy9tcWRlZmF1bHQuanBn";
+    NSData *nsdataFromBase64String = [[NSData alloc] initWithBase64EncodedString:base64EncodedUrl options:0];
+    NSString *base64Decoded = [[NSString alloc] initWithData:nsdataFromBase64String encoding:NSUTF8StringEncoding];
+    return [[NSURL alloc] initWithString:base64Decoded];
+}
+
 #pragma mark - <PINURLSessionManagerDelegate>
 
 - (void)didReceiveData:(NSData *)data forTask:(NSURLSessionTask *)task
@@ -388,6 +396,20 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
          [expectation fulfill];
      }];
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
+- (void)testHTTPResponse404WithData
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"image from 404 response should set correctly"];
+    PINRemoteImageManager *manager = [[PINRemoteImageManager alloc] init];
+    NSURL *url = [self imageFrom404URL];
+    [manager downloadImageWithURL:url completion:^(PINRemoteImageManagerResult * _Nonnull result) {
+      XCTAssertNotNil(result.image);
+      [expectation fulfill];
+    }];
+    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
+      XCTAssertNil(error);
+    }];
 }
 
 - (void)testErrorOnNilURLDownload

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -404,11 +404,11 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     PINRemoteImageManager *manager = [[PINRemoteImageManager alloc] init];
     NSURL *url = [self imageFrom404URL];
     [manager downloadImageWithURL:url completion:^(PINRemoteImageManagerResult * _Nonnull result) {
-      XCTAssertNotNil(result.image);
-      [expectation fulfill];
+        XCTAssertNotNil(result.image);
+        [expectation fulfill];
     }];
-    [self waitForExpectationsWithTimeout:5 handler:^(NSError * _Nullable error) {
-      XCTAssertNil(error);
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval]  handler:^(NSError * _Nullable error) {
+        XCTAssertNil(error);
     }];
 }
 


### PR DESCRIPTION
There are cases when image is returned along with 404 HttpResponse, this pr will handle the edge case from within framework. 
Since we manage cache any way, may be not necessary to expose api to client to handle this case?
Side Notes: NSUrlSession can handle this case correctly in NSURLSessionDataDelegate. 