### PR TITLE
#trivial Fix: Download fail when using processor with GIF image

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -776,7 +776,7 @@ static dispatch_once_t sharedDispatchToken;
         
         __weak typeof(self) weakSelf = self;
         NSUUID *downloadTaskUUID = [self downloadImageWithURL:url
-                                                      options:options | PINRemoteImageManagerDownloadOptionsSkipEarlyCheck
+                                                      options:options | PINRemoteImageManagerDownloadOptionsSkipEarlyCheck | PINRemoteImageManagerDisallowAlternateRepresentations
                                                    completion:^(PINRemoteImageManagerResult *result)
         {
             typeof(self) strongSelf = weakSelf;


### PR DESCRIPTION
Before: Since GIF image become alternate representation, processor can't get an UIImage/NSImage to process, a `PINRemoteImageManagerErrorFailedToFetchImageForProcessing` error is returned.

This Fix: Disallow alternate representation when obtaining the image for processing.