### PR TITLE
#trivial Invalidate sessionManager when remoteImageManager deallocated

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -259,6 +259,11 @@ static dispatch_once_t sharedDispatchToken;
     return [[PINRequestExponentialRetryStrategy alloc] initWithRetryMaxCount:3 delayBase:4];
 }
 
+- (void)dealloc
+{
+    [self.sessionManager invalidateSessionAndCancelTasks];
+}
+
 - (id<PINRemoteImageCaching>)defaultImageCache {
     return [PINRemoteImageManager defaultImageCache];
 }

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -263,6 +263,23 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     XCTAssert([self.imageManager.sessionManager.session.configuration.HTTPAdditionalHeaders isEqualToDictionary:@{ @"Authorization" : @"Pinterest 123456" }]);
 }
 
+- (void)testURLSessionManagerDeallocated
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"URLSessionManager should be deallocated"];
+    __block __weak PINURLSessionManager *sessionManager = nil;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        PINRemoteImageManager *manager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil];
+        sessionManager = manager.sessionManager;
+    });
+    
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        XCTAssert(sessionManager == nil);
+        [expectation fulfill];
+    });
+    
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
 - (void)testCustomHeaderIsAddedToImageRequests
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Custom header was added to image request"];


### PR DESCRIPTION
`PINURLSessionManager` has a retain cycle by `NSURLSession`'s delegate, let's break it when imageManager deallocated.