### PR TITLE
remove property:previousFrame from PINWebPAnimatedImage

### DIFF
--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -19,7 +19,6 @@
     NSData *_animatedImageData;
     WebPData _underlyingData;
     WebPDemuxer *_demux;
-    CGImageRef previousFrame;
     uint32_t _width;
     uint32_t _height;
     BOOL _hasAlpha;


### PR DESCRIPTION
- it is not used anywhere
- it is a private ivar so should be safe
- it would cause complier -WShaow warnings as there are same declarations in the same source file. i.e., `Users/lma/Diff/PINRemoteImage/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m:166:9: warning: local declaration of 'previousFrame' hides instance variable [-Wshadow-ivar]
    if (previousFrame) {
        ^
`