### PR TITLE
Set bpp(bits per pixel) to 32 bit for GIF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [new] Add PINRemoteImageManagerConfiguration configuration object. [#492](https://github.com/pinterest/PINRemoteImage/pull/492) [rqueue](https://github.com/rqueue)
 - [fixed] Fixes blending in animated WebP images. [#507](https://github.com/pinterest/PINRemoteImage/pull/507) [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes support in PINAnimatedImageView for WebP animated images. [#507](https://github.com/pinterest/PINRemoteImage/pull/507) [garrettmoon](https://github.com/garrettmoon)
+- [fixed] Set bpp(bits per pixel) to 32 bit for GIF. [#511](https://github.com/pinterest/PINRemoteImage/pull/511) [zhongwuzw](https://github.com/zhongwuzw)
 
 ## 3.0.0 Beta 14
 - [fixed] Re-enable warnings check [#506](https://github.com/pinterest/PINRemoteImage/pull/506) [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
@@ -130,7 +130,7 @@
 
 - (uint32_t)bytesPerFrame
 {
-    return _width * _height * 3;
+    return _width * _height * 4;
 }
 
 - (NSError *)error

--- a/Tests/PINAnimatedImageTests.swift
+++ b/Tests/PINAnimatedImageTests.swift
@@ -132,4 +132,27 @@ class PINAnimatedImageTests: XCTestCase, PINRemoteImageManagerAlternateRepresent
         }
         self.waitForExpectations(timeout: self.timeoutInterval(), handler: nil)
     }
+    
+    func testGIFBytes() {
+        let animatedExpectation =  self.expectation(description: "Animated image should be downloaded")
+        let imageManager = PINRemoteImageManager.init(sessionConfiguration: nil, alternativeRepresentationProvider: self)
+        imageManager.downloadImage(with: self.slowAnimatedGIFURL()!) { (result : PINRemoteImageManagerResult) in
+            XCTAssert(result.image == nil)
+            guard let animatedData = result.alternativeRepresentation as? NSData else {
+                XCTAssert(false, "alternativeRepresentation should be able to be coerced into data")
+                return
+            }
+            
+            XCTAssert(animatedData.pin_isGIF() && animatedData.pin_isAnimatedGIF())
+            
+            let pinCachedAnimatedImage = PINGIFAnimatedImage(animatedImageData: animatedData as Data)!
+            let bytesSize = UInt32((pinCachedAnimatedImage.image(at: 0, cacheProvider: nil)!.takeUnretainedValue() as CGImage).bytesPerRow) * pinCachedAnimatedImage.height
+
+            XCTAssert(pinCachedAnimatedImage.bytesPerFrame <= bytesSize)
+            
+            animatedExpectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: self.timeoutInterval(), handler: nil)
+    }
 }

--- a/Tests/PINAnimatedImageTests.swift
+++ b/Tests/PINAnimatedImageTests.swift
@@ -148,7 +148,7 @@ class PINAnimatedImageTests: XCTestCase, PINRemoteImageManagerAlternateRepresent
             let pinCachedAnimatedImage = PINGIFAnimatedImage(animatedImageData: animatedData as Data)!
             let bytesSize = UInt32((pinCachedAnimatedImage.image(at: 0, cacheProvider: nil)!.takeUnretainedValue() as CGImage).bytesPerRow) * pinCachedAnimatedImage.height
 
-            XCTAssert(pinCachedAnimatedImage.bytesPerFrame <= bytesSize)
+            XCTAssert(pinCachedAnimatedImage.bytesPerFrame == bytesSize)
             
             animatedExpectation.fulfill()
         }


### PR DESCRIPTION
For 8bpc and RGB color space, it's always 32bits per pixel. We can also use `CGImageGetBytesPerRow(imageRef) * _height`.

<img width="842" alt="image" src="https://user-images.githubusercontent.com/5061845/60766508-77d25380-a0dd-11e9-9d15-8fddf563ff1e.png">
