### PR TITLE
use frame size for data provider

### DIFF
--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -171,7 +171,7 @@ static void releaseData(void *info, const void *data, size_t size)
     }
     
     if (data) {
-        CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, data, _width * _height * pixelLength, releaseData);
+        CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, data, iterator.width * iterator.height * pixelLength, releaseData);
         
         CGColorSpaceRef colorSpaceRef = CGColorSpaceCreateDeviceRGB();
         CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;


### PR DESCRIPTION
frames can be of different size. (at least for my case). I am not sure if that's not valid format of webp. If it's valid this pr fix that. 