### PR TITLE
Exposure didCompleteTask:withError: delegate method of protocol PINURLSessionManagerDelegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [new] Add PINRemoteImageManagerConfiguration configuration object. [#492](https://github.com/pinterest/PINRemoteImage/pull/492) [rqueue](https://github.com/rqueue)
 - [fixed] Fixes blending in animated WebP images. [#507](https://github.com/pinterest/PINRemoteImage/pull/507) [garrettmoon](https://github.com/garrettmoon)
 - [fixed] Fixes support in PINAnimatedImageView for WebP animated images. [#507](https://github.com/pinterest/PINRemoteImage/pull/507) [garrettmoon](https://github.com/garrettmoon)
+- [new] Exposure didCompleteTask:withError: delegate method of protocol PINURLSessionManagerDelegate. [#519](https://github.com/pinterest/PINRemoteImage/pull/519) [zhongwuzw](https://github.com/zhongwuzw)
 
 ## 3.0.0 Beta 14
 - [fixed] Re-enable warnings check [#506](https://github.com/pinterest/PINRemoteImage/pull/506) [garrettmoon](https://github.com/garrettmoon)

--- a/Source/Classes/PINURLSessionManager.h
+++ b/Source/Classes/PINURLSessionManager.h
@@ -21,7 +21,7 @@ extern NSErrorDomain _Nonnull const PINURLErrorDomain;
 - (void)didCollectMetrics:(nonnull NSURLSessionTaskMetrics *)metrics forURL:(nonnull NSURL *)url API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 - (void)didReceiveResponse:(nonnull NSURLResponse *)response forTask:(nonnull NSURLSessionTask *)task;
 - (void)didReceiveAuthenticationChallenge:(nonnull NSURLAuthenticationChallenge *)challenge forTask:(nullable NSURLSessionTask *)task completionHandler:(nonnull void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential  * _Nullable credential))completionHandler;
-
+- (void)didCompleteTask:(NSURLSessionTask *)task withError:(NSError *)error;
 
 @end
 

--- a/Source/Classes/PINURLSessionManager.h
+++ b/Source/Classes/PINURLSessionManager.h
@@ -21,7 +21,7 @@ extern NSErrorDomain _Nonnull const PINURLErrorDomain;
 - (void)didCollectMetrics:(nonnull NSURLSessionTaskMetrics *)metrics forURL:(nonnull NSURL *)url API_AVAILABLE(macosx(10.12), ios(10.0), watchos(3.0), tvos(10.0));
 - (void)didReceiveResponse:(nonnull NSURLResponse *)response forTask:(nonnull NSURLSessionTask *)task;
 - (void)didReceiveAuthenticationChallenge:(nonnull NSURLAuthenticationChallenge *)challenge forTask:(nullable NSURLSessionTask *)task completionHandler:(nonnull void (^)(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential  * _Nullable credential))completionHandler;
-- (void)didCompleteTask:(NSURLSessionTask *)task withError:(NSError *)error;
+- (void)didCompleteTask:(nonnull NSURLSessionTask *)task withError:(nullable NSError *)error;
 
 @end
 

--- a/Source/Classes/PINURLSessionManager.m
+++ b/Source/Classes/PINURLSessionManager.m
@@ -201,6 +201,10 @@ NSErrorDomain const PINURLErrorDomain = @"PINURLErrorDomain";
         if (completionHandler) {
             completionHandler(task, error);
         }
+        
+        if ([strongSelf.delegate respondsToSelector:@selector(didCompleteTask:withError:)]) {
+            [strongSelf.delegate didCompleteTask:task withError:error];
+        }
     });
 }
 

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -211,6 +211,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 {
     self.task = task;
     self.error = error;
+    // Used for URLSessionDidCompleteDelegate test
     if (self.sessionDidCompleteDelegateSemaphore) {
         dispatch_semaphore_signal(self.sessionDidCompleteDelegateSemaphore);
     }
@@ -231,6 +232,9 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     self.imageManager = nil;
     [[PINSpeedRecorder sharedRecorder] setCurrentBytesPerSecond:-1];
     [[PINSpeedRecorder sharedRecorder] resetMeasurements];
+    if (self.sessionDidCompleteDelegateSemaphore) {
+        self.sessionDidCompleteDelegateSemaphore = nil;
+    }
     [super tearDown];
 }
 


### PR DESCRIPTION
After we exposure `didCompleteTask:withError:` method, user can have a global monitor that task finished success or fail.