### PR TITLE
Xcode 12.5 / SPM - Add missing headers to fix build errors

### DIFF
--- a/Source/Classes/include/PINRemoteImage.h
+++ b/Source/Classes/include/PINRemoteImage.h
@@ -23,3 +23,7 @@
 #import "PINProgressiveImage.h"
 #import "PINURLSessionManager.h"
 #import "PINRequestRetryStrategy.h"
+#import "PINAnimatedImageView.h"
+#import "PINAnimatedImageView+PINRemoteImage.h"
+#import "PINButton+PINRemoteImage.h"
+#import "PINImageView+PINRemoteImage.h"


### PR DESCRIPTION
Not sure if this just showed up in the final build of Xcode 12.5 but we're seeing builds errors this in our own project and in the the `Example-Xcode-SPM` sample project.

I've included the missing headers and it seems to fix the issues for us but not sure if I have impacted Carthage or Cocoapods. 
 
The PINRemoteImage package itself builds fine, but the UIKit classes and extensions are not being exposed resulting in errors like:
```
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h"
        ^
/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h:26:1: warning: umbrella header for module 'PINRemoteImage' does not include header 'PINAnimatedImageView+PINRemoteImage.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h"
        ^
/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h:26:1: warning: umbrella header for module 'PINRemoteImage' does not include header 'PINAnimatedImageView.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h"
        ^
/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h:26:1: warning: umbrella header for module 'PINRemoteImage' does not include header 'PINButton+PINRemoteImage.h'

^
<module-includes>:1:9: note: in file included from <module-includes>:1:
#import "/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h"
        ^
/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Source/Classes/include/PINRemoteImage.h:26:1: warning: umbrella header for module 'PINRemoteImage' does not include header 'PINImageView+PINRemoteImage.h'

^
/Users/bpollman/Library/Developer/Xcode/DerivedData/app-hdhkkktbvfylmkdtvwdwaqekbyzv/SourcePackages/checkouts/PINRemoteImage/Examples/Example-Xcode-SPM/Example-Xcode-SPM/ViewController.swift:13:33: error: cannot find type 'PINAnimatedImageView' in scope
    @IBOutlet weak var imgView: PINAnimatedImageView!
                                ^
```


