### PR TITLE
Replace crashing KVO with manually method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [new] Adds support for using cell vs. wifi in leau of speed for determing which URL to download if speed is unavailable. [garrettmoon](https://github.com/garrettmoon)
 - [new] Uses BPS minus time to first byte for deciding which of a set of URLs to download. [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes an edge case when image returned with 404 response, we now treat it as image instead of error [#399](https://github.com/pinterest/PINRemoteImage/pull/396) [maxwang](https://github.com/wsdwsd0829)
+- [fixed] Fixes crashing KVO with manually method call [#406](https://github.com/pinterest/PINRemoteImage/pull/406) [xilin](https://github.com/xilin)
 
 ## 3.0.0 Beta 11
 - [fixed] Fixes a deadlock with canceling processor tasks [#374](https://github.com/pinterest/PINRemoteImage/pull/374) [zachwaugh](https://github.com/zachwaugh)

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.h
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.h
@@ -10,7 +10,8 @@
 
 @interface NSURLSessionTask (Timing)
 
-- (void)PIN_setupSessionTaskObserver;
+- (void)PIN_updateStartTime;
+- (void)PIN_updateEndTime;
 - (CFTimeInterval)PIN_startTime;
 - (CFTimeInterval)PIN_endTime;
 

--- a/Source/Classes/Categories/NSURLSessionTask+Timing.m
+++ b/Source/Classes/Categories/NSURLSessionTask+Timing.m
@@ -11,111 +11,42 @@
 #import <objc/runtime.h>
 #import <QuartzCore/QuartzCore.h>
 
-static NSString * const kPINURLSessionTaskStateKey = @"state";
-
-@interface PINURLSessionTaskObserver : NSObject
-
-@property (atomic, assign) CFTimeInterval startTime;
-@property (atomic, assign) CFTimeInterval endTime;
-
-- (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithTask:(NSURLSessionTask *)task NS_DESIGNATED_INITIALIZER;
-
-@end
-
-@implementation PINURLSessionTaskObserver
-
-- (instancetype)initWithTask:(NSURLSessionTask *)task
-{
-    if (self = [super init]) {
-        _startTime = 0;
-        _endTime = 0;
-        [task addObserver:self forKeyPath:kPINURLSessionTaskStateKey options:0 context:nil];
-    }
-    return self;
-}
-
-- (void)removeObservers:(NSURLSessionTask *)task
-{
-    [task removeObserver:self forKeyPath:kPINURLSessionTaskStateKey];
-}
-
-
-- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context
-{
-    NSURLSessionTask *task = (NSURLSessionTask *)object;
-    if ([keyPath isEqualToString:kPINURLSessionTaskStateKey]) {
-        switch (task.state) {
-            case NSURLSessionTaskStateRunning:
-                if (self.startTime == 0) {
-                    self.startTime = CACurrentMediaTime();
-                }
-                break;
-                
-            case NSURLSessionTaskStateCompleted:
-                // Don't set endTime if task was never started.
-                if (self.startTime > 0 && self.endTime == 0) {
-                    self.endTime = CACurrentMediaTime();
-                }
-                break;
-                
-            default:
-                break;
-        }
-    }
-}
-
-@end
-
 @implementation NSURLSessionTask (Additions)
 
-- (void)PIN_setupSessionTaskObserver
+- (void)PIN_updateStartTime
 {
-    // It's necessary to swizzle dealloc here to remove the observer :(
-    // I wasn't able to figure out another way; kvo assertion about observed objects being observed occurs
-    // *before* associated objects are dealloc'd
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        SEL deallocSelector = NSSelectorFromString(@"dealloc");
-        Method deallocMethod = class_getInstanceMethod([NSURLSessionTask class], deallocSelector);
-        IMP originalImplementation = method_getImplementation(deallocMethod);
-        IMP newImplementation = imp_implementationWithBlock(^(void *obj){
-            @autoreleasepool {
-                //remove state observer
-                PINURLSessionTaskObserver *observer = objc_getAssociatedObject((__bridge id)obj, @selector(PIN_setupSessionTaskObserver));
-                if (observer) {
-                    [observer removeObservers:(__bridge NSURLSessionTask *)obj];
-                }
-            }
-            
-            //casting original implementation is necessary to ensure ARC doesn't attempt to retain during dealloc
-            ((void (*)(void *, SEL))originalImplementation)(obj, deallocSelector);
-        });
-        class_replaceMethod([NSURLSessionTask class], deallocSelector, newImplementation, method_getTypeEncoding(deallocMethod));
-    });
-    
-    PINURLSessionTaskObserver *observer = [[PINURLSessionTaskObserver alloc] initWithTask:self];
-    objc_setAssociatedObject(self, @selector(PIN_setupSessionTaskObserver), observer, OBJC_ASSOCIATION_RETAIN);
+    CFTimeInterval PIN_startTime = [self PIN_startTime];
+    if (PIN_startTime == 0) {
+        self.PIN_startTime = CACurrentMediaTime();
+    }
+}
+
+- (void)PIN_updateEndTime
+{
+    // Don't set endTime if task was never started.
+    if (self.PIN_startTime > 0 && self.PIN_endTime == 0) {
+        self.PIN_endTime = CACurrentMediaTime();
+    }
 }
 
 - (CFTimeInterval)PIN_startTime
 {
-    PINURLSessionTaskObserver *observer = objc_getAssociatedObject(self, @selector(PIN_setupSessionTaskObserver));
-    NSAssert(observer != nil, @"setupSessionTaskObserver should have been called before.");
-    if (observer == nil) {
-        return 0;
-    }
-    return observer.startTime;
+    return [objc_getAssociatedObject(self, @selector(PIN_startTime)) doubleValue];
+}
+
+- (void)setPIN_startTime:(CFTimeInterval)PIN_startTime
+{
+    objc_setAssociatedObject(self, @selector(PIN_startTime), @(PIN_startTime), OBJC_ASSOCIATION_COPY);
 }
 
 - (CFTimeInterval)PIN_endTime
 {
-    PINURLSessionTaskObserver *observer = objc_getAssociatedObject(self, @selector(PIN_setupSessionTaskObserver));
-    NSAssert(observer != nil, @"setupSessionTaskObserver should have been called before.");
-    if (observer == nil) {
-        return 0;
-    }
-    return observer.endTime;
+    return [objc_getAssociatedObject(self, @selector(PIN_endTime)) doubleValue];
+}
+
+- (void)setPIN_endTime:(CFTimeInterval)PIN_endTime
+{
+    objc_setAssociatedObject(self, @selector(PIN_endTime), @(PIN_endTime), OBJC_ASSOCIATION_COPY);
 }
 
 @end

--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -77,7 +77,6 @@
         
         [self scheduleDownloadsIfNeeded];
     }];
-    [dataTask PIN_setupSessionTaskObserver];
     
     [self setQueuePriority:priority forTask:dataTask addIfNecessary:YES];
     
@@ -106,7 +105,7 @@
             NSURLSessionDataTask *task = [queue firstObject];
             [queue removeObjectAtIndex:0];
             [task resume];
-            
+            [task PIN_updateStartTime];
             
             [_runningTasks addObject:task];
         }

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -7,6 +7,7 @@
 //
 
 #import "PINURLSessionManager.h"
+#import "NSURLSessionTask+Timing.h"
 
 NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
 
@@ -179,6 +180,9 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
                                     userInfo:@{NSLocalizedDescriptionKey : @"HTTP Error Response."}];
         }
     }
+    
+    [task PIN_updateEndTime];
+    
     __weak typeof(self) weakSelf = self;
     dispatch_async(delegateQueue, ^{
         typeof(self) strongSelf = weakSelf;


### PR DESCRIPTION
See the [issue 390](https://github.com/pinterest/PINRemoteImage/issues/390).
Same thing happened in AFNetworking (PR [2411](https://github.com/AFNetworking/AFNetworking/pull/2411) and [2702](https://github.com/AFNetworking/AFNetworking/pull/2702)).
So I tried to do the same thing in PINRemoteImage using method swizzle instead of KVO.