### PR TITLE
Allow warnings when pod trunk push

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Push to Cocoapods
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
-        run: pod trunk push
+        run: pod trunk push --allow-warnings


### PR DESCRIPTION
## Summary

We now have some warnings in PINRemoteImage because we still use MD5. It's fine for our use cases, but it means anywhere we use `pod` we have to pass `allow-warnings`. In this case, when publishing the Cocoapod.