### PR TITLE
Fix compiling in Xcode 12.0b4

### DIFF
--- a/Source/Classes/PINCache/PINCache+PINRemoteImageCaching.m
+++ b/Source/Classes/PINCache/PINCache+PINRemoteImageCaching.m
@@ -74,7 +74,7 @@
 {
   if (completion) {
     __weak typeof(self) weakSelf = self;
-    [self removeObjectForKeyAsync:key completion:^(PINCache * _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
+    [self removeObjectForKeyAsync:key completion:^(id<PINCaching> _Nonnull cache, NSString * _Nonnull key, id  _Nullable object) {
         typeof(self) strongSelf = weakSelf;
         completion(strongSelf, key, object);
     }];


### PR DESCRIPTION
This beta added a diagnostic for passing more specific types to `id`-typed values:

> Fixed type checking for block parameters using id with protocols. The compiler now emits an error for method calls with a block that uses parameters more specific than arguments with which it will be called. (57980961)