### PR TITLE
Add url configuration handler

### DIFF
--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -141,6 +141,13 @@ typedef void(^PINRemoteImageManagerAuthenticationChallenge)(NSURLSessionTask * _
  */
 typedef NSURLRequest * _Nonnull(^PINRemoteImageManagerRequestConfigurationHandler)(NSURLRequest * __nonnull request);
 
+/**
+ URL configuration handler. Used to modify the url of a network request.
+ Useful for modifying url.
+ 
+ @param url The url of the request about to be executed
+ */
+typedef NSURL * __nullable(^PINRemoteImageManagerUrlConfigurationHandler)(NSURL * __nullable url);
 
 /**
  Handler called for many PINRemoteImage tasks providing the progress of the download.
@@ -241,6 +248,13 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  @param configurationBlock A PINRemoteImageManagerRequestConfigurationHandler block.
  */
 - (void)setRequestConfiguration:(nullable PINRemoteImageManagerRequestConfigurationHandler)configurationBlock;
+
+/**
+ Sets the URL Configuration Block.
+ 
+ @param configurationBlock A PINRemoteImageManagerUrlConfigurationHandler block.
+ */
+- (void)setUrlConfiguration:(nullable PINRemoteImageManagerUrlConfigurationHandler)configurationBlock;
 
 /**
  Set the Authentication Challenge Block.

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -342,7 +342,7 @@ static dispatch_once_t sharedDispatchToken;
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         typeof(self) strongSelf = weakSelf;
         [strongSelf lock];
-        strongSelf.urlConfigurationHandler = configurationBlock;
+            strongSelf.urlConfigurationHandler = configurationBlock;
         [strongSelf unlock];
     });
 }


### PR DESCRIPTION
Adding an url configuration handler similar to request configuration handler which is useful to handling custom url modification.

Changes are also made to have the cache keys reflect the url modification.