### PR TITLE
Fix memory cache content in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ __weak UIImageView *weakImageView = self.imageView;
 // cache is an instance of PINCache as long as you haven't overridden defaultImageCache
 PINCache *cache = (PINCache *)[[PINRemoteImageManager sharedImageManager] cache];
 // Max memory cost is based on number of pixels, we estimate the size of one hundred 600x600 images as our max memory image cache.
-[[cache memoryCache] setCostLimit:600 * 600 * 100 * [[UIScreen mainScreen] scale]];
+[[cache memoryCache] setCostLimit:600 * [[UIScreen mainScreen] scale] * 600 * [[UIScreen mainScreen] scale] * 100];
 
 // ~50 MB
 [[cache diskCache] setByteLimit:50 * 1024 * 1024];


### PR DESCRIPTION
> we estimate the size of one hundred 600x600 images as our max memory image cache.

`600pt x 600pt`

You have to multiply the scale by both width and height.