### PR TITLE
#trivial Fix performance issue caused by saving encoded image data to memory cache

### DIFF
--- a/Source/Classes/PINCache/PINCache+PINRemoteImageCaching.m
+++ b/Source/Classes/PINCache/PINCache+PINRemoteImageCaching.m
@@ -59,7 +59,7 @@
 
 - (void)setObjectOnDisk:(id)object forKey:(NSString *)key
 {
-    [self setObject:object forKey:key withAgeLimit:0];
+    [self.diskCache setObject:object forKey:key withAgeLimit:0];
 }
 
 - (BOOL)objectExistsForKey:(NSString *)key


### PR DESCRIPTION
Saving disk data to memory cache causes image decoding on main thread (when early return), which may cause serious performance issues.