### PR TITLE
Fix compile errors when using Makefile

### DIFF
--- a/PINRemoteImage.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/PINRemoteImage.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>


### PR DESCRIPTION
There were random compile errors happening when using xcode 10 to compile via
the Makefile (like doing `make test`). This is related to the new build system
in xcode 10 and is suspected to be happening because of some sort of race
condition during compilation. The error revolved around multiple Targets
creating the same directories for framework dependencies. I have a feeling this
needs to be solved by Carthage since it sets up the dependencies, but as an
immediate solution we can set the build settings to use the legacy build
system.