### PR TITLE
Fix webp animated image frame over lapping

### DIFF
--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -171,7 +171,7 @@ static void releaseData(void *info, const void *data, size_t size)
     }
     
     if (data) {
-        CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, data, _width * _height * pixelLength, releaseData);
+        CGDataProviderRef provider = CGDataProviderCreateWithData(NULL, data, iterator.width * iterator.height * pixelLength, releaseData);
         
         CGColorSpaceRef colorSpaceRef = CGColorSpaceCreateDeviceRGB();
         CGBitmapInfo bitmapInfo = kCGBitmapByteOrderDefault;

--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -240,7 +240,7 @@ static void releaseData(void *info, const void *data, size_t size)
             // If we have a cached image provider, try to get the last frame from them
             CGImageRef previousFrame = [cacheProvider cachedFrameImageAtIndex:index - 1];
             if (previousFrame) {
-                canvas = [self canvasWithPreviousFrame:previousFrame image:imageRef atRect:CGRectMake(iterator.x_offset, iterator.y_offset, iterator.width, iterator.height)];
+                canvas = [self canvasWithPreviousFrame:nil image:imageRef atRect:CGRectMake(iterator.x_offset, iterator.y_offset, iterator.width, iterator.height)];
             } else if (index > 0) {
                 // Sadly, we need to draw *all* the frames from the previous key frame previousIterator to the current one :(
                 CGColorSpaceRef colorSpaceRef = CGColorSpaceCreateDeviceRGB();


### PR DESCRIPTION
The webp interpreter is trying to draw both previous and current frame to context resulting:
![Image_11](https://user-images.githubusercontent.com/5335780/57111062-96882880-6cef-11e9-8df4-23324dfb7fd2.png)
https://lh3.googleusercontent.com/z2B73tA2ofYnFho0sj2KEQpze1fYY7RFSh5Wa9uElu67vF0R6wB59S2Roe3mzqbca5VHA2EaTTmEjtIxyeN9=s208-rwa