### PR TITLE
Include tvOS in Supported Platforms build setting

### DIFF
--- a/PINRemoteImage.xcodeproj/project.pbxproj
+++ b/PINRemoteImage.xcodeproj/project.pbxproj
@@ -1404,6 +1404,7 @@
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = PINRemoteImage;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1451,6 +1452,7 @@
 				OTHER_CFLAGS = "";
 				PRODUCT_NAME = PINRemoteImage;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos appletvsimulator appletvos";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";


### PR DESCRIPTION
Adds `appletvos` and `appletvsimulator` to the Supported Platforms build setting.

Fixes: https://github.com/pinterest/PINRemoteImage/issues/400