### PR TITLE
#trivial Fix unused ivar warnings generated in PINMemMapAnimatedImage and

### DIFF
--- a/Source/Classes/AnimatedImages/PINMemMapAnimatedImage.h
+++ b/Source/Classes/AnimatedImages/PINMemMapAnimatedImage.h
@@ -55,7 +55,7 @@
 /**
  The current status of the animated image.
  */
-@property (nonatomic, assign, readwrite) PINAnimatedImageStatus status;
+@property (nonatomic, assign, readonly) PINAnimatedImageStatus status;
 
 /**
  A helper function which references status to check if the coverImage is ready.

--- a/Source/Classes/PINRemoteImageDownloadTask.h
+++ b/Source/Classes/PINRemoteImageDownloadTask.h
@@ -15,7 +15,7 @@
 
 @interface PINRemoteImageDownloadTask : PINRemoteImageTask
 
-@property (nonatomic, strong, nullable) NSURL *URL;
+@property (nonatomic, strong, nullable, readonly) NSURL *URL;
 @property (nonatomic, copy, nullable) NSString *ifRange;
 @property (nonatomic, copy, readonly, nullable) NSData *data;
 


### PR DESCRIPTION
PINRemoteImageDownloadTask