### PR TITLE
Make configuring PINRemoteImageManager more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## master
 * Add your own contributions to the next release on the line below this with your name.
+- [new] Add PINRemoteImageManagerConfiguration configuration object [#492](https://github.com/pinterest/PINRemoteImage/pull/492) [rqueue](https://github.com/rqueue)
 
 ## 3.0.0 Beta 14
-- [new] Add PINRemoteImageManagerConfiguration configuration object [#492](https://github.com/pinterest/PINRemoteImage/pull/492) [rqueue](https://github.com/rqueue)
 - [new] Allow use of NSURLCache via a custom NSURLSession [#477](https://github.com/pinterest/PINRemoteImage/pull/477) [wiseoldduck](https://github.com/wiseoldduck)
 - [new] Respect Cache-Control and Expires headers if the cache supports TTL. [#462](https://github.com/pinterest/PINRemoteImage/pull/462) [wiseoldduck](https://github.com/wiseoldduck)
 - [new] Updated to latest PINCache beta 7. [#461](https://github.com/pinterest/PINRemoteImage/pull/461) [wiseoldduck](https://github.com/wiseoldduck)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add your own contributions to the next release on the line below this with your name.
 
 ## 3.0.0 Beta 14
+- [new] Add PINRemoteImageManagerConfiguration configuration object [#492](https://github.com/pinterest/PINRemoteImage/pull/492) [rqueue](https://github.com/rqueue)
 - [new] Allow use of NSURLCache via a custom NSURLSession [#477](https://github.com/pinterest/PINRemoteImage/pull/477) [wiseoldduck](https://github.com/wiseoldduck)
 - [new] Respect Cache-Control and Expires headers if the cache supports TTL. [#462](https://github.com/pinterest/PINRemoteImage/pull/462) [wiseoldduck](https://github.com/wiseoldduck)
 - [new] Updated to latest PINCache beta 7. [#461](https://github.com/pinterest/PINRemoteImage/pull/461) [wiseoldduck](https://github.com/wiseoldduck)

--- a/PINRemoteImage.xcodeproj/project.pbxproj
+++ b/PINRemoteImage.xcodeproj/project.pbxproj
@@ -430,6 +430,10 @@
 		68F0EA951CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.m in Sources */ = {isa = PBXBuildFile; fileRef = 68F0EA911CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.m */; };
 		926E01631F0DFEE100874D01 /* PINRequestRetryStrategy.h in Headers */ = {isa = PBXBuildFile; fileRef = 926E015C1F0DFCAE00874D01 /* PINRequestRetryStrategy.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		926E01641F0DFEE800874D01 /* PINRequestRetryStrategy.m in Sources */ = {isa = PBXBuildFile; fileRef = 926E015D1F0DFCAE00874D01 /* PINRequestRetryStrategy.m */; };
+		938E98D52224775600029E4D /* PINRemoteImageManagerConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 939546BE2220AF84006031BB /* PINRemoteImageManagerConfiguration.h */; };
+		938E98DA2224775B00029E4D /* PINRemoteImageManagerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 939546BF2220AF84006031BB /* PINRemoteImageManagerConfiguration.m */; };
+		939546C02220AF84006031BB /* PINRemoteImageManagerConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 939546BE2220AF84006031BB /* PINRemoteImageManagerConfiguration.h */; };
+		939546C12220AF84006031BB /* PINRemoteImageManagerConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = 939546BF2220AF84006031BB /* PINRemoteImageManagerConfiguration.m */; };
 		9DD47F9C1C699F4B00F12CA0 /* PINButton+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD47F981C699F4B00F12CA0 /* PINButton+PINRemoteImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9DD47F9D1C699F4B00F12CA0 /* PINButton+PINRemoteImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 9DD47F991C699F4B00F12CA0 /* PINButton+PINRemoteImage.m */; };
 		9DD47F9E1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.h in Headers */ = {isa = PBXBuildFile; fileRef = 9DD47F9A1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -767,6 +771,8 @@
 		68F0EA911CB32EC900F1FD41 /* PINRemoteImageMemoryContainer.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageMemoryContainer.m; sourceTree = "<group>"; };
 		926E015C1F0DFCAE00874D01 /* PINRequestRetryStrategy.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINRequestRetryStrategy.h; sourceTree = "<group>"; };
 		926E015D1F0DFCAE00874D01 /* PINRequestRetryStrategy.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINRequestRetryStrategy.m; sourceTree = "<group>"; };
+		939546BE2220AF84006031BB /* PINRemoteImageManagerConfiguration.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PINRemoteImageManagerConfiguration.h; sourceTree = "<group>"; };
+		939546BF2220AF84006031BB /* PINRemoteImageManagerConfiguration.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PINRemoteImageManagerConfiguration.m; sourceTree = "<group>"; };
 		9DD47F981C699F4B00F12CA0 /* PINButton+PINRemoteImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PINButton+PINRemoteImage.h"; sourceTree = "<group>"; };
 		9DD47F991C699F4B00F12CA0 /* PINButton+PINRemoteImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "PINButton+PINRemoteImage.m"; sourceTree = "<group>"; };
 		9DD47F9A1C699F4B00F12CA0 /* PINImageView+PINRemoteImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "PINImageView+PINRemoteImage.h"; sourceTree = "<group>"; };
@@ -1176,6 +1182,8 @@
 				F1B918DC1BCF23C800710963 /* PINRemoteImageCategoryManager.m */,
 				F1B918F51BCF23C800710963 /* PINRemoteImageManager.h */,
 				F1B918F61BCF23C800710963 /* PINRemoteImageManager.m */,
+				939546BE2220AF84006031BB /* PINRemoteImageManagerConfiguration.h */,
+				939546BF2220AF84006031BB /* PINRemoteImageManagerConfiguration.m */,
 				F1B918F71BCF23C800710963 /* PINRemoteImageManagerResult.h */,
 				F1B918F81BCF23C800710963 /* PINRemoteImageManagerResult.m */,
 				F1B918FD1BCF23C800710963 /* PINURLSessionManager.h */,
@@ -1328,6 +1336,7 @@
 				139D50A51F672BBF00DE64E0 /* PINImage+WebP.h in Headers */,
 				139D50A71F672BBF00DE64E0 /* PINRemoteImageTask+Subclassing.h in Headers */,
 				139D50A91F672BBF00DE64E0 /* PINRemoteImageCallbacks.h in Headers */,
+				938E98D52224775600029E4D /* PINRemoteImageManagerConfiguration.h in Headers */,
 				139D50AA1F672BBF00DE64E0 /* PINRemoteImageDownloadTask.h in Headers */,
 				68D734EB1F75FE4500B9C95D /* vp8li_dec.h in Headers */,
 				139D50AB1F672BBF00DE64E0 /* PINRemoteImageProcessorTask.h in Headers */,
@@ -1414,6 +1423,7 @@
 				F1B919001BCF23C900710963 /* NSData+ImageDetectors.h in Headers */,
 				687750111F6B08F7008748B0 /* color_cache_utils.h in Headers */,
 				F1B9191E1BCF23C900710963 /* PINURLSessionManager.h in Headers */,
+				939546C02220AF84006031BB /* PINRemoteImageManagerConfiguration.h in Headers */,
 				68774FDC1F6B08C7008748B0 /* animi.h in Headers */,
 				689613E0208FD8B700D2095C /* PINAnimatedImageView.h in Headers */,
 				687750271F6B2305008748B0 /* PINWebPAnimatedImage.h in Headers */,
@@ -1741,6 +1751,7 @@
 				68D734BE1F75FE3C00B9C95D /* lossless_enc_msa.c in Sources */,
 				68D734851F75FE3400B9C95D /* histogram_enc.c in Sources */,
 				68D734AF1F75FE3C00B9C95D /* enc_mips_dsp_r2.c in Sources */,
+				938E98DA2224775B00029E4D /* PINRemoteImageManagerConfiguration.m in Sources */,
 				68D734B51F75FE3C00B9C95D /* enc.c in Sources */,
 				68D734B81F75FE3C00B9C95D /* filters_neon.c in Sources */,
 				689613E7208FD90B00D2095C /* PINDisplayLink.m in Sources */,
@@ -1911,6 +1922,7 @@
 				68774FB81F6B08B2008748B0 /* analysis_enc.c in Sources */,
 				68774EFD1F6B0871008748B0 /* frame_dec.c in Sources */,
 				68774EFF1F6B0871008748B0 /* io_dec.c in Sources */,
+				939546C12220AF84006031BB /* PINRemoteImageManagerConfiguration.m in Sources */,
 				68774FCB1F6B08B2008748B0 /* predictor_enc.c in Sources */,
 				68774FC91F6B08B2008748B0 /* picture_rescale_enc.c in Sources */,
 				689613E6208FD90B00D2095C /* PINDisplayLink.m in Sources */,

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -14,14 +14,16 @@
 #import <Cocoa/Cocoa.h>
 #endif
 
-@protocol PINRequestRetryStrategy;
 #import "PINRemoteImageMacros.h"
-
 #import "PINRemoteImageManagerResult.h"
+
+#define PINRemoteImageHTTPMaximumConnectionsPerHost UINT16_MAX
 
 @protocol PINRemoteImageManagerAlternateRepresentationProvider;
 @protocol PINRemoteImageCaching;
+@protocol PINRequestRetryStrategy;
 
+@class PINRemoteImageManagerConfiguration;
 @class PINRemoteImageManagerResult;
 
 extern NSErrorDomain _Nonnull const PINRemoteImageManagerErrorDomain;
@@ -163,30 +165,43 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
 
 /**
  Create and return a PINRemoteImageManager created with the specified configuration. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc.
- @param configuration The configuration used to create the PINRemoteImageManager.
+ @param sessionConfiguration The session configuration used to create the PINRemoteImageManager.
  @return A PINRemoteImageManager with the specified configuration.
  */
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration;
+- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration;
 
 /**
  Create and return a PINRemoteImageManager with the specified configuration and alternative representation delegate. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc. If alternativeRepresentationProvider is nil, the default is used (and supports PINAnimatedImageView).
- @param configuration The configuration used to create the PINRemoteImageManager.
+ @param sessionConfiguration The session configuration used to create the PINRemoteImageManager.
  @param alternativeRepresentationProvider a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
  @return A PINRemoteImageManager with the specified configuration.
  */
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
+- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration
                    alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternativeRepresentationProvider;
 
 /**
  Create and return a PINRemoteImageManager with the specified configuration and alternative representation delegate. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc. If alternativeRepresentationProvider is nil, the default is used (and supports PINAnimatedImageView).
- @param configuration The configuration used to create the PINRemoteImageManager.
+ @param sessionConfiguration The session configuration used to create the PINRemoteImageManager.
  @param alternateRepDelegate a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
  @param imageCache  Optional delegate which conforms to the PINRemoteImageCaching protocol. Provide a delegate if you want to control image caching. By default, image manager will use most appropriate implementation available (based on PINCache or NSCache, depending on subspec)@see PINRemoteImageBasicCache for an example.
  @return A PINRemoteImageManager with the specified configuration.
  */
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)configuration
+- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration
                    alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache NS_DESIGNATED_INITIALIZER;
+                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache;
+
+/**
+ Create and return a PINRemoteImageManager with the specified configuration and alternative representation delegate. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc. If alternativeRepresentationProvider is nil, the default is used (and supports PINAnimatedImageView).
+ @param sessionConfiguration The session configuration used to create the PINRemoteImageManager.
+ @param alternateRepDelegate a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
+ @param imageCache  Optional delegate which conforms to the PINRemoteImageCaching protocol. Provide a delegate if you want to control image caching. By default, image manager will use most appropriate implementation available (based on PINCache or NSCache, depending on subspec)@see PINRemoteImageBasicCache for an example.
+ @param configuration The configuration used to create the PINRemoteImageManager.
+ @return A PINRemoteImageManager with the specified configuration.
+ */
+- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration
+                   alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
+                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache
+                                       configuration:(nonnull PINRemoteImageManagerConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /**
  Get the shared instance of PINRemoteImageManager

--- a/Source/Classes/PINRemoteImageManager.h
+++ b/Source/Classes/PINRemoteImageManager.h
@@ -184,24 +184,13 @@ typedef void(^PINRemoteImageManagerMetrics)(NSURL  * __nonnull url, NSURLSession
  @param sessionConfiguration The session configuration used to create the PINRemoteImageManager.
  @param alternateRepDelegate a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
  @param imageCache  Optional delegate which conforms to the PINRemoteImageCaching protocol. Provide a delegate if you want to control image caching. By default, image manager will use most appropriate implementation available (based on PINCache or NSCache, depending on subspec)@see PINRemoteImageBasicCache for an example.
- @return A PINRemoteImageManager with the specified configuration.
- */
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration
-                   alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache;
-
-/**
- Create and return a PINRemoteImageManager with the specified configuration and alternative representation delegate. If configuration is nil, [NSURLSessionConfiguration defaultConfiguration] is used. Specify a custom configuration if you need to configure timeout values, cookie policies, additional HTTP headers, etc. If alternativeRepresentationProvider is nil, the default is used (and supports PINAnimatedImageView).
- @param sessionConfiguration The session configuration used to create the PINRemoteImageManager.
- @param alternateRepDelegate a delegate which conforms to the PINRemoteImageManagerAlternateRepresentationProvider protocol. Provide a delegate if you want to have non image results. The manager maintains a weak reference to the delegate. @see PINRemoteImageManagerAlternateRepresentationProvider for an example.
- @param imageCache  Optional delegate which conforms to the PINRemoteImageCaching protocol. Provide a delegate if you want to control image caching. By default, image manager will use most appropriate implementation available (based on PINCache or NSCache, depending on subspec)@see PINRemoteImageBasicCache for an example.
- @param configuration The configuration used to create the PINRemoteImageManager.
+ @param managerConfiguration The configuration used to create the PINRemoteImageManager.
  @return A PINRemoteImageManager with the specified configuration.
  */
 - (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration
                    alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepDelegate
                                           imageCache:(nullable id<PINRemoteImageCaching>)imageCache
-                                       configuration:(nonnull PINRemoteImageManagerConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
+                                managerConfiguration:(nullable PINRemoteImageManagerConfiguration *)managerConfiguration NS_DESIGNATED_INITIALIZER;
 
 /**
  Get the shared instance of PINRemoteImageManager

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -174,23 +174,20 @@ static dispatch_once_t sharedDispatchToken;
 
 - (instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration alternativeRepresentationProvider:(id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepProvider
 {
-    return [self initWithSessionConfiguration:sessionConfiguration alternativeRepresentationProvider:alternateRepProvider imageCache:nil];
-}
-
-- (nonnull instancetype)initWithSessionConfiguration:(nullable NSURLSessionConfiguration *)sessionConfiguration
-                   alternativeRepresentationProvider:(nullable id <PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepProvider
-                                          imageCache:(nullable id<PINRemoteImageCaching>)imageCache
-{
-    PINRemoteImageManagerConfiguration *configuration = [[PINRemoteImageManagerConfiguration alloc] init];
-    return [self initWithSessionConfiguration:sessionConfiguration alternativeRepresentationProvider:alternateRepProvider imageCache:imageCache configuration:configuration];
+    return [self initWithSessionConfiguration:sessionConfiguration alternativeRepresentationProvider:alternateRepProvider imageCache:nil managerConfiguration:nil];
 }
 
 -(nonnull instancetype)initWithSessionConfiguration:(NSURLSessionConfiguration *)sessionConfiguration
                   alternativeRepresentationProvider:(id<PINRemoteImageManagerAlternateRepresentationProvider>)alternateRepProvider
                                          imageCache:(id<PINRemoteImageCaching>)imageCache
-                                      configuration:(nonnull PINRemoteImageManagerConfiguration *)configuration
+                               managerConfiguration:(nullable PINRemoteImageManagerConfiguration *)managerConfiguration
 {
     if (self = [super init]) {
+        PINRemoteImageManagerConfiguration *configuration = managerConfiguration;
+        if (!configuration) {
+            configuration = [[PINRemoteImageManagerConfiguration alloc] init];
+        }
+        
         if (imageCache) {
             self.cache = imageCache;
         } else if (PINRemoteImageManagerSubclassOverridesSelector([self class], @selector(defaultImageCache))) {

--- a/Source/Classes/PINRemoteImageManagerConfiguration.h
+++ b/Source/Classes/PINRemoteImageManagerConfiguration.h
@@ -1,0 +1,44 @@
+//
+//  PINRemoteImageManagerConfiguration.h
+//  Pods
+//
+//  Created by Ryan Quan on 2/22/19.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+#if PIN_TARGET_IOS
+#import <UIKit/UIKit.h>
+#elif PIN_TARGET_MAC
+#import <Cocoa/Cocoa.h>
+#endif
+
+/** A configuration object used to customize a PINRemoteImageManager instance **/
+@interface PINRemoteImageManagerConfiguration : NSObject
+
+/** The maximum number of concurrent operations. Defaults to NSOperationQueueDefaultMaxConcurrentOperationCount. */
+@property (nonatomic, readwrite, assign) NSUInteger maxConcurrentOperations;
+
+/** The maximum number of concurrent downloads. Defaults to 10, maximum 65535. */
+@property (nonatomic, readwrite, assign) NSUInteger maxConcurrentDownloads;
+
+/** The estimated remaining time threshold used to decide to skip progressive rendering. Defaults to 0.1. */
+@property (nonatomic, readwrite, assign) NSTimeInterval estimatedRemainingTimeThreshold;
+
+/** A bool value indicating whether PINRemoteImage should blur progressive render results */
+@property (nonatomic, readwrite, assign) BOOL shouldBlurProgressive;
+
+/** A CGSize which indicates the max size PINRemoteImage will render a progressive image. If an image is larger in either dimension, progressive rendering will be skipped */
+@property (nonatomic, readwrite, assign) CGSize maxProgressiveRenderSize;
+
+/** The minimum BPS to download the highest quality image in a set. */
+@property (nonatomic, readwrite, assign) float highQualityBPSThreshold;
+
+/** The maximum BPS to download the lowest quality image in a set. */
+@property (nonatomic, readwrite, assign) float lowQualityBPSThreshold;
+
+/** Whether high quality images should be downloaded when a low quality image is cached if network connectivity has improved. */
+@property (nonatomic, readwrite, assign) BOOL shouldUpgradeLowQualityImages;
+
+@end

--- a/Source/Classes/PINRemoteImageManagerConfiguration.m
+++ b/Source/Classes/PINRemoteImageManagerConfiguration.m
@@ -20,7 +20,7 @@
         _shouldBlurProgressive = YES;
         _maxProgressiveRenderSize = CGSizeMake(1024, 1024);
         _highQualityBPSThreshold = 500000;
-        _lowQualityBPSThreshold = 500000; // approximately edge speed
+        _lowQualityBPSThreshold = 50000; // approximately edge speed
         _shouldUpgradeLowQualityImages = NO;
     }
     return self;

--- a/Source/Classes/PINRemoteImageManagerConfiguration.m
+++ b/Source/Classes/PINRemoteImageManagerConfiguration.m
@@ -1,0 +1,36 @@
+//
+//  PINRemoteImageManagerConfiguration.m
+//  Pods
+//
+//  Created by Ryan Quan on 2/22/19.
+//
+//
+
+#import "PINRemoteImageManagerConfiguration.h"
+
+#import "PINRemoteImageManager.h"
+
+@implementation PINRemoteImageManagerConfiguration
+
+- (nonnull instancetype)init {
+    if (self = [super init]) {
+        _maxConcurrentOperations = [[NSProcessInfo processInfo] activeProcessorCount] * 2;
+        _maxConcurrentDownloads = 10;
+        _estimatedRemainingTimeThreshold = 0.1;
+        _shouldBlurProgressive = YES;
+        _maxProgressiveRenderSize = CGSizeMake(1024, 1024);
+        _highQualityBPSThreshold = 500000;
+        _lowQualityBPSThreshold = 500000; // approximately edge speed
+        _shouldUpgradeLowQualityImages = NO;
+    }
+    return self;
+}
+
+#pragma mark - Setters
+
+- (void)setMaxConcurrentDownloads:(NSUInteger)maxConcurrentDownloads {
+    NSAssert(maxConcurrentDownloads <= PINRemoteImageHTTPMaximumConnectionsPerHost, @"maxNumberOfConcurrentDownloads must be less than or equal to %d", PINRemoteImageHTTPMaximumConnectionsPerHost);
+    _maxConcurrentDownloads = maxConcurrentDownloads;
+}
+
+@end

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -946,7 +946,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 
 - (void)testCacheControlSupport
 {
-    self.imageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil alternativeRepresentationProvider:nil imageCache:[PINRemoteImageManager defaultImageTtlCache]];
+    self.imageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil alternativeRepresentationProvider:nil imageCache:[PINRemoteImageManager defaultImageTtlCache] managerConfiguration:nil];
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
     id cache = self.imageManager.cache;
     XCTAssert([cache isKindOfClass:[PINCache class]]);


### PR DESCRIPTION
This commit adds a way to configure the PINRemoteImageManager upon
initialization via a PINRemoteImageManagerConfiguration object. This provides:
- An easy way to see default values of customizable properties
- Customization upon initialization (the "set" methods are dispatched asynchronously)