### PR TITLE
Add support for Querying and Setting the playback timestamp in PINAnimatedImageView

### DIFF
--- a/Source/Classes/AnimatedImages/PINAnimatedImageView.m
+++ b/Source/Classes/AnimatedImages/PINAnimatedImageView.m
@@ -27,6 +27,7 @@
 
 @end
 
+
 @implementation PINAnimatedImageView
 
 @synthesize animatedImage = _animatedImage;
@@ -105,6 +106,13 @@
 }
 
 #pragma mark - Public
+
+-(void)setAnimatedImage:(PINCachedAnimatedImage*)image atTimestamp:(CFTimeInterval)newTimestamp
+{
+	[self setAnimatedImage:image];
+	
+	[self setCurrentTimestamp:newTimestamp];
+}
 
 - (void)setAnimatedImage:(PINCachedAnimatedImage *)animatedImage
 {
@@ -190,12 +198,39 @@
     _frameImage = CGImageRetain([coverImage CGImage]);
 }
 
+-(CFTimeInterval)lastDisplayedTimestamp
+{
+	return _playHead;
+}
+
+-(void)setCurrentTimestamp:(CFTimeInterval)newTimestamp
+{
+	if (_displayLink == nil) {
+		[self startAnimating];
+		
+		_playHead = newTimestamp;
+	}
+	else {
+		// Reset
+		_displayLink.paused = YES;
+		_displayLink.paused = NO;
+		
+		_lastDisplayLinkFire = 0;
+		_playedLoops = 0;
+		
+		_playHead = newTimestamp;
+		
+		[self displayLinkFired:_displayLink];
+	}
+}
+
 #pragma mark - Animating
 
 - (void)checkIfShouldAnimate
 {
     PINAssertMain();
     BOOL shouldAnimate = _playbackPaused == NO && _animatedImage.playbackReady && [self canBeVisible];
+	
     if (shouldAnimate) {
         [self startAnimating];
     } else {

--- a/Source/Classes/include/PINAnimatedImageView.h
+++ b/Source/Classes/include/PINAnimatedImageView.h
@@ -25,4 +25,9 @@
 @property (nullable, nonatomic, strong) NSString *animatedImageRunLoopMode;
 @property (nonatomic, assign, getter=isPlaybackPaused) BOOL playbackPaused;
 
+-(CFTimeInterval)lastDisplayedTimestamp;
+-(void)setCurrentTimestamp:(CFTimeInterval)newTimestamp;
+
+-(void)setAnimatedImage:(nullable PINCachedAnimatedImage*)image atTimestamp:(CFTimeInterval)newTimestamp;
+
 @end


### PR DESCRIPTION
If you have GIFs in a table view or collection view and you want to let them scroll off screen, then back on screen, and resume playback from the same frame, as if they were never unloaded you need to be able to save the current playback timestamp and then resume playback from that timestamp.

Added 3 new public methods to `PINAnimatedImageView` to achieve this.
```
-(CFTimeInterval)lastDisplayedTimestamp;
-(void)setCurrentTimestamp:(CFTimeInterval)newTimestamp;

-(void)setAnimatedImage:(PINCachedAnimatedImage*)image atTimestamp:(CFTimeInterval)newTimestamp
```