### PR TITLE
Revert "Integrated UIGraphicsImageRenderer for iOS/tvOS 10.0"

### DIFF
--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -16,49 +16,6 @@
 
 #import "NSData+ImageDetectors.h"
 
-NS_INLINE BOOL pin_CGImageRefIsOpaque(CGImageRef imageRef) {
-    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
-    switch (alpha) {
-        case kCGImageAlphaNone:
-        case kCGImageAlphaNoneSkipLast:
-        case kCGImageAlphaNoneSkipFirst:
-            return YES;
-        default:
-            return NO;
-    }
-}
-
-#if PIN_TARGET_IOS
-NS_INLINE void pin_degreesFromOrientation(UIImageOrientation orientation, void (^completion)(CGFloat degrees, BOOL horizontalFlip, BOOL verticalFlip)) {
-    switch (orientation) {
-        case UIImageOrientationUp: // default orientation
-            completion(0.0, NO, NO);
-            break;
-        case UIImageOrientationDown: // 180 deg rotation
-            completion(180.0, NO, NO);
-            break;
-        case UIImageOrientationLeft:
-            completion(270.0, NO, NO); // 90 deg CCW
-            break;
-        case UIImageOrientationRight:
-            completion(90.0, NO, NO); // 90 deg CW
-            break;
-        case UIImageOrientationUpMirrored: // as above but image mirrored along other axis. horizontal flip
-            completion(0.0, YES, NO);
-            break;
-        case UIImageOrientationDownMirrored: // horizontal flip
-            completion(180.0, YES, NO);
-            break;
-        case UIImageOrientationLeftMirrored: // vertical flip
-            completion(270.0, NO, YES);
-            break;
-        case UIImageOrientationRightMirrored: // vertical flip
-            completion(90.0, NO, YES);
-            break;
-    }
-}
-#endif
-
 #if !PIN_TARGET_IOS
 @implementation NSImage (PINiOSMapping)
 
@@ -169,76 +126,23 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 {
 #endif
 #if PIN_TARGET_IOS
-    if (@available(iOS 10.0, tvOS 10.0, *)) {
-        return [self pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:imageRef scale:1.0 orientation:orientation];
-    } else {
-        return [UIImage imageWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] scale:1.0 orientation:orientation];
-    }
+    return [UIImage imageWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] scale:1.0 orientation:orientation];
 #elif PIN_TARGET_MAC
     return [[NSImage alloc] initWithCGImage:[self pin_decodedImageRefWithCGImageRef:imageRef] size:NSZeroSize];
 #endif
 }
 
-#if PIN_TARGET_IOS
-+ (PINImage *)pin_decodedImageUsingGraphicsImageRendererRefWithCGImageRef:(CGImageRef)imageRef
-                                                                    scale:(CGFloat)scale
-                                                              orientation:(UIImageOrientation)orientation API_AVAILABLE(ios(10.0), tvos(10.0)) {
-    UIGraphicsImageRendererFormat *format = nil;
-    if (@available(iOS 11.0, tvOS 11.0, *)) {
-        format = [UIGraphicsImageRendererFormat preferredFormat];
-    } else {
-        format = [UIGraphicsImageRendererFormat defaultFormat];
-    }
-    
-    format.scale = scale;
-    format.opaque = pin_CGImageRefIsOpaque(imageRef);
-    
-    __block CGFloat radians = 0.0;
-    __block BOOL doHorizontalFlip = NO;
-    __block BOOL doVerticalFlip = NO;
-    
-    pin_degreesFromOrientation(orientation, ^(CGFloat degrees, BOOL horizontalFlip, BOOL verticalFlip) {
-        // Convert degrees to radians
-        radians = [[[NSMeasurement alloc] initWithDoubleValue:degrees
-                                                         unit:[NSUnitAngle degrees]]
-                   measurementByConvertingToUnit:[NSUnitAngle radians]].doubleValue;
-        doHorizontalFlip = horizontalFlip;
-        doVerticalFlip = verticalFlip;
-    });
-    
-    // Create rotation out of radians
-    CGAffineTransform transform = CGAffineTransformMakeRotation(radians);
-    
-    // Grab image size
-    CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
-    
-    // Rotate rect by transformation
-    CGRect rotatedRect = CGRectApplyAffineTransform(CGRectMake(0.0, 0.0, imageSize.width, imageSize.height), transform);
-    
-    // Use graphics renderer to render image
-    UIGraphicsImageRenderer *renderer = [[UIGraphicsImageRenderer alloc] initWithSize:rotatedRect.size format:format];
-    
-    return [renderer imageWithActions:^(UIGraphicsImageRendererContext * _Nonnull rendererContext) {
-        CGContextRef ctx = rendererContext.CGContext;
-        
-        // Flip the default coordinate system for iOS/tvOS:  https://developer.apple.com/library/archive/documentation/2DDrawing/Conceptual/DrawingPrintingiOS/GraphicsDrawingOverview/GraphicsDrawingOverview.html#//apple_ref/doc/uid/TP40010156-CH14-SW4
-        CGContextTranslateCTM(ctx, rotatedRect.size.width / 2.0, rotatedRect.size.height / 2.0);
-        CGContextScaleCTM(ctx, (doHorizontalFlip ? -1.0 : 1.0), (doVerticalFlip ? 1.0 : -1.0));
-        
-        // Apply transformation
-        CGContextConcatCTM(ctx, transform);
-        
-        // Draw image
-        CGContextDrawImage(ctx, CGRectMake(-(imageSize.width / 2.0), -(imageSize.height / 2.0), imageSize.width, imageSize.height), imageRef);
-    }];
-}
-#endif
-
 + (CGImageRef)pin_decodedImageRefWithCGImageRef:(CGImageRef)imageRef
 {
+    BOOL opaque = YES;
+    CGImageAlphaInfo alpha = CGImageGetAlphaInfo(imageRef);
+    if (alpha == kCGImageAlphaFirst || alpha == kCGImageAlphaLast || alpha == kCGImageAlphaOnly || alpha == kCGImageAlphaPremultipliedFirst || alpha == kCGImageAlphaPremultipliedLast) {
+        opaque = NO;
+    }
+    
     CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
     
-    CGBitmapInfo info = pin_CGImageRefIsOpaque(imageRef) ? (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host) : (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
+    CGBitmapInfo info = opaque ? (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host) : (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
     CGColorSpaceRef colorspace = CGColorSpaceCreateDeviceRGB();
     
     //Use UIGraphicsBeginImageContext parameters from docs: https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIKitFunctionReference/#//apple_ref/c/func/UIGraphicsBeginImageContextWithOptions

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -60,13 +60,6 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 
 @end
 
-@interface PINImage (Private)
-
-+ (nullable PINImage *)pin_decodedImageWithCGImageRef:(nonnull CGImageRef)imageRef orientation:(UIImageOrientation) orientation;
-
-@end
-
-
 #if DEBUG
 
 @interface PINRemoteImageWeakTask : NSObject
@@ -191,11 +184,6 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 - (NSURL *)transparentWebPURL
 {
     return [NSURL URLWithString:@"https://www.gstatic.com/webp/gallery3/4_webp_ll.webp"];
-}
-
-- (NSURL *)grayscalePNGURL
-{
-    return [NSURL URLWithString:@"https://upload.wikimedia.org/wikipedia/commons/f/fa/Grayscale_8bits_palette_sample_image.png"];
 }
 
 - (NSURL *)veryLongURL
@@ -1238,84 +1226,6 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 		 [expectation fulfill];
 	 }];
 	[self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
-}
-
-- (void)testThatGrayscalePNGImageIsEightBPP
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Downloading grayscale PNG image"];
-    [self.imageManager downloadImageWithURL:[self grayscalePNGURL]
-                                    options:PINRemoteImageManagerDownloadOptionsNone
-                                 completion:^(PINRemoteImageManagerResult *result)
-     {
-         UIImage *outImage = result.image;
-        
-         XCTAssertEqual(CGImageGetBitsPerPixel(outImage.CGImage), 8, @"This grayscale image should've been decoded as a 8 bit per pixel image.");
-         XCTAssert(PINImageAlphaInfoIsOpaque(CGImageGetAlphaInfo(outImage.CGImage)), @"Opaque image has an alpha channel.");
-         
-         [expectation fulfill];
-     }];
-    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
-}
-
-- (void)testImageRendererOrientation
-{
-    dispatch_group_t group = dispatch_group_create();
-    __block CGImageRef imageRefEncoded = nil;
-    
-    dispatch_group_enter(group);
-    [self.imageManager downloadImageWithURL:[self JPEGURL]
-                                    options:PINRemoteImageManagerDownloadOptionsSkipDecode
-                                 completion:^(PINRemoteImageManagerResult *result)
-    {
-        imageRefEncoded = CGImageCreateCopy(result.image.CGImage);
-        dispatch_group_leave(group);
-    }];
-    
-    dispatch_group_wait(group, DISPATCH_TIME_FOREVER);
-    
-    // All image orientations (copied from `UIImage.h`)
-    UIImageOrientation allOrientations[] = {
-        UIImageOrientationUp,            // default orientation
-        UIImageOrientationDown,          // 180 deg rotation
-        UIImageOrientationLeft,          // 90 deg CCW
-        UIImageOrientationRight,         // 90 deg CW
-        UIImageOrientationUpMirrored,    // as above but image mirrored along other axis. horizontal flip
-        UIImageOrientationDownMirrored,  // horizontal flip
-        UIImageOrientationLeftMirrored,  // vertical flip
-        UIImageOrientationRightMirrored, // vertical flip
-    };
-    
-    // iOS or tvOS versions below 10.0 use the traditional `+[UIImage imageWithCGImage:]` API that doesn't translate orientation.
-    // For iOS/tvOS 10.0+ we manually convert the `UIImageOrientation` in `UIGraphicsImageRenderer`, and therefore,
-    // the following test is meant to solidify that behavior
-    if (@available(iOS 10.0, tvOS 10.0, *)) {
-        // Loop over all orientations and compare each element respective to one-another
-        for (NSInteger i = 0; i < sizeof(allOrientations)/sizeof(allOrientations[0]); i++) {
-            
-            // Rotate the reference image by the given orientation
-            UIImage *referenceImage = [UIImage pin_decodedImageWithCGImageRef:imageRefEncoded orientation:allOrientations[i]];
-            
-            // Compare the reference image to each element
-            for (NSInteger j = 0; j < sizeof(allOrientations)/sizeof(allOrientations[0]); j++) {
-                
-                // Rotate the image by the given orientation
-                UIImage *rotatedImage = [UIImage pin_decodedImageWithCGImageRef:imageRefEncoded orientation:allOrientations[j]];
-                
-                // equal images must succeed
-                if (i == j) {
-                    XCTAssert([UIImageJPEGRepresentation(referenceImage, 1.0) isEqualToData:UIImageJPEGRepresentation(rotatedImage, 1.0)],
-                              @"Unsuccessful transformation. The `referenceImage` and `rotatedImage` are not the same.");
-                }
-                // unequal images must fail
-                else {
-                    XCTAssertFalse([UIImageJPEGRepresentation(referenceImage, 1.0) isEqualToData:UIImageJPEGRepresentation(rotatedImage, 1.0)],
-                                   @"Unsuccessful transformation. The `referenceImage` and `rotatedImage` are the same.");
-                }
-            }
-        }
-    }
-    
-    CGImageRelease(imageRefEncoded);
 }
 
 - (void)testExponentialRetryStrategy


### PR DESCRIPTION
Passing large images (e.g, 5000x5000) to `UIGraphicsImageRenderer` seems to cause the underlying pipeline to allocate huge amounts of memory until the device finally OOMs on some arbitrary location, e.g:

```
PINRemoteImageManager, L1499:
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'We only cache a decompressed image if we decompressed it ourselves. In that case, it should be backed by a CGImageRef.'
```

I've attached two screenshots of profiles (sorry, couldn't attach the actual profiles due to company policy) and created a radar for Apple to look into.

**Reproducing it should be relatively simple:**
1. Load large images, e.g, 5000x5000
2. Observe that the pipeline backing `UIGraphicsImageRenderer` grows in memory
3. Continue to load large images until the device finally OOMs

**Suggested action:**
Without spending too much time looking into the underlying reason (although I have some theories), I figured the most appropriate action would be to revert this integration until we better understand the bigger picture.

**Time profiler:**
<img width="600" alt="Time profiler" src="https://user-images.githubusercontent.com/25216555/101310754-9540ab00-3804-11eb-91e5-303d8a938e76.png">

**Allocations profiler:**
<img width="600" alt="Allocations" src="https://user-images.githubusercontent.com/25216555/101310762-9bcf2280-3804-11eb-8e60-df5b43d29067.png">
