### PR TITLE
fix: build error when using multiproject config

### DIFF
--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -15,7 +15,7 @@
 #if SWIFT_PACKAGE
 @import libwebp;
 #else
-#import "demux.h"
+#import "webp/demux.h"
 #endif
 
 @interface PINWebPAnimatedImage ()

--- a/Source/Classes/Categories/PINImage+WebP.m
+++ b/Source/Classes/Categories/PINImage+WebP.m
@@ -13,7 +13,7 @@
 #if SWIFT_PACKAGE
 @import libwebp;
 #else
-#import "decode.h"
+#import "webp/decode.h"
 #endif
 
 static void releaseData(void *info, const void *data, size_t size)


### PR DESCRIPTION
Fix path import to be compatible with multiple project config cocoapods

> Warning: Switching your project to use multiple .xcodeproj may result in some compiler errors if your pods have relied on importing headers using the quote syntax for its dependencies. For example #import "PDDebugger.h" will no longer work in a pod that depends on PonyDebugger. Instead, we highly suggest you update your headers to correctly import the framework and its associated header: #import <PonyDebugger/PDDebugger.h>. This is intentional since this feature is currently opt-in.

Taken from: http://blog.cocoapods.org/CocoaPods-1.7.0-beta/ 

fixes #568 