### PR TITLE
unarchiveObjectWithData: and archivedDataWithRootObject: are deprecated

### DIFF
--- a/Carthage/Checkouts/PINCache/Source/PINDiskCache.h
+++ b/Carthage/Checkouts/PINCache/Source/PINDiskCache.h
@@ -13,19 +13,15 @@ NS_ASSUME_NONNULL_BEGIN
 @class PINDiskCache;
 @class PINOperationQueue;
 
-extern NSString * const PINDiskCacheLogErrorDomain;
-extern NSErrorUserInfoKey const PINDiskCacheLogErrorReadFailureCodeKey;
-extern NSErrorUserInfoKey const PINDiskCacheLogErrorWriteFailureCodeKey;
+extern NSString * const PINDiskCacheErrorDomain;
+extern NSErrorUserInfoKey const PINDiskCacheErrorReadFailureCodeKey;
+extern NSErrorUserInfoKey const PINDiskCacheErrorWriteFailureCodeKey;
 extern NSString * const PINDiskCachePrefix;
 
-typedef NS_ENUM(NSInteger, PINDiskCacheErrorType) {
-  PINDiskCacheLogErrorReadFailure = -1000,
-  PINDiskCacheLogErrorWriteFailure = -1001,
+typedef NS_ENUM(NSInteger, PINDiskCacheError) {
+    PINDiskCacheErrorReadFailure = -1000,
+    PINDiskCacheErrorWriteFailure = -1001,
 };
-
-#define PINDiskCacheLogError(error) if (error) { NSLog(@"%@ (%d) ERROR: %@", \
-[[NSString stringWithUTF8String:__FILE__] lastPathComponent], \
-__LINE__, [error localizedDescription]); }
 
 /**
  A callback block which provides the cache, key and object as arguments

--- a/Carthage/Checkouts/PINCache/Source/PINDiskCache.h
+++ b/Carthage/Checkouts/PINCache/Source/PINDiskCache.h
@@ -13,15 +13,19 @@ NS_ASSUME_NONNULL_BEGIN
 @class PINDiskCache;
 @class PINOperationQueue;
 
-extern NSString * const PINDiskCacheErrorDomain;
-extern NSErrorUserInfoKey const PINDiskCacheErrorReadFailureCodeKey;
-extern NSErrorUserInfoKey const PINDiskCacheErrorWriteFailureCodeKey;
+extern NSString * const PINDiskCacheLogErrorDomain;
+extern NSErrorUserInfoKey const PINDiskCacheLogErrorReadFailureCodeKey;
+extern NSErrorUserInfoKey const PINDiskCacheLogErrorWriteFailureCodeKey;
 extern NSString * const PINDiskCachePrefix;
 
-typedef NS_ENUM(NSInteger, PINDiskCacheError) {
-  PINDiskCacheErrorReadFailure = -1000,
-  PINDiskCacheErrorWriteFailure = -1001,
+typedef NS_ENUM(NSInteger, PINDiskCacheErrorType) {
+  PINDiskCacheLogErrorReadFailure = -1000,
+  PINDiskCacheLogErrorWriteFailure = -1001,
 };
+
+#define PINDiskCacheLogError(error) if (error) { NSLog(@"%@ (%d) ERROR: %@", \
+[[NSString stringWithUTF8String:__FILE__] lastPathComponent], \
+__LINE__, [error localizedDescription]); }
 
 /**
  A callback block which provides the cache, key and object as arguments

--- a/Carthage/Checkouts/PINCache/Source/PINDiskCache.m
+++ b/Carthage/Checkouts/PINCache/Source/PINDiskCache.m
@@ -343,7 +343,11 @@ static NSURL *_sharedTrashURL;
 - (PINDiskCacheDeserializerBlock)defaultDeserializer
 {
     return ^id(NSData * data, NSString *key){
-        return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        if (@available(iOS 11.0, tvOS 11.0, *)) {
+            return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:data error:nil];
+        } else {
+            return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        }
     };
 }
 

--- a/Carthage/Checkouts/PINCache/Source/PINDiskCache.m
+++ b/Carthage/Checkouts/PINCache/Source/PINDiskCache.m
@@ -339,8 +339,13 @@ static NSURL *_sharedTrashURL;
 - (PINDiskCacheDeserializerBlock)defaultDeserializer
 {
     return ^id(NSData * data, NSString *key){
-        if (@available(iOS 11.0, tvOS 11.0, *)) {
-            return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:data error:nil];
+        if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+            NSError *error = nil;
+            NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:&error];
+            PINDiskCacheLogError(error);
+            unarchiver.requiresSecureCoding = NO;
+            id obj = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+            return obj;
         } else {
             return [NSKeyedUnarchiver unarchiveObjectWithData:data];
         }

--- a/Carthage/Checkouts/PINCache/Tests/PINCacheTests.m
+++ b/Carthage/Checkouts/PINCache/Tests/PINCacheTests.m
@@ -1396,7 +1396,7 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     
     [testCache setObject:@(1) forKey:@"test_key"];
     
-    XCTAssertNotNil([testCache objectForKey:@"test_key"], @"Object should not be nil");
+    XCTAssertEqualObjects([testCache objectForKey:@"test_key"], @1);
     
     NSString *encodedKey = [[testCache fileURLForKey:@"test_key"] lastPathComponent];
     XCTAssertEqualObjects(@"test_key", encodedKey, @"Encoded key should be equal to decoded one");
@@ -1407,6 +1407,9 @@ const NSTimeInterval PINCacheTestBlockTimeout = 20.0;
     PINCache *cache = [[PINCache alloc] initWithName:@"test" rootPath:PINDiskCachePrefix serializer:nil deserializer:nil keyEncoder:nil keyDecoder:nil ttlCache:YES];
     XCTAssert(cache.diskCache.isTTLCache);
     XCTAssert(cache.memoryCache.isTTLCache);
+    
+    [cache setObject:@(1) forKey:@"test_key"];
+    XCTAssertNotNil([cache objectForKey:@"test_key"], @"Object should not be nil");
 }
 
 @end

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -331,7 +331,7 @@ static dispatch_once_t sharedDispatchToken;
             if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
                 NSError *error = nil;
                 NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
-                PINDiskCacheError(error);
+                PINDiskCacheLogError(error);
                 return data;
             } else {
                 return [NSKeyedArchiver archivedDataWithRootObject:object];

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -342,8 +342,7 @@ static dispatch_once_t sharedDispatchToken;
                 NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:&error];
                 NSAssert(!error, @"unarchiver init failed with error");
                 unarchiver.requiresSecureCoding = NO;
-                id obj = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
-                return obj;
+                return [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
             } else {
                 return [NSKeyedUnarchiver unarchiveObjectWithData:data];
             }

--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -329,10 +329,7 @@ static dispatch_once_t sharedDispatchToken;
         id <NSCoding, NSObject> obj = (id <NSCoding, NSObject>)object;
         if ([key hasPrefix:PINRemoteImageCacheKeyResumePrefix]) {
             if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-                NSError *error = nil;
-                NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
-                PINDiskCacheLogError(error);
-                return data;
+                return [NSKeyedArchiver archivedDataWithRootObject:obj requiringSecureCoding:NO error:nil];
             } else {
                 return [NSKeyedArchiver archivedDataWithRootObject:object];
             }

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -796,10 +796,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
   
     PINDiskCache *tempDiskCache = [[PINDiskCache alloc] initWithName:kPINRemoteImageDiskCacheName rootPath:cachePath serializer:^NSData * _Nonnull(id<NSCoding>  _Nonnull object, NSString * _Nonnull key) {
         if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
-            NSError *error = nil;
-            NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
-            PINDiskCacheLogError(error);
-            return data;
+            return [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:nil];
         } else {
             return [NSKeyedArchiver archivedDataWithRootObject:object];
         }

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -798,7 +798,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
         if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
             NSError *error = nil;
             NSData *data = [NSKeyedArchiver archivedDataWithRootObject:object requiringSecureCoding:NO error:&error];
-            PINDiskCacheError(error);
+            PINDiskCacheLogError(error);
             return data;
         } else {
             return [NSKeyedArchiver archivedDataWithRootObject:object];

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -804,8 +804,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
         if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
             NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nil];
             unarchiver.requiresSecureCoding = NO;
-            id obj = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
-            return obj;
+            return [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
         } else {
             return [NSKeyedUnarchiver unarchiveObjectWithData:data];
         }

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -801,8 +801,11 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
             return [NSKeyedArchiver archivedDataWithRootObject:object];
         }
     } deserializer:^id<NSCoding> _Nonnull(NSData * _Nonnull data, NSString * _Nonnull key) {
-        if (@available(iOS 11.0, tvOS 11.0, *)) {
-            return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSObject class] fromData:data error:nil];
+        if (@available(iOS 11.0, macOS 10.13, tvOS 11.0, watchOS 4.0, *)) {
+            NSKeyedUnarchiver *unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:nil];
+            unarchiver.requiresSecureCoding = NO;
+            id obj = [unarchiver decodeObjectForKey:NSKeyedArchiveRootObjectKey];
+            return obj;
         } else {
             return [NSKeyedUnarchiver unarchiveObjectWithData:data];
         }


### PR DESCRIPTION
migrate code to new apis.