### PR TITLE
Set priority of download data tasks at the right time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [cleanup] Use NS_ERROR_ENUM to improve Swift import. [#440](https://github.com/pinterest/PINRemoteImage/pull/440) [Adlai-Holler](https://github.com/Adlai-Holler)
 - [fixed] Fixes nil session manager configuration. [#460](https://github.com/pinterest/PINRemoteImage/pull/460) [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes deprecated -defaultImageCache not being called if overridden. [479](https://github.com/pinterest/PINRemoteImage/pull/479) [nguyenhuy](https://github.com/nguyenhuy)
+- [new] Add a new API that allows a priority to be set when a new download task is scheduled. [#490](https://github.com/pinterest/PINRemoteImage/pull/490) [nguyenhuy](https://github.com/nguyenhuy)
 
 ## 3.0.0 Beta 13
 - [new] Support for webp and improved support for GIFs. [#411](https://github.com/pinterest/PINRemoteImage/pull/411) [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINRemoteImageDownloadQueue.h
+++ b/Source/Classes/PINRemoteImageDownloadQueue.h
@@ -19,11 +19,9 @@ typedef void (^PINRemoteImageDownloadCompletion)(NSURLResponse * _Nullable respo
 @interface PINRemoteImageDownloadQueue : NSObject
 
 @property (atomic, assign) NSUInteger maxNumberOfConcurrentDownloads;
-@property (atomic, assign, readonly) BOOL shouldUseNewDataTaskPriorityBehavior;
 
 - (instancetype)init NS_UNAVAILABLE;
-+ (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads
-                            shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior;
++ (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads;
 
 - (NSURLSessionDataTask *)addDownloadWithSessionManager:(PINURLSessionManager *)sessionManager
                                                 request:(NSURLRequest *)request

--- a/Source/Classes/PINRemoteImageDownloadQueue.h
+++ b/Source/Classes/PINRemoteImageDownloadQueue.h
@@ -18,10 +18,12 @@ typedef void (^PINRemoteImageDownloadCompletion)(NSURLResponse * _Nullable respo
 
 @interface PINRemoteImageDownloadQueue : NSObject
 
-@property (nonatomic, assign) NSUInteger maxNumberOfConcurrentDownloads;
+@property (atomic, assign) NSUInteger maxNumberOfConcurrentDownloads;
+@property (atomic, assign, readonly, getter = shouldUseNewDataTaskPriorityBehavior) BOOL usesNewDataTaskPriorityBehavior;
 
 - (instancetype)init NS_UNAVAILABLE;
-+ (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads;
++ (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads
+                            shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior;
 
 - (NSURLSessionDataTask *)addDownloadWithSessionManager:(PINURLSessionManager *)sessionManager
                                                 request:(NSURLRequest *)request

--- a/Source/Classes/PINRemoteImageDownloadQueue.h
+++ b/Source/Classes/PINRemoteImageDownloadQueue.h
@@ -19,7 +19,7 @@ typedef void (^PINRemoteImageDownloadCompletion)(NSURLResponse * _Nullable respo
 @interface PINRemoteImageDownloadQueue : NSObject
 
 @property (atomic, assign) NSUInteger maxNumberOfConcurrentDownloads;
-@property (atomic, assign, readonly, getter = shouldUseNewDataTaskPriorityBehavior) BOOL usesNewDataTaskPriorityBehavior;
+@property (atomic, assign, readonly) BOOL shouldUseNewDataTaskPriorityBehavior;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads

--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -26,22 +26,17 @@
 @implementation PINRemoteImageDownloadQueue
 
 @synthesize maxNumberOfConcurrentDownloads = _maxNumberOfConcurrentDownloads;
-@synthesize shouldUseNewDataTaskPriorityBehavior = _shouldUseNewDataTaskPriorityBehavior;
 
 + (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads
-                            shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior
 {
-    return [[PINRemoteImageDownloadQueue alloc] initWithMaxConcurrentDownloads:maxNumberOfConcurrentDownloads
-                                          shouldUseNewDataTaskPriorityBehavior:shouldUseNewDataTaskPriorityBehavior];
+    return [[PINRemoteImageDownloadQueue alloc] initWithMaxConcurrentDownloads:maxNumberOfConcurrentDownloads];
 }
 
 - (PINRemoteImageDownloadQueue *)initWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads
-                           shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior
 {
     if (self = [super init]) {
         _maxNumberOfConcurrentDownloads = maxNumberOfConcurrentDownloads;
-        _shouldUseNewDataTaskPriorityBehavior = shouldUseNewDataTaskPriorityBehavior;
-        
+
         _lock = [[PINRemoteLock alloc] initWithName:@"PINRemoteImageDownloadQueue Lock"];
         _highPriorityQueuedOperations = [[NSMutableOrderedSet alloc] init];
         _defaultPriorityQueuedOperations = [[NSMutableOrderedSet alloc] init];
@@ -68,20 +63,13 @@
     [self scheduleDownloadsIfNeeded];
 }
 
-- (BOOL)shouldUseNewDataTaskPriorityBehavior
-{
-    // _shouldUseNewDataTaskPriorityBehavior is set during initialization and never changed
-    // so it can be accessed without locking
-    return _shouldUseNewDataTaskPriorityBehavior;
-}
-
 - (NSURLSessionDataTask *)addDownloadWithSessionManager:(PINURLSessionManager *)sessionManager
                                                 request:(NSURLRequest *)request
                                                priority:(PINRemoteImageManagerPriority)priority
                                       completionHandler:(PINRemoteImageDownloadCompletion)completionHandler
 {
     NSURLSessionDataTask *dataTask = [sessionManager dataTaskWithRequest:request
-                                                                priority:self.shouldUseNewDataTaskPriorityBehavior ? priority : PINRemoteImageManagerPriorityDefault
+                                                                priority:priority
                                                        completionHandler:^(NSURLSessionTask *task, NSError *error) {
                                                            completionHandler(task.response, error);
                                                            [self lock];

--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -68,7 +68,9 @@
                                                priority:(PINRemoteImageManagerPriority)priority
                                       completionHandler:(PINRemoteImageDownloadCompletion)completionHandler
 {
-    NSURLSessionDataTask *dataTask = [sessionManager dataTaskWithRequest:request completionHandler:^(NSURLSessionTask *task, NSError *error) {
+    NSURLSessionDataTask *dataTask = [sessionManager dataTaskWithRequest:request
+                                                                priority:priority
+                                                       completionHandler:^(NSURLSessionTask *task, NSError *error) {
         completionHandler(task.response, error);
         [self lock];
             [self->_runningTasks removeObject:task];
@@ -104,7 +106,6 @@
             NSURLSessionDataTask *task = [queue firstObject];
             [queue removeObjectAtIndex:0];
             [task resume];
-            
             
             [_runningTasks addObject:task];
         }

--- a/Source/Classes/PINRemoteImageDownloadQueue.m
+++ b/Source/Classes/PINRemoteImageDownloadQueue.m
@@ -26,7 +26,7 @@
 @implementation PINRemoteImageDownloadQueue
 
 @synthesize maxNumberOfConcurrentDownloads = _maxNumberOfConcurrentDownloads;
-@synthesize usesNewDataTaskPriorityBehavior = _usesNewDataTaskPriorityBehavior;
+@synthesize shouldUseNewDataTaskPriorityBehavior = _shouldUseNewDataTaskPriorityBehavior;
 
 + (PINRemoteImageDownloadQueue *)queueWithMaxConcurrentDownloads:(NSUInteger)maxNumberOfConcurrentDownloads
                             shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior
@@ -40,7 +40,7 @@
 {
     if (self = [super init]) {
         _maxNumberOfConcurrentDownloads = maxNumberOfConcurrentDownloads;
-        _usesNewDataTaskPriorityBehavior = shouldUseNewDataTaskPriorityBehavior;
+        _shouldUseNewDataTaskPriorityBehavior = shouldUseNewDataTaskPriorityBehavior;
         
         _lock = [[PINRemoteLock alloc] initWithName:@"PINRemoteImageDownloadQueue Lock"];
         _highPriorityQueuedOperations = [[NSMutableOrderedSet alloc] init];
@@ -70,9 +70,9 @@
 
 - (BOOL)shouldUseNewDataTaskPriorityBehavior
 {
-    // _usesNewDataTaskPriorityBehavior is set during initialization and never changed
+    // _shouldUseNewDataTaskPriorityBehavior is set during initialization and never changed
     // so it can be accessed without locking
-    return _usesNewDataTaskPriorityBehavior;
+    return _shouldUseNewDataTaskPriorityBehavior;
 }
 
 - (NSURLSessionDataTask *)addDownloadWithSessionManager:(PINURLSessionManager *)sessionManager
@@ -81,7 +81,7 @@
                                       completionHandler:(PINRemoteImageDownloadCompletion)completionHandler
 {
     NSURLSessionDataTask *dataTask = [sessionManager dataTaskWithRequest:request
-                                                                priority:self.usesNewDataTaskPriorityBehavior ? priority : PINRemoteImageManagerPriorityDefault
+                                                                priority:self.shouldUseNewDataTaskPriorityBehavior ? priority : PINRemoteImageManagerPriorityDefault
                                                        completionHandler:^(NSURLSessionTask *task, NSError *error) {
                                                            completionHandler(task.response, error);
                                                            [self lock];

--- a/Source/Classes/PINRemoteImageDownloadTask.m
+++ b/Source/Classes/PINRemoteImageDownloadTask.m
@@ -343,12 +343,6 @@
                 }
             }];
         }]];
-
-        if (!self.manager.urlSessionTaskQueue.shouldUseNewDataTaskPriorityBehavior) {
-            if (@available(iOS 8.0, macOS 10.10, tvOS 9.0, watchOS 2.0, *)) {
-                self->_progressImage.dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
-            }
-        }
     }];
 }
 

--- a/Source/Classes/PINRemoteImageDownloadTask.m
+++ b/Source/Classes/PINRemoteImageDownloadTask.m
@@ -342,10 +342,6 @@
                 }
             }];
         }]];
-        
-        if (@available(iOS 8.0, macOS 10.10, tvOS 9.0, watchOS 2.0, *)) {
-            self->_progressImage.dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
-        }
     }];
 }
 

--- a/Source/Classes/PINRemoteImageDownloadTask.m
+++ b/Source/Classes/PINRemoteImageDownloadTask.m
@@ -139,9 +139,10 @@
     [super setPriority:priority];
     if (@available(iOS 8.0, macOS 10.10, tvOS 9.0, watchOS 2.0, *)) {
         [self.lock lockWithBlock:^{
-            if (self->_progressImage.dataTask) {
-                self->_progressImage.dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
-                [self.manager.urlSessionTaskQueue setQueuePriority:priority forTask:self->_progressImage.dataTask];
+            NSURLSessionDataTask *dataTask = self->_progressImage.dataTask;
+            if (dataTask) {
+                dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
+                [self.manager.urlSessionTaskQueue setQueuePriority:priority forTask:dataTask];
             }
         }];
     }
@@ -342,6 +343,12 @@
                 }
             }];
         }]];
+
+        if (!self.manager.urlSessionTaskQueue.shouldUseNewDataTaskPriorityBehavior) {
+            if (@available(iOS 8.0, macOS 10.10, tvOS 9.0, watchOS 2.0, *)) {
+                self->_progressImage.dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
+            }
+        }
     }];
 }
 

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -186,20 +186,7 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  */
 - (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
                    alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache;
-
-/**
- Create and return a PINRemoteImageManager with the specified configuration and alternative representation delegate. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc. If alternativeRepresentationProvider is nil, the default is used (and supports PINAnimatedImageView).
- @param configuration The configuration used to create the PINRemoteImageManager.
- @param alternateRepDelegate a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
- @param imageCache  Optional delegate which conforms to the PINRemoteImageCaching protocol. Provide a delegate if you want to control image caching. By default, image manager will use most appropriate implementation available (based on PINCache or NSCache, depending on subspec)@see PINRemoteImageBasicCache for an example.
- @param shouldUseNewDataTaskPriorityBehavior Previously the priority is set after a data task has been scheduled and potentially sent off. The new behavior sets it when the task is created.
- @return A PINRemoteImageManager with the specified configuration.
- */
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
-                   alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache
-                shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior NS_DESIGNATED_INITIALIZER;
+                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache NS_DESIGNATED_INITIALIZER;
 
 /**
  Get the shared instance of PINRemoteImageManager
@@ -448,6 +435,23 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+
+/**
+ Download or retrieve from cache the image found at the url and process it before calling completion. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
+
+ @param url NSURL where the image to download resides.
+ @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
+ @param priority PINRemoteImageManagerPriority which indicates the priority of the download task.
+ @param progressDownload PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
+
+ @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
+ */
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                                 priority:(PINRemoteImageManagerPriority)priority
                          progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -186,8 +186,20 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  */
 - (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
                    alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache NS_DESIGNATED_INITIALIZER;
+                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache;
 
+/**
+ Create and return a PINRemoteImageManager with the specified configuration and alternative representation delegate. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc. If alternativeRepresentationProvider is nil, the default is used (and supports PINAnimatedImageView).
+ @param configuration The configuration used to create the PINRemoteImageManager.
+ @param alternateRepDelegate a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
+ @param imageCache  Optional delegate which conforms to the PINRemoteImageCaching protocol. Provide a delegate if you want to control image caching. By default, image manager will use most appropriate implementation available (based on PINCache or NSCache, depending on subspec)@see PINRemoteImageBasicCache for an example.
+ @param shouldUseNewDataTaskPriorityBehavior Previously the priority is set after a data task has been scheduled and potentially sent off. The new behavior sets it when the task is created.
+ @return A PINRemoteImageManager with the specified configuration.
+ */
+- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
+                   alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
+                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache
+                shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior NS_DESIGNATED_INITIALIZER;
 
 /**
  Get the shared instance of PINRemoteImageManager
@@ -650,6 +662,5 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
 - (void)setRetryStrategyCreationBlock:(_Nonnull id<PINRequestRetryStrategy> (^_Nonnull)(void))retryStrategyCreationBlock;
 
 @property (nonatomic, readonly) _Nonnull id<PINRequestRetryStrategy> (^_Nonnull retryStrategyCreationBlock)(void);
-
 
 @end

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -439,23 +439,6 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 
 /**
- Download or retrieve from cache the image found at the url and process it before calling completion. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
-
- @param url NSURL where the image to download resides.
- @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
- @param priority PINRemoteImageManagerPriority which indicates the priority of the download task.
- @param progressDownload PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
- @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
-
- @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
- */
-- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
-                                  options:(PINRemoteImageManagerDownloadOptions)options
-                                 priority:(PINRemoteImageManagerPriority)priority
-                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
-                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
-
-/**
  Download or retrieve from cache the image found at the url. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
  
  @param url NSURL where the image to download resides.
@@ -468,6 +451,25 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
+
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+
+/**
+ Download or retrieve from cache the image found at the url and process it before calling completion. All completions are called on an arbitrary callback queue unless called on the main thread and the result is in the memory cache (this is an optimization to allow synchronous results for the UI when an object is cached in memory).
+
+ @param url NSURL where the image to download resides.
+ @param options PINRemoteImageManagerDownloadOptions options with which to fetch the image.
+ @param priority PINRemoteImageManagerPriority which indicates the priority of the download task.
+ @param progressImage PINRemoteImageManagerImageCompletion block which will be called to update progress of the image download.
+ @param progressDownload PINRemoteImageManagerDownloadProgress block which will be called to update progress in bytes of the image download. NOTE: For performance reasons, this block is not called on the main thread every time, if you need to update your UI ensure that you dispatch to the main thread first.
+ @param completion PINRemoteImageManagerImageCompletion block to call when image has been fetched from the cache or downloaded.
+
+ @return An NSUUID which uniquely identifies this request. To be used for canceling requests and verifying that the callback is for the request you expect (see categories for example).
+ */
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                                 priority:(PINRemoteImageManagerPriority)priority
                             progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
                          progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -451,7 +451,7 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  */
 - (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
                                   options:(PINRemoteImageManagerDownloadOptions)options
-
+                            progressImage:(nullable PINRemoteImageManagerImageCompletion)progressImage
                          progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
                                completion:(nullable PINRemoteImageManagerImageCompletion)completion;
 

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -180,18 +180,6 @@ static dispatch_once_t sharedDispatchToken;
                    alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepProvider
                                           imageCache:(nullable id<PINRemoteImageCaching>)imageCache
 {
-    return [self initWithSessionConfiguration:configuration
-            alternativeRepresentationProvider:alternateRepProvider
-                                   imageCache:imageCache
-         shouldUseNewDataTaskPriorityBehavior:NO];
-}
-
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
-                   alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache
-                shouldUseNewDataTaskPriorityBehavior:(BOOL)shouldUseNewDataTaskPriorityBehavior
-{
-
     if (self = [super init]) {
         if (imageCache) {
             self.cache = imageCache;
@@ -225,8 +213,7 @@ static dispatch_once_t sharedDispatchToken;
         _lock = [[PINRemoteLock alloc] initWithName:@"PINRemoteImageManager"];
 
         _concurrentOperationQueue = [[PINOperationQueue alloc] initWithMaxConcurrentOperations:[[NSProcessInfo processInfo] activeProcessorCount] * 2];
-        _urlSessionTaskQueue = [PINRemoteImageDownloadQueue queueWithMaxConcurrentDownloads:10
-                                                       shouldUseNewDataTaskPriorityBehavior:shouldUseNewDataTaskPriorityBehavior];
+        _urlSessionTaskQueue = [PINRemoteImageDownloadQueue queueWithMaxConcurrentDownloads:10];
         
         self.sessionManager = [[PINURLSessionManager alloc] initWithSessionConfiguration:_sessionConfiguration];
         self.sessionManager.delegate = self;
@@ -530,12 +517,8 @@ static dispatch_once_t sharedDispatchToken;
     return [self downloadImageWithURL:url
                               options:options
                              priority:PINRemoteImageManagerPriorityDefault
-                         processorKey:nil
-                            processor:nil
                         progressImage:progressImage
-                     progressDownload:nil
-                           completion:completion
-                            inputUUID:nil];
+                           completion:completion];
 }
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
@@ -546,6 +529,19 @@ static dispatch_once_t sharedDispatchToken;
     return [self downloadImageWithURL:url
                               options:options
                              priority:PINRemoteImageManagerPriorityDefault
+                     progressDownload:progressDownload
+                           completion:completion];
+}
+
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                                 priority:(PINRemoteImageManagerPriority)priority
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+{
+    return [self downloadImageWithURL:url
+                              options:options
+                             priority:priority
                          processorKey:nil
                             processor:nil
                         progressImage:nil
@@ -596,14 +592,14 @@ static dispatch_once_t sharedDispatchToken;
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {
     return [self downloadImageWithURL:url
-                          options:options
-                         priority:PINRemoteImageManagerPriorityDefault
-                     processorKey:processorKey
-                        processor:processor
-                    progressImage:nil
-                 progressDownload:progressDownload
-                       completion:completion
-                        inputUUID:nil];
+                              options:options
+                             priority:PINRemoteImageManagerPriorityDefault
+                         processorKey:processorKey
+                            processor:processor
+                        progressImage:nil
+                     progressDownload:progressDownload
+                           completion:completion
+                            inputUUID:nil];
 }
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -528,26 +528,9 @@ static dispatch_once_t sharedDispatchToken;
 {
     return [self downloadImageWithURL:url
                               options:options
-                             priority:PINRemoteImageManagerPriorityDefault
-                     progressDownload:progressDownload
-                           completion:completion];
-}
-
-- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
-                                  options:(PINRemoteImageManagerDownloadOptions)options
-                                 priority:(PINRemoteImageManagerPriority)priority
-                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
-                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
-{
-    return [self downloadImageWithURL:url
-                              options:options
-                             priority:priority
-                         processorKey:nil
-                            processor:nil
                         progressImage:nil
                      progressDownload:progressDownload
-                           completion:completion
-                            inputUUID:nil];
+                           completion:completion];
 }
 
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
@@ -559,6 +542,21 @@ static dispatch_once_t sharedDispatchToken;
     return [self downloadImageWithURL:url
                               options:options
                              priority:PINRemoteImageManagerPriorityDefault
+                        progressImage:progressImage
+                     progressDownload:progressDownload
+                           completion:completion];
+}
+
+- (nullable NSUUID *)downloadImageWithURL:(nonnull NSURL *)url
+                                  options:(PINRemoteImageManagerDownloadOptions)options
+                                 priority:(PINRemoteImageManagerPriority)priority
+                            progressImage:(PINRemoteImageManagerImageCompletion)progressImage
+                         progressDownload:(nullable PINRemoteImageManagerProgressDownload)progressDownload
+                               completion:(nullable PINRemoteImageManagerImageCompletion)completion;
+{
+    return [self downloadImageWithURL:url
+                              options:options
+                             priority:priority
                          processorKey:nil
                             processor:nil
                         progressImage:progressImage

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -171,8 +171,7 @@ static dispatch_once_t sharedDispatchToken;
     return [self initWithSessionConfiguration:configuration alternativeRepresentationProvider:nil];
 }
 
-- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration
-           alternativeRepresentationProvider:(id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepProvider
+- (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)configuration alternativeRepresentationProvider:(id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepProvider
 {
     return [self initWithSessionConfiguration:configuration alternativeRepresentationProvider:alternateRepProvider imageCache:nil];
 }

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -516,8 +516,8 @@ static dispatch_once_t sharedDispatchToken;
 {
     return [self downloadImageWithURL:url
                               options:options
-                             priority:PINRemoteImageManagerPriorityDefault
                         progressImage:progressImage
+                     progressDownload:nil
                            completion:completion];
 }
 

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -504,17 +504,6 @@ static dispatch_once_t sharedDispatchToken;
     });
 }
 
-- (void)enableNewDataTaskPriorityBehavior
-{
-    __weak typeof(self) weakSelf = self;
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        typeof(self) strongSelf = weakSelf;
-        [strongSelf lock];
-            [strongSelf.urlSessionTaskQueue enableNewDataTaskPriorityBehavior];
-        [strongSelf unlock];
-    });
-}
-
 - (NSUUID *)downloadImageWithURL:(NSURL *)url
                       completion:(PINRemoteImageManagerImageCompletion)completion
 {

--- a/Source/Classes/PINURLSessionManager.h
+++ b/Source/Classes/PINURLSessionManager.h
@@ -8,6 +8,8 @@
 
 #import <Foundation/Foundation.h>
 
+#import "PINRemoteImageManager.h"
+
 extern NSErrorDomain _Nonnull const PINURLErrorDomain;
 
 @protocol PINURLSessionManagerDelegate <NSObject>
@@ -29,7 +31,9 @@ typedef void (^PINURLSessionDataTaskCompletion)(NSURLSessionTask * _Nonnull task
 
 - (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration;
 
-- (nonnull NSURLSessionDataTask *)dataTaskWithRequest:(nonnull NSURLRequest *)request completionHandler:(nonnull PINURLSessionDataTaskCompletion)completionHandler;
+- (nonnull NSURLSessionDataTask *)dataTaskWithRequest:(nonnull NSURLRequest *)request
+                                             priority:(PINRemoteImageManagerPriority)priority
+                                    completionHandler:(nonnull PINURLSessionDataTaskCompletion)completionHandler;
 
 - (void)invalidateSessionAndCancelTasks;
 

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -48,10 +48,15 @@ NSErrorDomain const PINURLErrorDomain = @"PINURLErrorDomain";
     [self unlock];
 }
 
-- (nonnull NSURLSessionDataTask *)dataTaskWithRequest:(nonnull NSURLRequest *)request completionHandler:(nonnull PINURLSessionDataTaskCompletion)completionHandler
+- (nonnull NSURLSessionDataTask *)dataTaskWithRequest:(nonnull NSURLRequest *)request
+                                             priority:(PINRemoteImageManagerPriority)priority
+                                    completionHandler:(nonnull PINURLSessionDataTaskCompletion)completionHandler
 {
     [self lock];
         NSURLSessionDataTask *dataTask = [self.session dataTaskWithRequest:request];
+        if (@available(iOS 8.0, macOS 10.10, tvOS 9.0, watchOS 2.0, *)) {
+            dataTask.priority = dataTaskPriorityWithImageManagerPriority(priority);
+        }
         if (completionHandler) {
             [self.completions setObject:completionHandler forKey:@(dataTask.taskIdentifier)];
         }


### PR DESCRIPTION
Currently the priority is set after a task has been scheduled and potentially sent off. It means the priority may not be picked up at all. This diff adds a new behavior that sets the priority right after the task is created.

Also expose an API that allows the priority to be set by Texture.