### PR TITLE
Removes the optimization to reduce the display links frame interval

### DIFF
--- a/Source/Classes/AnimatedImages/PINAnimatedImageView.m
+++ b/Source/Classes/AnimatedImages/PINAnimatedImageView.m
@@ -211,14 +211,10 @@
     if ([self canBeVisible] == NO) {
         return;
     }
-    
-    // Get frame interval before holding display link lock to avoid deadlock
-    NSUInteger frameInterval = self.animatedImage.frameInterval;
 
     if (_displayLink == nil) {
         _playHead = 0;
         _displayLink = [PINDisplayLink displayLinkWithTarget:[PINRemoteWeakProxy weakProxyWithTarget:self] selector:@selector(displayLinkFired:)];
-        _displayLink.frameInterval = frameInterval;
         _lastSuccessfulFrameIndex = NSUIntegerMax;
         
         [_displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:self.animatedImageRunLoopMode];
@@ -361,7 +357,7 @@
         _playHead = 0;
         _playedLoops++;
     }
-    
+  
     if (self.animatedImage.loopCount > 0 && _playedLoops >= self.animatedImage.loopCount) {
         [self stopAnimating];
         return;


### PR DESCRIPTION
The idea behind this optimization was to reduce the number of calls the display
link would need for animated images which didn't draw every frame. But this
has resulted in frames being dropped in certain cases where frameInterval isn't
respected (see https://i.pinimg.com/originals/58/9c/e8/589ce828d2ef0797da0e85b1c6d2f2b3.gif)

Since the the display link fire method continues if we detect we're
at the same image index as before, let's just remove this optimization.