### PR TITLE
Use proper units when setting preferredFramesPerSecond

### DIFF
--- a/Source/Classes/AnimatedImages/PINAnimatedImageView.m
+++ b/Source/Classes/AnimatedImages/PINAnimatedImageView.m
@@ -221,13 +221,16 @@
     
     // Get frame interval before holding display link lock to avoid deadlock
     NSUInteger frameInterval = self.animatedImage.frameInterval;
+    
+    // Convert from display link fractional value to fps (note: frameInterval is always at least 1)
+    NSInteger frameRate = ceil([PINAnimatedImage maximumFramesPerSecond] / ((double) frameInterval));
 
     if (_displayLink == nil) {
         _playHead = 0;
         _displayLink = [PINDisplayLink displayLinkWithTarget:[PINRemoteWeakProxy weakProxyWithTarget:self] selector:@selector(displayLinkFired:)];
 #if PIN_TARGET_IOS
         if (@available(iOS 10.0, tvOS 10.0, *)) {
-            _displayLink.preferredFramesPerSecond = frameInterval;
+            _displayLink.preferredFramesPerSecond = frameRate;
         } else {
 #endif
             _displayLink.frameInterval = frameInterval;

--- a/Source/Classes/AnimatedImages/PINAnimatedImageView.m
+++ b/Source/Classes/AnimatedImages/PINAnimatedImageView.m
@@ -219,17 +219,15 @@
         return;
     }
     
-    // Get frame interval before holding display link lock to avoid deadlock
     NSUInteger frameInterval = self.animatedImage.frameInterval;
     
-    // Convert from display link fractional value to fps (note: frameInterval is always at least 1)
-    NSInteger frameRate = ceil([PINAnimatedImage maximumFramesPerSecond] / ((double) frameInterval));
-
     if (_displayLink == nil) {
         _playHead = 0;
         _displayLink = [PINDisplayLink displayLinkWithTarget:[PINRemoteWeakProxy weakProxyWithTarget:self] selector:@selector(displayLinkFired:)];
 #if PIN_TARGET_IOS
         if (@available(iOS 10.0, tvOS 10.0, *)) {
+            // Convert from display link fractional value to fps (note: frameInterval is always at least 1)
+            NSInteger frameRate = ceil([PINAnimatedImage maximumFramesPerSecond] / ((double) frameInterval));
             _displayLink.preferredFramesPerSecond = frameRate;
         } else {
 #endif


### PR DESCRIPTION
preferredFramesPerSecond expects frames-per-second, rather than the
fractional interval expected by frameInterval.

For example, frameInterval=2 is the equivalent (on most devices) of
preferredFramesPerSecond=30.

This issue was introduced in https://github.com/pinterest/PINRemoteImage/pull/552

It's likely this fixes #570 