### PR TITLE
Fixed a bug where using PINRemoteImageBasicCache would cause images to be decoded on the main thread.

### DIFF
--- a/Source/Classes/PINRemoteImageBasicCache.h
+++ b/Source/Classes/PINRemoteImageBasicCache.h
@@ -11,7 +11,8 @@
 
 /**
  *  Simplistic <PINRemoteImageCacheProtocol> wrapper based on NSCache.
- *  not persisting any data on disk
+ *
+ *  No data is persisted on disk. The disk cache methods are no-op.
  */
 @interface PINRemoteImageBasicCache : NSObject <PINRemoteImageCaching>
 

--- a/Source/Classes/PINRemoteImageBasicCache.m
+++ b/Source/Classes/PINRemoteImageBasicCache.m
@@ -46,7 +46,7 @@
 //******************************************************************************************************
 -(nullable id)objectFromDiskForKey:(NSString *)key
 {
-    return [self.cache objectForKey:key];
+    return nil;
 }
 
 -(void)objectFromDiskForKey:(NSString *)key completion:(PINRemoteImageCachingObjectBlock)completion
@@ -55,28 +55,29 @@
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         if (completion) {
             typeof(self) strongSelf = weakSelf;
-            completion(strongSelf, key, [strongSelf.cache objectForKey:key]);
+            completion(strongSelf, key, nil);
         }
     });
 }
 
 -(void)setObjectOnDisk:(id)object forKey:(NSString *)key
 {
-    [self.cache setObject:object forKey:key];
-}
-
-- (BOOL)objectExistsForKey:(NSString *)key
-{
-    return [self.cache objectForKey:key] != nil;
+    
 }
 
 //******************************************************************************************************
 // Common methods, should apply to both in-memory and disk storage
 //******************************************************************************************************
+- (BOOL)objectExistsForKey:(NSString *)key
+{
+    return [self.cache objectForKey:key] != nil;
+}
+
 - (void)removeObjectForKey:(NSString *)key
 {
     [self.cache removeObjectForKey:key];
 }
+
 - (void)removeObjectForKey:(NSString *)key completion:(PINRemoteImageCachingObjectBlock)completion
 {
     __weak typeof(self) weakSelf = self;

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -564,8 +564,9 @@ typedef void(^PINRemoteImageManagerProgressDownload)(int64_t completedBytes, int
  Cancel a download. Canceling will only cancel the download if all other downloads are also canceled with their associated UUIDs. 
  Canceling *does not* guarantee that your completion will not be called. You can use the UUID provided on the result object to verify
  the completion you want called is being called.
- @param storeResumeData if YES and the server indicates it supports resuming downloads, downloaded data will be stored in the memory
+ @param storeResumeData if YES and the server indicates it supports resuming downloads, downloaded data will be stored in the disk
  cache and used to resume the download if the same URL is attempted to be downloaded in the future.
+ PINRemoteImageBasicCache does not support disk caching, use PINCache.
  */
 - (void)cancelTaskWithUUID:(nonnull NSUUID *)UUID storeResumeData:(BOOL)storeResumeData;
 


### PR DESCRIPTION
Issue reference: #451 

-  PINRemoteImageBasicCache disk-cache methods are now no-op.
- Changed `cancelTaskWithUUID:` documentation to say disk cache, and not memory cache.

Feel free to (of course) to pick on anything that seems weird. One decision that may feel odd is that I left the global-queue code in `objectFromDiskForKey:completion:`. My thought-process was to leave the code functioning as it did before as to not cause any unknown side effects. In this case, the completionHandler will continue to return from a global queue (as before), but it will just _always_ return a nil for `object`, instead of just _sometimes_.
