### PR TITLE
Allow clients to configure URLSession URLCache if they choose.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
-- [new] Respect Cache-Control and Expires headers if the cache supports TTL [#462](https://github.com/pinterest/PINRemoteImage/pull/462) [wiseoldduck](https://github.com/wiseoldduck)
+- [new] Allow use of NSURLCache via a custom NSURLSession [#477](https://github.com/pinterest/PINRemoteImage/pull/477) [wiseoldduck](https://github.com/wiseoldduck)
+- [new] Respect Cache-Control and Expires headers if the cache supports TTL. [#462](https://github.com/pinterest/PINRemoteImage/pull/462) [wiseoldduck](https://github.com/wiseoldduck)
 - [new] Updated to latest PINCache beta 7. [wiseoldduck](https://github.com/wiseoldduck)
 - [iOS11] Fix warnings [#428](https://github.com/pinterest/PINRemoteImage/pull/428) [Eke](https://github.com/Eke)
 - [new / beta] Native Support for GIFs and animated WebP [#453](https://github.com/pinterest/PINRemoteImage/pull/453) [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -192,6 +192,8 @@ static dispatch_once_t sharedDispatchToken;
         if (!_sessionConfiguration) {
             _sessionConfiguration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
             _sessionConfiguration.timeoutIntervalForRequest = PINRemoteImageManagerDefaultTimeout;
+            _sessionConfiguration.requestCachePolicy = NSURLRequestReloadIgnoringLocalCacheData;
+            _sessionConfiguration.URLCache = nil;
         }
         _sessionConfiguration.HTTPMaximumConnectionsPerHost = PINRemoteImageHTTPMaximumConnectionsPerHost;
         
@@ -902,10 +904,8 @@ static dispatch_once_t sharedDispatchToken;
 
 - (NSURLRequest *)requestWithURL:(NSURL *)url key:(NSString *)key
 {
-    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url
-                                                           cachePolicy:NSURLRequestReloadIgnoringLocalCacheData
-                                                       timeoutInterval:_sessionConfiguration.timeoutIntervalForRequest];
-    
+    NSMutableURLRequest *request = [NSMutableURLRequest requestWithURL:url];
+
     NSMutableDictionary *headers = [self.httpHeaderFields mutableCopy];
     
     if (headers.count > 0) {


### PR DESCRIPTION
Set NSURLRequestReloadIgnoringLocalCacheData in the default  session instead of per-request. This lets a client configure a session with a URLCache if they so choose. Also explicitly set URLCache in the default session to  nil to avoid the small costs associated with the default ephemeral session memory cache that is never used.