### PR TITLE
#trivial Return nil if webp or gif's data not valid

### DIFF
--- a/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
@@ -16,6 +16,7 @@
 #endif
 
 #import "PINImage+DecodedImage.h"
+#import "NSData+ImageDetectors.h"
 
 @interface PINGIFAnimatedImage ()
 {
@@ -43,7 +44,7 @@
                                                                (__bridge NSString *)kUTTypeGIF,
                                                            (__bridge NSString *)kCGImageSourceShouldCache:
                                                                (__bridge NSNumber *)kCFBooleanFalse});
-        if (_imageSource) {
+        if (_imageSource && [animatedImageData pin_isGIF]) {
             _frameCount = (uint32_t)CGImageSourceGetCount(_imageSource);
             NSDictionary *imageProperties = (__bridge_transfer NSDictionary *)CGImageSourceCopyProperties(_imageSource, nil);
             _loopCount = (uint32_t)[[[imageProperties objectForKey:(__bridge NSString *)kCGImagePropertyGIFDictionary]

--- a/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
@@ -60,6 +60,8 @@
             for (NSUInteger frameIdx = 0; frameIdx < _frameCount; frameIdx++) {
                 _durations[frameIdx] = [PINGIFAnimatedImage frameDurationAtIndex:frameIdx source:_imageSource];
             }
+        } else {
+            return nil;
         }
     }
     return self;

--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -72,6 +72,8 @@ static void releaseData(void *info, const void *data, size_t size)
                 } while (WebPDemuxNextFrame(&iter));
                 WebPDemuxReleaseIterator(&iter);
             }
+        } else {
+            return nil;
         }
     }
     return self;

--- a/Tests/PINAnimatedImageTests.swift
+++ b/Tests/PINAnimatedImageTests.swift
@@ -132,4 +132,13 @@ class PINAnimatedImageTests: XCTestCase, PINRemoteImageManagerAlternateRepresent
         }
         self.waitForExpectations(timeout: self.timeoutInterval(), handler: nil)
     }
+    
+    func testInvalidAnimatedData() {
+        let data = "AA".data(using: .ascii)
+        let gifAnimatedImage = PINGIFAnimatedImage(animatedImageData: data)
+        XCTAssert(gifAnimatedImage == nil)
+        
+        let webpAnimatedImage = PINWebPAnimatedImage(animatedImageData: data)
+        XCTAssert(webpAnimatedImage == nil)
+    }
 }


### PR DESCRIPTION
Prevent crash if `animatedImageData` is not valid, we just return `nil` rather than return invalid `PINGIF/WebPAnimatedImage` instance. 