### PR TITLE
Serialize animated-image frame decodes; refuse damaged frames; fix fr…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,8 +11,9 @@ on:
       - master
 
 env:
-  # Use Xcode 15.2 or newer to support VisionOS
-  DEVELOPER_DIR: /Applications/Xcode_16.4.app
+  # Must exist on the current macos-latest runner image:
+  # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+  DEVELOPER_DIR: /Applications/Xcode_26.5.0.app/Contents/Developer
 
 jobs:
   debuggithub:
@@ -28,9 +29,6 @@ jobs:
   analyze:
     name: Analyze
     runs-on: macos-latest
-    strategy:
-      matrix:
-        platform: ['iOS Simulator,name=iPhone 16,OS=18.5']
     steps:
       - uses: actions/checkout@v2
       - name: Analyze
@@ -38,9 +36,6 @@ jobs:
   test:
     name: Test
     runs-on: macos-latest
-    strategy:
-      matrix:
-        platform: ['iOS Simulator,name=iPhone 16,OS=18.5']
     steps:
       - uses: actions/checkout@v2
       - name: Test

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -7,8 +7,9 @@ on:
         required: true
 
 env:
-  # Use Xcode 15.2 or newer to support VisionOS
-  DEVELOPER_DIR: /Applications/Xcode_16.4.app
+  # Must exist on the current macos-latest runner image:
+  # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md
+  DEVELOPER_DIR: /Applications/Xcode_26.5.0.app/Contents/Developer
 
 jobs:
   create_release:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PLATFORM="platform=iOS Simulator,name=iPhone 16,OS=18.5"
-SDK="iphonesimulator18.5"
+PLATFORM="platform=iOS Simulator,name=iPhone 17"
+SDK="iphonesimulator"
 SHELL=/bin/bash -o pipefail
 XCODE_MAJOR_VERSION=$(shell xcodebuild -version | HEAD -n 1 | sed -E 's/Xcode ([0-9]+).*/\1/')
 IOS_EXAMPLE_PROJECT="Examples/Example-Xcode-SPM/Example-Xcode-SPM.xcodeproj"
@@ -14,13 +14,13 @@ analyze:
 	xcodebuild clean analyze -destination ${PLATFORM} -sdk ${SDK} -workspace PINRemoteImage.xcworkspace -scheme PINRemoteImage \
 	CODE_SIGNING_REQUIRED=NO \
 	CLANG_ANALYZER_OUTPUT=plist-html \
-	CLANG_ANALYZER_OUTPUT_DIR="$(shell pwd)/clang" | xcpretty
+	CLANG_ANALYZER_OUTPUT_DIR="$(shell pwd)/clang" | xcbeautify
 	if [[ -n `find $(shell pwd)/clang -name "*.html"` ]] ; then rm -rf `pwd`/clang; exit 1; fi
 	rm -rf $(shell pwd)/clang
 	
 test:
 	xcodebuild clean test -destination ${PLATFORM} -sdk ${SDK} -workspace PINRemoteImage.xcworkspace -scheme PINRemoteImage \
-	CODE_SIGNING_REQUIRED=NO | xcpretty
+	CODE_SIGNING_REQUIRED=NO | xcbeautify
 	
 carthage:
 	carthage update --no-use-binaries --no-build
@@ -36,6 +36,6 @@ example:
 	fi
 	xcodebuild clean build -project ${IOS_EXAMPLE_PROJECT} -scheme ${EXAMPLE_SCHEME} -destination ${PLATFORM} -sdk ${SDK} \
 	ONLY_ACTIVE_ARCH=NO \
-	CODE_SIGNING_REQUIRED=NO | xcpretty
+	CODE_SIGNING_REQUIRED=NO | xcbeautify
 	
 all: carthage test cocoapods analyze spm example

--- a/Source/Classes/AnimatedImages/PINAPNGAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINAPNGAnimatedImage.m
@@ -31,6 +31,7 @@
     size_t _loopCount;
     CFTimeInterval *_durations;
     NSError *_error;
+    NSLock *_decodeLock; // serializes frame decodes on _imageSource
 }
 @end
 
@@ -40,6 +41,7 @@
 {
     if (self = [super init]) {
         _animatedImageData = animatedImageData;
+        _decodeLock = [[NSLock alloc] init];
         _imageSource =
             CGImageSourceCreateWithData((CFDataRef)animatedImageData,
                                         (CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint:
@@ -150,7 +152,16 @@
 
 - (CGImageRef)imageAtIndex:(NSUInteger)index cacheProvider:(nullable id<PINCachedAnimatedFrameProvider>)cacheProvider
 {
-    // I believe this is threadsafe as CGImageSource *seems* immutable…
+    // same hardening as PINGIFAnimatedImage — serialize
+    // all ImageIO calls on the shared source (including the status query, which
+    // advances parser state), and refuse affirmatively damaged frames.
+    [_decodeLock lock];
+    CGImageSourceStatus frameStatus = CGImageSourceGetStatusAtIndex(_imageSource, index);
+    if (frameStatus == kCGImageStatusInvalidData || frameStatus == kCGImageStatusUnexpectedEOF) {
+        [_decodeLock unlock];
+        return NULL;
+    }
+
     CGImageRef imageRef =
         CGImageSourceCreateImageAtIndex(_imageSource,
                                         index,
@@ -161,7 +172,8 @@
         CGImageRelease(imageRef);
         imageRef = decodedImageRef;
     }
-    
+    [_decodeLock unlock];
+
     return imageRef;
 }
 

--- a/Source/Classes/AnimatedImages/PINAPNGAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINAPNGAnimatedImage.m
@@ -19,6 +19,7 @@
 
 #import <PINRemoteImage/PINImage+DecodedImage.h>
 #import <PINRemoteImage/NSData+ImageDetectors.h>
+#import "PINRemoteLock.h"
 
 @interface PINAPNGAnimatedImage ()
 {
@@ -31,7 +32,7 @@
     size_t _loopCount;
     CFTimeInterval *_durations;
     NSError *_error;
-    NSLock *_decodeLock; // serializes frame decodes on _imageSource
+    PINRemoteLock *_decodeLock; // serializes frame decodes on _imageSource
 }
 @end
 
@@ -41,7 +42,7 @@
 {
     if (self = [super init]) {
         _animatedImageData = animatedImageData;
-        _decodeLock = [[NSLock alloc] init];
+        _decodeLock = [[PINRemoteLock alloc] initWithName:@"PINAPNGAnimatedImage decode lock"];
         _imageSource =
             CGImageSourceCreateWithData((CFDataRef)animatedImageData,
                                         (CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint:

--- a/Source/Classes/AnimatedImages/PINCachedAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINCachedAnimatedImage.m
@@ -361,10 +361,10 @@ static const CFTimeInterval kSecondsBetweenMemoryWarnings = 15;
     CGImageRef imageRef = [self->_animatedImage imageAtIndex:frameIndex cacheProvider:self];
     PINLog(@"Generating: %lu", (unsigned long)frameIndex);
 
-    if (imageRef) {
-        __block PINImage *coverImage = nil;
-        __block PINAnimatedImageInfoReady coverImageReadyCallback = nil;
-        [self->_lock lockWithBlock:^{
+    __block PINImage *coverImage = nil;
+    __block PINAnimatedImageInfoReady coverImageReadyCallback = nil;
+    [self->_lock lockWithBlock:^{
+        if (imageRef) {
             [self->_frameCache setObject:(__bridge id _Nonnull)(imageRef) forKey:@(frameIndex)];
 
             // Update the cover image
@@ -373,26 +373,31 @@ static const CFTimeInterval kSecondsBetweenMemoryWarnings = 15;
                 coverImageReadyCallback = notifyCallback ? self->_coverImageReadyCallback : nil;
                 coverImage = self->_coverImage;
             }
-
-            self->_frameRenderCount--;
-            NSAssert(self->_frameRenderCount >= 0, @"playback ready is less than zero, something is wrong :(");
-
-            PINLog(@"Frames left: %ld", (long)_frameRenderCount);
-
-            dispatch_block_t notify = nil;
-            if (self->_frameRenderCount == 0 && self->_notifyOnReady) {
-                self->_notifyOnReady = NO;
-                if (self->_playbackReadyCallback) {
-                    notify = self->_playbackReadyCallback;
-                    [self->_operationQueue scheduleOperation:^{
-                        notify();
-                    }];
-                }
-            }
-        }];
-        if (coverImageReadyCallback) {
-            coverImageReadyCallback(coverImage);
+        } else {
+            // a frame that fails to decode must release its
+            // render slot; leaving it in _cachedOrCachingFrames with _frameRenderCount
+            // held meant playbackReady never fired and the frame was never retried.
+            [self->_cachedOrCachingFrames removeIndex:frameIndex];
         }
+
+        self->_frameRenderCount--;
+        NSAssert(self->_frameRenderCount >= 0, @"playback ready is less than zero, something is wrong :(");
+
+        PINLog(@"Frames left: %ld", (long)_frameRenderCount);
+
+        dispatch_block_t notify = nil;
+        if (self->_frameRenderCount == 0 && self->_notifyOnReady) {
+            self->_notifyOnReady = NO;
+            if (self->_playbackReadyCallback) {
+                notify = self->_playbackReadyCallback;
+                [self->_operationQueue scheduleOperation:^{
+                    notify();
+                }];
+            }
+        }
+    }];
+    if (coverImageReadyCallback) {
+        coverImageReadyCallback(coverImage);
     }
 }
 

--- a/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
@@ -29,6 +29,7 @@
     size_t _loopCount;
     CFTimeInterval *_durations;
     NSError *_error;
+    NSLock *_decodeLock; // serializes frame decodes on _imageSource
 }
 @end
 
@@ -38,6 +39,7 @@
 {
     if (self = [super init]) {
         _animatedImageData = animatedImageData;
+        _decodeLock = [[NSLock alloc] init];
         _imageSource =
             CGImageSourceCreateWithData((CFDataRef)animatedImageData,
                                         (CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint:
@@ -148,7 +150,26 @@
 
 - (CGImageRef)imageAtIndex:(NSUInteger)index cacheProvider:(nullable id<PINCachedAnimatedFrameProvider>)cacheProvider
 {
-    // I believe this is threadsafe as CGImageSource *seems* immutable…
+    // serialize ALL ImageIO calls on the shared source.
+    // Despite the optimistic comment this replaced ("CGImageSource *seems* immutable"),
+    // CGImageSource is not safe for concurrent access, and PINCachedAnimatedImage
+    // reaches this concurrently from the caching queue, the init-time warmup block,
+    // and coverImage callers. The status query below also advances ImageIO parser
+    // state, so it must be inside the lock too.
+    [_decodeLock lock];
+
+    // Refuse frames whose data is affirmatively damaged. Frames are decoded lazily
+    // (kCGImageSourceShouldCache is false), so a damaged frame doesn't fail at
+    // creation — it crashes later inside CGContextDrawImage when CoreGraphics
+    // dereferences the failed decode. Only hard-failure statuses are rejected:
+    // kCGImageStatusIncomplete is what trailer-less-but-renderable GIFs (common in
+    // the wild) report, and those decode fine.
+    CGImageSourceStatus frameStatus = CGImageSourceGetStatusAtIndex(_imageSource, index);
+    if (frameStatus == kCGImageStatusInvalidData || frameStatus == kCGImageStatusUnexpectedEOF) {
+        [_decodeLock unlock];
+        return NULL;
+    }
+
     CGImageRef imageRef =
         CGImageSourceCreateImageAtIndex(_imageSource,
                                         index,
@@ -159,7 +180,8 @@
         CGImageRelease(imageRef);
         imageRef = decodedImageRef;
     }
-    
+    [_decodeLock unlock];
+
     return imageRef;
 }
 

--- a/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINGIFAnimatedImage.m
@@ -17,6 +17,7 @@
 
 #import <PINRemoteImage/PINImage+DecodedImage.h>
 #import <PINRemoteImage/NSData+ImageDetectors.h>
+#import "PINRemoteLock.h"
 
 @interface PINGIFAnimatedImage ()
 {
@@ -29,7 +30,7 @@
     size_t _loopCount;
     CFTimeInterval *_durations;
     NSError *_error;
-    NSLock *_decodeLock; // serializes frame decodes on _imageSource
+    PINRemoteLock *_decodeLock; // serializes frame decodes on _imageSource
 }
 @end
 
@@ -39,7 +40,7 @@
 {
     if (self = [super init]) {
         _animatedImageData = animatedImageData;
-        _decodeLock = [[NSLock alloc] init];
+        _decodeLock = [[PINRemoteLock alloc] initWithName:@"PINGIFAnimatedImage decode lock"];
         _imageSource =
             CGImageSourceCreateWithData((CFDataRef)animatedImageData,
                                         (CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint:

--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -32,6 +32,7 @@
     size_t _loopCount;
     CFTimeInterval *_durations;
     NSError *_error;
+    NSLock *_decodeLock; // serializes frame decodes on _imageSource
 }
 @end
 
@@ -41,7 +42,8 @@
 {
     if (self = [super init]) {
         _animatedImageData = animatedImageData;
-        
+        _decodeLock = [[NSLock alloc] init];
+
         _imageSource =
             CGImageSourceCreateWithData((CFDataRef)animatedImageData,
                                         (CFDictionaryRef)@{(__bridge NSString *)kCGImageSourceTypeIdentifierHint:
@@ -152,7 +154,18 @@
 
 - (CGImageRef)imageAtIndex:(NSUInteger)index cacheProvider:(nullable id<PINCachedAnimatedFrameProvider>)cacheProvider
 {
-    // I believe this is threadsafe as CGImageSource *seems* immutable…
+    // same hardening as PINGIFAnimatedImage — serialize
+    // all ImageIO calls on the shared source (including the status query, which
+    // advances parser state), and refuse affirmatively damaged frames. CGImageSource
+    // is not safe for concurrent lazy decodes of the same source, despite the
+    // optimistic comment this replaced.
+    [_decodeLock lock];
+    CGImageSourceStatus frameStatus = CGImageSourceGetStatusAtIndex(_imageSource, index);
+    if (frameStatus == kCGImageStatusInvalidData || frameStatus == kCGImageStatusUnexpectedEOF) {
+        [_decodeLock unlock];
+        return NULL;
+    }
+
     CGImageRef imageRef =
         CGImageSourceCreateImageAtIndex(_imageSource,
                                         index,
@@ -163,7 +176,8 @@
         CGImageRelease(imageRef);
         imageRef = decodedImageRef;
     }
-    
+    [_decodeLock unlock];
+
     return imageRef;
 }
 

--- a/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
+++ b/Source/Classes/AnimatedImages/PINWebPAnimatedImage.m
@@ -20,6 +20,7 @@
 
 #import <PINRemoteImage/PINImage+DecodedImage.h>
 #import <PINRemoteImage/NSData+ImageDetectors.h>
+#import "PINRemoteLock.h"
 
 @interface PINWebPAnimatedImage ()
 {
@@ -32,7 +33,7 @@
     size_t _loopCount;
     CFTimeInterval *_durations;
     NSError *_error;
-    NSLock *_decodeLock; // serializes frame decodes on _imageSource
+    PINRemoteLock *_decodeLock; // serializes frame decodes on _imageSource
 }
 @end
 
@@ -42,7 +43,7 @@
 {
     if (self = [super init]) {
         _animatedImageData = animatedImageData;
-        _decodeLock = [[NSLock alloc] init];
+        _decodeLock = [[PINRemoteLock alloc] initWithName:@"PINWebPAnimatedImage decode lock"];
 
         _imageSource =
             CGImageSourceCreateWithData((CFDataRef)animatedImageData,

--- a/Source/Classes/Categories/PINImage+DecodedImage.m
+++ b/Source/Classes/Categories/PINImage+DecodedImage.m
@@ -229,6 +229,12 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
 
 + (CGImageRef)pin_decodedImageRefWithCGImageRef:(CGImageRef)imageRef
 {
+    // Guard against NULL despite the nonnull annotation: CGImageSourceCreateImageAtIndex returns
+    // NULL for corrupt/truncated frames and callers have historically passed that straight through.
+    if (imageRef == NULL) {
+        return NULL;
+    }
+
     CGSize imageSize = CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
     
     CGBitmapInfo info = pin_CGImageRefIsOpaque(imageRef) ? (kCGImageAlphaNoneSkipFirst | kCGBitmapByteOrder32Host) : (kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Host);
@@ -253,9 +259,15 @@ NSData * __nullable PINImagePNGRepresentation(PINImage * __nonnull image) {
         }
         CGContextRelease(ctx);
         return decodedImageRef;
-        
+
     }
-    
+
+    // match the success path's +0 autoreleased contract.
+    // Returning the borrowed imageRef directly made the animated-image callers release
+    // it and then return the same (now dangling) pointer whenever CGBitmapContextCreate
+    // failed under memory pressure — an over-release/use-after-free.
+    CGImageRetain(imageRef);
+    CFAutorelease(imageRef);
     return imageRef;
 }
 

--- a/Tests/PINRemoteImageTests.m
+++ b/Tests/PINRemoteImageTests.m
@@ -152,6 +152,12 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
     return [NSURL URLWithString:@"https://httpbin.org/headers"];
 }
 
+// The pinimg CDN periodically re-encodes these derivatives, drifting the pixel
+// width by a pixel or so around the nominal size in the URL (e.g. 736x has served
+// both 736- and 735-wide images). Tests only need to tell the three sizes apart,
+// so compare widths with XCTAssertEqualWithAccuracy and this tolerance.
+static const CGFloat PINSizeVariantWidthAccuracy = 2;
+
 - (NSURL *)JPEGURL_Small
 {
     return [NSURL URLWithString:@"https://i.pinimg.com/345x/1b/bc/c2/1bbcc264683171eb3815292d2f546e92.jpg"];
@@ -975,7 +981,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
-        XCTAssertEqual(image.size.width, 736, @"Large image should be downloaded. result.image: %@, result.error: %@", result.image, result.error);
+        XCTAssertEqualWithAccuracy(image.size.width, 736, PINSizeVariantWidthAccuracy, @"Large image should be downloaded. result.image: %@, result.error: %@", result.image, result.error);
         dispatch_semaphore_signal(semaphore);
     }];
     XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
@@ -991,7 +997,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
-        XCTAssertEqual(image.size.width, 736, @"Large image should be found in cache");
+        XCTAssertEqualWithAccuracy(image.size.width, 736, PINSizeVariantWidthAccuracy, @"Large image should be found in cache");
         dispatch_semaphore_signal(semaphore);
     }];
     XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
@@ -1003,7 +1009,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
-        XCTAssert(image.size.width == 345, @"Small image should be downloaded at low bps");
+        XCTAssertEqualWithAccuracy(image.size.width, 345, PINSizeVariantWidthAccuracy, @"Small image should be downloaded at low bps");
         dispatch_semaphore_signal(semaphore);
     }];
     XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
@@ -1017,7 +1023,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
                                   completion:^(PINRemoteImageManagerResult *result)
     {
         image = result.image;
-        XCTAssert(image.size.width == 345, @"Small image should be found in cache");
+        XCTAssertEqualWithAccuracy(image.size.width, 345, PINSizeVariantWidthAccuracy, @"Small image should be found in cache");
         dispatch_semaphore_signal(semaphore);
     }];
     XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
@@ -1034,7 +1040,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
                                   completion:^(PINRemoteImageManagerResult *result)
      {
          image = result.image;
-         XCTAssert(image.size.width == 564, @"Medium image should be now downloaded");
+         XCTAssertEqualWithAccuracy(image.size.width, 564, PINSizeVariantWidthAccuracy, @"Medium image should be now downloaded");
          dispatch_semaphore_signal(semaphore);
      }];
     XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");
@@ -1063,7 +1069,7 @@ static inline BOOL PINImageAlphaInfoIsOpaque(CGImageAlphaInfo info) {
                                   completion:^(PINRemoteImageManagerResult *result)
      {
          image = result.image;
-         XCTAssert(image.size.width == 345, @"Small image should be now downloaded");
+         XCTAssertEqualWithAccuracy(image.size.width, 345, PINSizeVariantWidthAccuracy, @"Small image should be now downloaded");
          dispatch_semaphore_signal(semaphore);
      }];
     XCTAssert(dispatch_semaphore_wait(semaphore, [self timeout]) == 0, @"Semaphore timed out.");


### PR DESCRIPTION
…ame-failure bookkeeping

CGImageSource is not safe for concurrent lazy decodes of the same source (despite the optimistic '*seems* immutable' comments), and PINCachedAnimatedImage reaches imageAtIndex:cacheProvider: concurrently from its caching queue, its init-time warmup dispatch, and coverImage callers. The racing decode crashes inside ImageIO
(GIFReadPlugin::copyImageBlockSetImp / GIFBufferInfo memmove).

- GIF, APNG, and WebP now serialize all ImageIO calls on the shared source — including CGImageSourceGetStatusAtIndex, which advances parser state — behind a per-image lock.
- Refuse affirmatively damaged frames (kCGImageStatusInvalidData / kCGImageStatusUnexpectedEOF) before attempting creation. Deliberately narrow: kCGImageStatusIncomplete (trailer-less but renderable GIFs, common in the wild) still decodes.
- A frame that fails to decode previously left _frameRenderCount held and its index parked in _cachedOrCachingFrames forever: playbackReady never fired and the frame was never retried. Failures now release their render slot.
- pin_decodedImageRefWithCGImageRef: returned the borrowed input ref when CGBitmapContextCreate fails (memory pressure); animated callers then released it and returned the dangling pointer. The fallback now matches the success path's +0 autoreleased contract. Also guard NULL input.

Fixes a long-standing top crasher in a large production app (EXC_BAD_ACCESS at PINImage+DecodedImage's CGContextDrawImage during GIF frame decode).