### PR TITLE
Integrated UIGraphicsImageRenderer for iOS/tvOS 10.0 and above

### DIFF
--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -16,6 +16,49 @@
 
 #import "NSData+ImageDetectors.h"
 
+NS_INLINE BOOL pin_CGImageRefIsOpaque(CGImageRef imageRef) {
+    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
+    switch (alpha) {
+        case kCGImageAlphaNone:
+        case kCGImageAlphaNoneSkipLast:
+        case kCGImageAlphaNoneSkipFirst:
+            return YES;
+        default:
+            return NO;
+    }
+}
+
+#if PIN_TARGET_IOS
+NS_INLINE void pin_degreesFromOrientation(UIImageOrientation orientation, void (^completion)(CGFloat degrees, BOOL horizontalFlip, BOOL verticalFlip)) {
+    switch (orientation) {
+        case UIImageOrientationUp: // default orientation
+            completion(0.0, NO, NO);
+            break;
+        case UIImageOrientationDown: // 180 deg rotation
+            completion(180.0, NO, NO);
+            break;
+        case UIImageOrientationLeft:
+            completion(270.0, NO, NO); // 90 deg CCW
+            break;
+        case UIImageOrientationRight:
+            completion(90.0, NO, NO); // 90 deg CW
+            break;
+        case UIImageOrientationUpMirrored: // as above but image mirrored along other axis. horizontal flip
+            completion(0.0, YES, NO);
+            break;
+        case UIImageOrientationDownMirrored: // horizontal flip
+            completion(180.0, YES, NO);
+            break;
+        case UIImageOrientationLeftMirrored: // vertical flip
+            completion(270.0, NO, YES);
+            break;
+        case UIImageOrientationRightMirrored: // vertical flip
+            completion(90.0, NO, YES);
+            break;
+    }
+}
+#endif
+
 #if !PIN_TARGET_IOS
 @implementation NSImage (PINiOSMapping)
 
@@ -277,47 +320,6 @@ UIImageOrientation pin_UIImageOrientationFromImageSource(CGImageSourceRef imageS
     return orientation;
 }
 
-void pin_degreesFromOrientation(UIImageOrientation orientation, void (^completion)(CGFloat degrees, BOOL horizontalFlip, BOOL verticalFlip)) {
-    switch (orientation) {
-        case UIImageOrientationUp: // default orientation
-            completion(0.0, NO, NO);
-            break;
-        case UIImageOrientationDown: // 180 deg rotation
-            completion(180.0, NO, NO);
-            break;
-        case UIImageOrientationLeft:
-            completion(270.0, NO, NO); // 90 deg CCW
-            break;
-        case UIImageOrientationRight:
-            completion(90.0, NO, NO); // 90 deg CW
-            break;
-        case UIImageOrientationUpMirrored: // as above but image mirrored along other axis. horizontal flip
-            completion(0.0, YES, NO);
-            break;
-        case UIImageOrientationDownMirrored: // horizontal flip
-            completion(180.0, YES, NO);
-            break;
-        case UIImageOrientationLeftMirrored: // vertical flip
-            completion(270.0, NO, YES);
-            break;
-        case UIImageOrientationRightMirrored: // vertical flip
-            completion(90.0, NO, YES);
-            break;
-    }
-}
-
 #endif
-
-BOOL pin_CGImageRefIsOpaque(CGImageRef imageRef) {
-    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
-    switch (alpha) {
-        case kCGImageAlphaNone:
-        case kCGImageAlphaNoneSkipLast:
-        case kCGImageAlphaNoneSkipFirst:
-            return YES;
-        default:
-            return NO;
-    }
-}
 
 @end

--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -126,23 +126,76 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 {
 #endif
 #if PIN_TARGET_IOS
-    return [UIImage imageWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] scale:1.0 orientation:orientation];
+    if (@available(iOS 10.0, *)) {
+        return [self pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:imageRef scale:1.0 orientation:orientation];
+    } else {
+        return [UIImage imageWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] scale:1.0 orientation:orientation];
+    }
 #elif PIN_TARGET_MAC
     return [[NSImage alloc] initWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] size:NSZeroSize];
 #endif
 }
 
-+ (CGImageRef)pin_decodedImageRefWithCGImageRef:(CGImageRef)imageRef
-{
-    BOOL opaque = YES;
-    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
-    if (alpha == kCGImageAlphaFirst || alpha == kCGImageAlphaLast || alpha == kCGImageAlphaOnly || alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaPremultipliedLast) {
-        opaque = NO;
+#if PIN_TARGET_IOS
++ (PINImage *)pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:(CGImageRef)imageRef
+                                                                    scale:(CGFloat)scale
+                                                              orientation:(UIImageOrientation)orientation API_AVAILABLE(ios(10.0)) {
+    UIGraphicsImageRendererFormat *format = nil;
+    if (@available(iOS 11.0, *)) {
+        format = [UIGraphicsImageRendererFormat preferredFormat];
+    } else {
+        format = [UIGraphicsImageRendererFormat defaultFormat];
     }
     
+    format.scale = scale;
+    format.opaque = pin_CGImageRefIsOpaque(imageRef);
+    
+    __block CGFloat radians = 0.0;
+    __block BOOL doHorizontalFlip = NO;
+    __block BOOL doVerticalFlip = NO;
+    
+    pin_degreesFromOrientation(orientation, ^(CGFloat degrees, BOOL horizontalFlip, BOOL verticalFlip) {
+        // Convert degrees to radians
+        radians = [[[NSMeasurement alloc] initWithDoubleValue:degrees
+                                                         unit:[NSUnitAngle degrees]]
+                   measurementByConvertingToUnit:[NSUnitAngle radians]].doubleValue;
+        doHorizontalFlip = horizontalFlip;
+        doVerticalFlip = verticalFlip;
+    });
+    
+    // Create rotation out of radians
+    CGAffineTransform transform = CGAffineTransformMakeRotation(radians);
+    
+    // Grab image size
     CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
     
-    CGBitmapInfo info = opaque ? (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host) : (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
+    // Rotate rect by transformation
+    CGRect rotatedRect = CGRectApplyAffineTransform(CGRectMake(0.0, 0.0, imageSize.width, imageSize.height), transform);
+    
+    // Use graphics renderer to render image
+    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedRect.size format:format];
+    
+    return [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
+        CGContextRef ctx = rendererContext.CGContext;
+        
+        // Flip the default coordinate system for iOS:  https://developer.apple.com/library/archive/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/GraphicsDrawingOverview/GraphicsDrawingOverview.html#//apple_ref/doc/uid/TP40010156-CH14-SW4
+        CGContextTranslateCTM(ctx, rotatedRect.size.width / 2.0, rotatedRect.size.height / 2.0);
+        CGContextScaleCTM(ctx, (doHorizontalFlip ? -1.0 : 1.0), (doVerticalFlip ? 1.0 : -1.0));
+        
+        // Apply transformation
+        CGContextConcatCTM(ctx, transform);
+        
+        // Draw image
+        CGContextDrawImage(ctx, CGRectMake(-(imageSize.width / 2.0), -(imageSize.height / 2.0), imageSize.width, imageSize.height), imageRef);
+    }];
+}
+#endif
+
++ (CGImageRef)pin_decodedImageRefWithCGImageRef:(CGImageRef)imageRef
+{
+    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
+    
+    CGBitmapInfo info = pin_CGImageRefIsOpaque(imageRef) ? (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host) : (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
     CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     
     //Use UIGraphicsBeginImageContext parameters from docs: https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIKitFunctionReference/#//apple_ref/c/func/UIGraphicsBeginImageContextWithOptions
@@ -224,6 +277,47 @@ UIImageOrientation pin_UIImageOrientationFromImageSource(CGImageSourceRef imageS
     return orientation;
 }
 
+void pin_degreesFromOrientation(UIImageOrientation orientation, void (^completion)(CGFloat degrees, BOOL horizontalFlip, BOOL verticalFlip)) {
+    switch (orientation) {
+        case UIImageOrientationUp: // default orientation
+            completion(0.0, NO, NO);
+            break;
+        case UIImageOrientationDown: // 180 deg rotation
+            completion(180.0, NO, NO);
+            break;
+        case UIImageOrientationLeft:
+            completion(270.0, NO, NO); // 90 deg CCW
+            break;
+        case UIImageOrientationRight:
+            completion(90.0, NO, NO); // 90 deg CW
+            break;
+        case UIImageOrientationUpMirrored: // as above but image mirrored along other axis. horizontal flip
+            completion(0.0, YES, NO);
+            break;
+        case UIImageOrientationDownMirrored: // horizontal flip
+            completion(180.0, YES, NO);
+            break;
+        case UIImageOrientationLeftMirrored: // vertical flip
+            completion(270.0, NO, YES);
+            break;
+        case UIImageOrientationRightMirrored: // vertical flip
+            completion(90.0, NO, YES);
+            break;
+    }
+}
+
 #endif
+
+BOOL pin_CGImageRefIsOpaque(CGImageRef imageRef) {
+    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
+    switch (alpha) {
+        case kCGImageAlphaNone:
+        case kCGImageAlphaNoneSkipLast:
+        case kCGImageAlphaNoneSkipFirst:
+            return YES;
+        default:
+            return NO;
+    }
+}
 
 @end

--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -139,9 +139,9 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 #if PIN_TARGET_IOS
 + (PINImage *)pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:(CGImageRef)imageRef
                                                                     scale:(CGFloat)scale
-                                                              orientation:(UIImageOrientation)orientation API_AVAILABLE(ios(10.0)) {
+                                                              orientation:(UIImageOrientation)orientation API_AVAILABLE(macosx(10.13), ios(10.0), tvos(11.0)) {
     UIGraphicsImageRendererFormat *format = nil;
-    if (@available(iOS 11.0, *)) {
+    if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, *)) {
         format = [UIGraphicsImageRendererFormat preferredFormat];
     } else {
         format = [UIGraphicsImageRendererFormat defaultFormat];

--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -126,7 +126,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 {
 #endif
 #if PIN_TARGET_IOS
-    if (@available(iOS 10.0, *)) {
+    if (@available(iOS 10.0, tvOS 10.0, *)) {
         return [self pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:imageRef scale:1.0 orientation:orientation];
     } else {
         return [UIImage imageWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] scale:1.0 orientation:orientation];
@@ -139,9 +139,9 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 #if PIN_TARGET_IOS
 + (PINImage *)pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:(CGImageRef)imageRef
                                                                     scale:(CGFloat)scale
-                                                              orientation:(UIImageOrientation)orientation API_AVAILABLE(macosx(10.13), ios(10.0), tvos(11.0)) {
+                                                              orientation:(UIImageOrientation)orientation API_AVAILABLE(ios(10.0), tvos(10.0)) {
     UIGraphicsImageRendererFormat *format = nil;
-    if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, *)) {
+    if (@available(iOS 11.0, tvOS 11.0, *)) {
         format = [UIGraphicsImageRendererFormat preferredFormat];
     } else {
         format = [UIGraphicsImageRendererFormat defaultFormat];
@@ -178,7 +178,7 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
     return [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
         CGContextRef ctx = rendererContext.CGContext;
         
-        // Flip the default coordinate system for iOS:  https://developer.apple.com/library/archive/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/GraphicsDrawingOverview/GraphicsDrawingOverview.html#//apple_ref/doc/uid/TP40010156-CH14-SW4
+        // Flip the default coordinate system for iOS/tvOS:  https://developer.apple.com/library/archive/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/GraphicsDrawingOverview/GraphicsDrawingOverview.html#//apple_ref/doc/uid/TP40010156-CH14-SW4
         CGContextTranslateCTM(ctx, rotatedRect.size.width / 2.0, rotatedRect.size.height / 2.0);
         CGContextScaleCTM(ctx, (doHorizontalFlip ? -1.0 : 1.0), (doVerticalFlip ? 1.0 : -1.0));
         

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -1285,10 +1285,10 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
         UIImageOrientationRightMirrored, // vertical flip
     };
     
-    // iOS versions below iOS 10 use the traditional `+[UIImage imageWithCGImage:]` API that doesn't translate orientation.
-    // For iOS 10+ we manually convert the `UIImageOrientation` in `UIGraphicsImageRenderer`, and therefore,
-    // the following test is here to solidify that behavior
-    if (@available(iOS 10.0, *)) {
+    // iOS or tvOS versions below 10.0 use the traditional `+[UIImage imageWithCGImage:]` API that doesn't translate orientation.
+    // For iOS/tvOS 10.0+ we manually convert the `UIImageOrientation` in `UIGraphicsImageRenderer`, and therefore,
+    // the following test is meant to solidify that behavior
+    if (@available(iOS 10.0, tvOS 10.0, *)) {
         // Loop over all orientations and compare each element respective to one-another
         for (NSInteger i = 0; i < sizeof(allOrientations)/sizeof(allOrientations[0]); i++) {
             

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -1285,9 +1285,9 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
         UIImageOrientationRightMirrored, // vertical flip
     };
     
-    // iOS versions below iOS 10 we use the traditional `+[UIImage imageWithCGImage:]` API that doesn't translate orientation.
+    // iOS versions below iOS 10 use the traditional `+[UIImage imageWithCGImage:]` API that doesn't translate orientation.
     // For iOS 10+ we manually convert the `UIImageOrientation` in `UIGraphicsImageRenderer`, and therefore,
-    // the following test is here to solidify that experience
+    // the following test is here to solidify that behavior
     if (@available(iOS 10.0, *)) {
         // Loop over all orientations and compare each element respective to one-another
         for (NSInteger i = 0; i < sizeof(allOrientations)/sizeof(allOrientations[0]); i++) {


### PR DESCRIPTION
Migrated to `UIGraphicsImageRenderer` for applications running iOS/tvOS 10.0 and above. 

As mentioned in this [WWDC talk](https://developer.apple.com/videos/play/wwdc2018/416/?time=1269), `UIGraphicsImageRenderer` allows us to punt the BPP (bits per pixel), et. al, to the system. As a result, this allows us to save up to [75% less memory](https://developer.apple.com/videos/play/wwdc2018-416/?time=1230) in cases we previously wouldn't.

The implementation defaults back to the original way of decoding if the user is on an older version of iOS/tvOS (below 10.0). 