### PR TITLE
Decode WebP images directly into a buffer Core Animation likes

### DIFF
--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -122,12 +122,6 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
         return nil;
     }
     
-#if PIN_WEBP
-    if ([data pin_isWebP]) {
-        return [PINImage pin_imageWithWebPData:data];
-    }
-#endif
-    
     PINImage *decodedImage = nil;
     
     CGImageSourceRef imageSourceRef = CGImageSourceCreateWithData((CFDataRef)data, NULL);
@@ -156,6 +150,12 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
         CFRelease(imageSourceRef);
     }
     
+#if PIN_WEBP
+    if (!decodedImage && [data pin_isWebP]) {
+        return [PINImage pin_imageWithWebPData:data];
+    }
+#endif
+
     return decodedImage;
 }
 

--- a/Source/Classes/Categories/PINImage+WebP.m
+++ b/Source/Classes/Categories/PINImage+WebP.m
@@ -82,7 +82,7 @@ static enum WEBP_CSP_MODE webp_cs_mode_from_cg_bitmap_info(CGBitmapInfo info, BO
     NSAssert(ctx != NULL, @"Failed to get CG context.");
     BOOL getColorspaceFailed = NO;
     cfg.output.colorspace = webp_cs_mode_from_cg_bitmap_info(CGBitmapContextGetBitmapInfo(ctx),
-                                                             &fail);
+                                                             &getColorspaceFailed);
     if (getColorspaceFailed) {
         PIN_WEBP_DECODE_CLEANUP();
         return nil;

--- a/Source/Classes/Categories/PINImage+WebP.m
+++ b/Source/Classes/Categories/PINImage+WebP.m
@@ -19,6 +19,84 @@ static void releaseData(void *info, const void *data, size_t size)
 
 @implementation PINImage (PINWebP)
 
+#if PIN_TARGET_IOS
+
+static enum WEBP_CSP_MODE webp_cs_mode_from_cg_bitmap_info(CGBitmapInfo info, BOOL *fail) {
+    CGImageByteOrderInfo byteOrder = info & kCGBitmapByteOrderMask;
+    BOOL keepByteOrder;
+    switch (byteOrder) {
+        case kCGImageByteOrder32Big:
+            keepByteOrder = YES;
+            break;
+        case kCGImageByteOrder32Little:
+            keepByteOrder = NO;
+            break;
+        case kCGImageByteOrder16Big:
+        case kCGImageByteOrder16Little:
+        case kCGImageByteOrderDefault:
+        case kCGImageByteOrderMask:
+            *fail = YES;
+            return MODE_RGBA;
+    }
+
+    CGImageAlphaInfo ai = info & kCGBitmapAlphaInfoMask;
+    switch (ai) {
+        case kCGImageAlphaLast:
+        case kCGImageAlphaNoneSkipLast:
+            return keepByteOrder ? MODE_RGBA : MODE_ARGB;
+        case kCGImageAlphaNone:
+            return keepByteOrder ? MODE_RGB  : MODE_BGR;
+        case kCGImageAlphaFirst:
+        case kCGImageAlphaNoneSkipFirst:
+            return keepByteOrder ? MODE_ARGB : MODE_BGRA;
+        case kCGImageAlphaPremultipliedLast:
+            return keepByteOrder ? MODE_rgbA : MODE_Argb;
+        case kCGImageAlphaPremultipliedFirst:
+            return keepByteOrder ? MODE_Argb : MODE_rgbA;
+        case kCGImageAlphaOnly:
+            *fail = YES;
+            return MODE_RGB;
+    }
+}
+
+// For iOS we let the system decide all the bitmap options for us, so Core Animation won't have
+// to copy our images over to the render server. Use "Color Copied Images" in the iOS simulator to
+// detect this case.
++ (PINImage *)pin_imageWithWebPData:(NSData *)webPData
+{
+    WebPDecoderConfig cfg;
+    WebPInitDecoderConfig(&cfg);
+    if (WebPGetFeatures(webPData.bytes, webPData.length, &cfg.input) != VP8_STATUS_OK) {
+        return nil;
+    }
+    CGSize size = CGSizeMake(cfg.input.width, cfg.input.height);
+    UIGraphicsBeginImageContextWithOptions(size, !cfg.input.has_alpha, 1.0);
+    CGContextRef ctx = UIGraphicsGetCurrentContext();
+    BOOL fail = NO;
+    cfg.output.colorspace = webp_cs_mode_from_cg_bitmap_info(CGBitmapContextGetBitmapInfo(ctx),
+                                                             &fail);
+    if (fail) {
+        UIGraphicsEndImageContext();
+        return nil;
+    }
+    cfg.output.width = cfg.input.width;
+    cfg.output.height = cfg.input.height;
+    cfg.output.is_external_memory = 1;
+    cfg.output.u.RGBA.rgba = (uint8_t *)CGBitmapContextGetData(ctx);
+    cfg.output.u.RGBA.stride = (int)CGBitmapContextGetBytesPerRow(ctx);
+    cfg.output.u.RGBA.size = cfg.output.u.RGBA.stride * cfg.input.height;
+    int status = WebPDecode(webPData.bytes, webPData.length, &cfg);
+    UIImage *image = nil;
+    if (status == VP8_STATUS_OK) {
+        image = UIGraphicsGetImageFromCurrentImageContext();
+    }
+    UIGraphicsEndImageContext();
+    return image;
+}
+
+#elif PIN_TARGET_MAC
+
+// TODO: Can we get the optimal bitmap config from macOS like we do for iOS?
 + (PINImage *)pin_imageWithWebPData:(NSData *)webPData
 {
     WebPBitstreamFeatures features;
@@ -61,12 +139,7 @@ static void releaseData(void *info, const void *data, size_t size)
                                                 NO,
                                                 renderingIntent);
             
-            PINImage *image = nil;
-#if PIN_TARGET_IOS
-            image = [UIImage imageWithCGImage:imageRef];
-#elif PIN_TARGET_MAC
-            image = [[self alloc] initWithCGImage:imageRef size:CGSizeZero];
-#endif
+            PINImage *image = [[self alloc] initWithCGImage:imageRef size:CGSizeZero];
             
             CGImageRelease(imageRef);
             CGColorSpaceRelease(colorSpaceRef);
@@ -77,6 +150,8 @@ static void releaseData(void *info, const void *data, size_t size)
     }
     return nil;
 }
+
+#endif
 
 @end
 

--- a/Source/Classes/Categories/PINImage+WebP.m
+++ b/Source/Classes/Categories/PINImage+WebP.m
@@ -58,7 +58,7 @@ static enum WEBP_CSP_MODE webp_cs_mode_from_cg_bitmap_info(CGBitmapInfo info, BO
 #define PIN_WEBP_DECODE_CLEANUP() [image unlockFocus]
 #endif
 
-// For iOS we let the system decide all the bitmap options for us, so Core Animation won't have
+// We let the system decide all the bitmap options for us, so Core Animation won't have
 // to copy our images over to the render server. Use "Color Copied Images" in the iOS simulator to
 // detect this case.
 + (PINImage *)pin_imageWithWebPData:(NSData *)webPData


### PR DESCRIPTION
Without this change, the images we output aren't compatible with the GPU and so CA has to copy them all on the main thread at commit time, which means stutters. Plus memory bloat.

The difference here is so substantial that you may seriously want to consider re-running a WebP experiment if you did in the past and bailed on it.

`CA::copy_image` before: 
<img width="1858" alt="Screen Shot 2021-05-28 at 5 11 00 PM" src="https://user-images.githubusercontent.com/2466893/120042284-c5a91b00-bfd7-11eb-8a9c-f6953189a5cf.png">

After:
<img width="1858" alt="Screen Shot 2021-05-28 at 5 11 24 PM" src="https://user-images.githubusercontent.com/2466893/120042287-c8a40b80-bfd7-11eb-8abf-497fccfb6cf7.png">

~Yes I am too lazy to figure out how to do this on macOS, and for that I am sorry. Desktops are fast anyway!~