### PR TITLE
Replace deprecated CC_MD5 with CC_SHA256 for cache key generation

### DIFF
--- a/Source/Classes/PINRemoteImageManager.m
+++ b/Source/Classes/PINRemoteImageManager.m
@@ -1568,18 +1568,18 @@ static dispatch_once_t sharedDispatchToken;
     //In case the generated key exceeds PINRemoteImageManagerCacheKeyMaxLength characters,
     //we return the hash of it instead.
     if (cacheKey.length > PINRemoteImageManagerCacheKeyMaxLength) {
-        __block CC_MD5_CTX ctx;
-        CC_MD5_Init(&ctx);
+        __block CC_SHA256_CTX ctx;
+        CC_SHA256_Init(&ctx);
         NSData *data = [cacheKey dataUsingEncoding:NSUTF8StringEncoding];
         [data enumerateByteRangesUsingBlock:^(const void * _Nonnull bytes, NSRange byteRange, BOOL * _Nonnull stop) {
-            CC_MD5_Update(&ctx, bytes, (CC_LONG)byteRange.length);
+            CC_SHA256_Update(&ctx, bytes, (CC_LONG)byteRange.length);
         }];
 
-        unsigned char digest[CC_MD5_DIGEST_LENGTH];
-        CC_MD5_Final(digest, &ctx);
+        unsigned char digest[CC_SHA256_DIGEST_LENGTH];
+        CC_SHA256_Final(digest, &ctx);
 
-        NSMutableString *hexString  = [NSMutableString stringWithCapacity:(CC_MD5_DIGEST_LENGTH * 2)];
-        for (int i = 0; i < CC_MD5_DIGEST_LENGTH; i++) {
+        NSMutableString *hexString  = [NSMutableString stringWithCapacity:(CC_SHA256_DIGEST_LENGTH * 2)];
+        for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; i++) {
             [hexString appendFormat:@"%02lx", (unsigned long)digest[i]];
         }
         cacheKey = [hexString copy];


### PR DESCRIPTION
**Summary**

This PR replaces the deprecated `CC_MD5` APIs with `CC_SHA256` in `PINRemoteImageManager` when generating hashed cache keys.

**Motivation**

Apple has deprecated the `CC_MD5` APIs, and many security scanning tools (such as NowSecure) flag MD5 usage even when it is used for non-cryptographic purposes. Replacing it with SHA-256 removes the dependency on the deprecated hashing algorithm while continuing to generate deterministic cache keys.

**Changes**

- Replaced `CC_MD5_CTX` with `CC_SHA256_CTX`
- Replaced `CC_MD5_Init` with `CC_SHA256_Init`
- Replaced `CC_MD5_Update` with `CC_SHA256_Update`
- Replaced `CC_MD5_Final` with `CC_SHA256_Final`
- Updated digest length from `CC_MD5_DIGEST_LENGTH` to `CC_SHA256_DIGEST_LENGTH`

**Notes**

This change only affects the hashing algorithm used when generating cache keys for long cache key strings. The overall cache key generation logic remains unchanged, although the resulting hash values will differ from those generated using MD5.