### PR TITLE
Disable asserts in release builds when using Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
                 .headerSearchPath("ImageCategories"),
                 .headerSearchPath("PinCache"),
                 
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release)),
                 .define("USE_PINCACHE", to: "1"),
                 .define("PIN_WEBP", to: "1"),
                 ]),


### PR DESCRIPTION
When using Swift Package Manager to integrate `PINRemoteImage` into an app, Xcode does not automatically set `NS_BLOCK_ASSERTIONS` to `1` when building the package in release. This means that any NSAsserts that are hit in release cause crashes. This appears to only be an issue with ObjC packages.

The change I've made is to Package.swift to set `NS_BLOCK_ASSERTIONS` to `1` when building in release.

(Note: I didn't actually hit an assert in this PINRemoteImage, but the possibility is there)