### PR TITLE
Revert premature version bump

### DIFF
--- a/PINRemoteImage.podspec
+++ b/PINRemoteImage.podspec
@@ -9,7 +9,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "PINRemoteImage"
-  s.version          = "3.0.4"
+  s.version          = "3.0.3"
   s.summary          = "A thread safe, performant, feature rich image fetcher"
   s.homepage         = "https://github.com/pinterest/PINRemoteImage"
   s.license          = 'Apache 2.0'


### PR DESCRIPTION
## Summary

I bumped the version on the podspec prematurely. This causes the Publish Release CI action to fail because _it_ wants to bump the release. But since it's already bumped, the script fails to find the old version.