### PR TITLE
[Breaking Swift API] Use Fancy NSError Macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [new] Add support for higher frame rate devices to animated images. [#417](https://github.com/pinterest/PINRemoteImage/pull/417) [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes non-animated GIFs being delivered as an animated image. [#434](https://github.com/pinterest/PINRemoteImage/pull/434) [garrettmoon](https://github.com/garrettmoon)
 - Remove unused code that supported iOS < 7. [#435](https://github.com/pinterest/PINRemoteImage/pull/435) [Adlai-Holler](https://github.com/Adlai-Holler)
+- Use NS_ERROR_ENUM to improve Swift import. [#440](https://github.com/pinterest/PINRemoteImage/pull/440) [Adlai-Holler](https://github.com/Adlai-Holler)
 
 ## 3.0.0 Beta 13
 - [new] Support for webp and improved support for GIFs. [#411](https://github.com/pinterest/PINRemoteImage/pull/411) [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/AnimatedImages/PINAnimatedImage.h
+++ b/Source/Classes/AnimatedImages/PINAnimatedImage.h
@@ -23,7 +23,7 @@ extern NSErrorDomain const kPINAnimatedImageErrorDomain;
 /**
  PINAnimatedImage decoding and processing errors.
  */
-NS_ERROR_ENUM(kPINAnimatedImageErrorDomain) {
+typedef NS_ERROR_ENUM(kPINAnimatedImageErrorDomain, PINAnimatedImageErrorCode) {
     /** No error, yay! */
     PINAnimatedImageErrorNoError = 0,
     /** Could not create a necessary file. */

--- a/Source/Classes/AnimatedImages/PINAnimatedImage.h
+++ b/Source/Classes/AnimatedImages/PINAnimatedImage.h
@@ -16,12 +16,14 @@
 
 #import "PINRemoteImageMacros.h"
 
-extern NSString * _Nonnull kPINAnimatedImageErrorDomain;
+NS_ASSUME_NONNULL_BEGIN
+
+extern NSErrorDomain const kPINAnimatedImageErrorDomain;
 
 /**
  PINAnimatedImage decoding and processing errors.
  */
-typedef NS_ENUM(NSUInteger, PINAnimatedImageError) {
+NS_ERROR_ENUM(kPINAnimatedImageErrorDomain) {
     /** No error, yay! */
     PINAnimatedImageErrorNoError = 0,
     /** Could not create a necessary file. */
@@ -155,3 +157,5 @@ typedef void(^PINAnimatedImageInfoReady)(PINImage * _Nonnull coverImage);
 - (CFTimeInterval)durationAtIndex:(NSUInteger)index;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Source/Classes/AnimatedImages/PINAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINAnimatedImage.m
@@ -8,7 +8,7 @@
 
 #import "PINAnimatedImage.h"
 
-NSString *kPINAnimatedImageErrorDomain = @"kPINAnimatedImageErrorDomain";
+NSErrorDomain const kPINAnimatedImageErrorDomain = @"kPINAnimatedImageErrorDomain";
 
 //http://nullsleep.tumblr.com/post/16524517190/animated-gif-minimum-frame-delay-browser
 const Float32 kPINAnimatedImageDefaultDuration = 0.1;

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -24,12 +24,12 @@
 
 @class PINRemoteImageManagerResult;
 
-extern NSString * __nonnull const PINRemoteImageManagerErrorDomain;
+extern NSErrorDomain _Nonnull const PINRemoteImageManagerErrorDomain;
 
 /**
  Error codes returned by PINRemoteImage
  */
-typedef NS_ENUM(NSUInteger, PINRemoteImageManagerError) {
+NS_ERROR_ENUM(PINRemoteImageManagerErrorDomain) {
     /** The image failed to decode */
     PINRemoteImageManagerErrorFailedToDecodeImage = 1,
     /** The image could not be downloaded and therefore could not be processed */

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -29,7 +29,7 @@ extern NSErrorDomain _Nonnull const PINRemoteImageManagerErrorDomain;
 /**
  Error codes returned by PINRemoteImage
  */
-NS_ERROR_ENUM(PINRemoteImageManagerErrorDomain) {
+typedef NS_ERROR_ENUM(PINRemoteImageManagerErrorDomain, PINRemoteImageManagerError) {
     /** The image failed to decode */
     PINRemoteImageManagerErrorFailedToDecodeImage = 1,
     /** The image could not be downloaded and therefore could not be processed */

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -78,7 +78,7 @@ float dataTaskPriorityWithImageManagerPriority(PINRemoteImageManagerPriority pri
     }
 }
 
-NSString * const PINRemoteImageManagerErrorDomain = @"PINRemoteImageManagerErrorDomain";
+NSErrorDomain const PINRemoteImageManagerErrorDomain = @"PINRemoteImageManagerErrorDomain";
 NSString * const PINRemoteImageCacheKey = @"cacheKey";
 NSString * const PINRemoteImageCacheKeyResumePrefix = @"R-";
 typedef void (^PINRemoteImageManagerDataCompletion)(NSData *data, NSURLResponse *response, NSError *error);

--- a/Source/Classes/PINURLSessionManager.h
+++ b/Source/Classes/PINURLSessionManager.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString * __nonnull const PINURLErrorDomain;
+extern NSErrorDomain _Nonnull const PINURLErrorDomain;
 
 @protocol PINURLSessionManagerDelegate <NSObject>
 

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -10,7 +10,7 @@
 
 #import "PINSpeedRecorder.h"
 
-NSString * const PINURLErrorDomain = @"PINURLErrorDomain";
+NSErrorDomain const PINURLErrorDomain = @"PINURLErrorDomain";
 
 @interface PINURLSessionManager () <NSURLSessionDelegate, NSURLSessionDataDelegate>
 


### PR DESCRIPTION
These improve the swift import. Currently they don't really do anything in Objective-C but never hurts to have.