### PR TITLE
Set cachePolicy accordingly when PINRemoteImageManagerDownloadOptions is provided

### DIFF
--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -386,6 +386,25 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
 }
 
+- (void)testImageRequestIgnoresLocalData
+{
+    XCTestExpectation *expectation = [self expectationWithDescription:@"xxx"];
+    
+    self.imageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil];
+    self.imageManager.sessionManager.delegate = self;
+    
+    [self.imageManager setRequestConfiguration:^NSURLRequest * _Nonnull(NSURLRequest * _Nonnull request) {
+        XCTAssertEqual(request.cachePolicy, NSURLRequestReloadIgnoringLocalCacheData);
+        [expectation fulfill];
+        return request;
+    }];
+  
+    [self.imageManager downloadImageWithURL:[self headersURL]
+                                    options:PINRemoteImageManagerDownloadOptionsIgnoreCache
+                                 completion:nil];
+    [self waitForExpectationsWithTimeout:[self timeoutTimeInterval] handler:nil];
+}
+
 - (void)testRequestConfigurationIsUsedForImageRequest
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"Requestion configuration block was called image request"];

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -388,7 +388,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
 
 - (void)testImageRequestIgnoresLocalData
 {
-    XCTestExpectation *expectation = [self expectationWithDescription:@"xxx"];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Verify cache policy of request"];
     
     self.imageManager = [[PINRemoteImageManager alloc] initWithSessionConfiguration:nil];
     self.imageManager.sessionManager.delegate = self;


### PR DESCRIPTION
Otherwise it might be confusing (and surprising) that the underlying network client may returns locally cached data

There is a use case in Pinterest that expects one response would never be cached.