### PR TITLE
 [iOS11] Fix warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [iOS11] Fix warnings [#428](https://github.com/pinterest/PINRemoteImage/pull/428) [Eke](https://github.com/Eke)
 
 ## 3.0.0 Beta 13
 - [new] Support for webp and improved support for GIFs. [#411](https://github.com/pinterest/PINRemoteImage/pull/411) [garrettmoon](https://github.com/garrettmoon)

--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -76,7 +76,9 @@ Pod::Spec.new do |s|
   s.subspec "PINCache" do |pc|
     pc.dependency 'PINRemoteImage/Core'    
   	pc.dependency 'PINCache', '=3.0.1-beta.6'
-	pc.osx.deployment_target = osx_deployment
+    pc.ios.deployment_target = ios_deployment
+    pc.tvos.deployment_target = tvos_deployment
+    pc.osx.deployment_target = osx_deployment
   	pc.source_files = 'Source/Classes/PINCache/*.{h,m}'
   end
   

--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -74,12 +74,12 @@ Pod::Spec.new do |s|
   end
   
   s.subspec "PINCache" do |pc|
-    pc.dependency 'PINRemoteImage/Core'    
-  	pc.dependency 'PINCache', '=3.0.1-beta.6'
+    pc.dependency 'PINRemoteImage/Core'
+    pc.dependency 'PINCache', '=3.0.1-beta.6'
     pc.ios.deployment_target = ios_deployment
     pc.tvos.deployment_target = tvos_deployment
     pc.osx.deployment_target = osx_deployment
-  	pc.source_files = 'Source/Classes/PINCache/*.{h,m}'
+    pc.source_files = 'Source/Classes/PINCache/*.{h,m}'
   end
   
 end

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -209,9 +209,18 @@ NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
 #if DEBUG
 - (void)concurrentDownloads:(void (^_Nullable)(NSUInteger concurrentDownloads))concurrentDownloadsCompletion
 {
-    [self.session getAllTasksWithCompletionHandler:^(NSArray<__kindof NSURLSessionTask *> * _Nonnull tasks) {
-        concurrentDownloadsCompletion(tasks.count);
-    }];
+    if (@available(macos 10.11, iOS 9.0, watchOS 2.0, tvOS 9.0,  *)) {
+        [self.session getAllTasksWithCompletionHandler:^(NSArray<__kindof NSURLSessionTask *> * _Nonnull tasks) {
+            concurrentDownloadsCompletion(tasks.count);
+        }];
+    } else {
+        [self.session getTasksWithCompletionHandler:^(NSArray<NSURLSessionDataTask *> * _Nonnull dataTasks,
+                                                      NSArray<NSURLSessionUploadTask *> * _Nonnull uploadTasks,
+                                                      NSArray<NSURLSessionDownloadTask *> * _Nonnull downloadTasks) {
+          NSUInteger total = dataTasks.count + uploadTasks.count + downloadTasks.count;
+          concurrentDownloadsCompletion(total);
+        }];
+    }
 }
 
 #endif

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -1136,7 +1136,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     //I want this retain cycle
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
-    __block void (^checkConcurrentDownloads) ();
+    __block void (^checkConcurrentDownloads) (void);
     checkConcurrentDownloads = ^{
         usleep(10000);
         [self.imageManager.sessionManager concurrentDownloads:^(NSUInteger concurrentDownloads) {


### PR DESCRIPTION
Hello!

I fixed some warnings in Xcode 9 and iOS 11. Also re-enabled iOS and tvOS support for `PINCache` in `PINRemoteImage.podspec`, i think it was disabled in #421 .

After that PR was merged users got error(was reported in Texture slack channel too) :
```
[!] The platform of the target `App name` (iOS 8.0) is not compatible with `PINRemoteImage/PINCache (3.0.0-beta.13)`, which does not support `ios`.
```